### PR TITLE
add redux: Provider & store to storybook

### DIFF
--- a/content/react/en/data.md
+++ b/content/react/en/data.md
@@ -120,9 +120,11 @@ However, we can easily solve this problem by simply rendering the `PureTaskList`
 ```javascript
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { Provider } from "react-redux";
 
 import { PureTaskList } from './TaskList';
 import { task, actions } from './Task.stories';
+import store from "../lib/redux";
 
 export const defaultTasks = [
   { ...task, id: '1', title: 'Task 1' },
@@ -139,7 +141,7 @@ export const withPinnedTasks = [
 ];
 
 storiesOf('TaskList', module)
-  .addDecorator(story => <div style={{ padding: '3rem' }}>{story()}</div>)
+  .addDecorator(story => <Provider store={store}><div style={{ padding: '3rem' }}>{story()}</div></Provider>)
   .add('default', () => <PureTaskList tasks={defaultTasks} {...actions} />)
   .add('withPinnedTasks', () => <PureTaskList tasks={withPinnedTasks} {...actions} />)
   .add('loading', () => <PureTaskList loading tasks={[]} {...actions} />)

--- a/content/react/en/screen.md
+++ b/content/react/en/screen.md
@@ -40,6 +40,7 @@ export function PureInboxScreen({ error }) {
       <nav>
         <h1 className="title-page">
           <span className="title-wrapper">Taskbox</span>
+          <TaskList />
         </h1>
       </nav>
       <TaskList />


### PR DESCRIPTION
fixing issue:

Could not find "store" in the context of "Connect(PureTaskList)". Either wrap the root component in a <Provider>, or pass a custom React context provider to <Provider> and the corresponding React context consumer to Connect(PureTaskList) in connect options.