### PR TITLE
Minor changes to Vue/en tutorial pages content

### DIFF
--- a/content/vue/en/composite-component.md
+++ b/content/vue/en/composite-component.md
@@ -74,7 +74,7 @@ Next create `Tasklist`’s test states in the story file.
 import { storiesOf } from '@storybook/vue';
 import { task } from './Task.stories';
 
-import PureTaskList from './PureTaskList';
+import TaskList from './TaskList';
 import { methods } from './Task.stories';
 
 export const defaultTaskList = [

--- a/content/vue/en/simple-component.md
+++ b/content/vue/en/simple-component.md
@@ -225,7 +225,7 @@ With the [Storyshots addon](https://github.com/storybooks/storybook/tree/master/
 yarn add --dev @storybook/addon-storyshots jest-vue-preprocessor
 ```
 
-Then create an `src/storybook.test.js` file with the following in it:
+Then create an `tests/unit/storybook.spec.js` file with the following in it:
 
 ```javascript
 import initStoryshots from '@storybook/addon-storyshots';


### PR DESCRIPTION
df79878  
With the previous configuration the snapshots were not generated.  
The related [commit (b2274bd)](https://github.com/hichroma/learnstorybook-code/commit/b2274bd) shows proper path and file name.

f866397  
Invalid import.
