### PR TITLE
Get vue styles working

### DIFF
--- a/content/vue/en/get-started.md
+++ b/content/vue/en/get-started.md
@@ -82,7 +82,13 @@ Depending on what part of the app you’re working on, you may want to run one o
 
 ## Reuse CSS
 
-Taskbox reuses design elements from the GraphQL and React Tutorial [example app](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858), so we won’t need to write CSS in this tutorial. We’ll simply compile the LESS to a single CSS file and include it in our app. Copy and paste [this compiled CSS](https://github.com/hichroma/learnstorybook-code/blob/master/src/index.css) into the src/index.css file per CRA’s convention.
+Taskbox reuses design elements from the GraphQL and React Tutorial [example app](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858), so we won’t need to write CSS in this tutorial. We’ll simply compile the LESS to a single CSS file and include it in our app. Copy and paste [this compiled CSS](https://github.com/hichroma/learnstorybook-code/blob/master/src/index.css) into `src/index.css` and then import the CSS into the app by editing the `<style>` tag in `src/App.vue` so it looks like:
+
+```html
+<style>
+@import './index.css';
+</style>
+```
 
 ![Taskbox UI](/ss-browserchrome-taskbox-learnstorybook.png)
 


### PR DESCRIPTION
Updated the "Reuse CSS" section of the vue docs to show how to reuse the CSS inside a vue app. It is also possible to import the CSS into `main.js` but if you did that it's likely you would also need to remove the default styles in `App.vue` as it would override what's in `index.css`. So I've updated to what I believe is the easiest solution.