### PR TITLE
corrected the documentation to avoid 404 in documents links

### DIFF
--- a/content/angular/en/deploy.md
+++ b/content/angular/en/deploy.md
@@ -11,7 +11,7 @@ In this tutorial we ran Storybook on our development machine. You may also want 
 <div class="aside">
 <strong>Did you setup Chromatic testing earlier?</strong>
 <br/>
-🎉 Your stories are already deployed! Chromatic securely indexes your stories online and tracks them across branches and commits. Skip this chapter and go to the <a href="/conclusion">conclusion</a>.
+🎉 Your stories are already deployed! Chromatic securely indexes your stories online and tracks them across branches and commits. Skip this chapter and go to the <a href="/angular/en/conclusion">conclusion</a>.
 </div>
 
 ## Exporting as a static app

--- a/content/angular/es/deploy.md
+++ b/content/angular/es/deploy.md
@@ -11,7 +11,7 @@ En este tutorial hemos ejecutado Storybook en nuestra máquina de desarrollo. Es
 <div class="aside">
 <strong>¿Seguiste los pasos del capítulo anterior con Chromatic?</strong>
 <br/>
-🎉 ¡Tus historias ya están desplegadas! Chromatic indexa de forma segura tus historias en línea y las rastrea a través de ramas y commits. Salta este capítulo y ve a la <a href="/conclusion">conclusión</a>.
+🎉 ¡Tus historias ya están desplegadas! Chromatic indexa de forma segura tus historias en línea y las rastrea a través de ramas y commits. Salta este capítulo y ve a la <a href="/angular/es/conclusion">conclusión</a>.
 </div>
 
 ## Exportando como una app estática

--- a/content/react/en/deploy.md
+++ b/content/react/en/deploy.md
@@ -11,7 +11,7 @@ In this tutorial we ran Storybook on our development machine. You may also want 
 <div class="aside">
 <strong>Did you setup Chromatic testing earlier?</strong>
 <br/>
-🎉 Your stories are already deployed! Chromatic securely indexes your stories online and tracks them across branches and commits. Skip this chapter and go to the <a href="/conclusion">conclusion</a>.
+🎉 Your stories are already deployed! Chromatic securely indexes your stories online and tracks them across branches and commits. Skip this chapter and go to the <a href="/react/en/conclusion">conclusion</a>.
 </div>
 
 ## Exporting as a static app

--- a/content/react/es/deploy.md
+++ b/content/react/es/deploy.md
@@ -11,7 +11,7 @@ En este tutorial hemos ejecutado Storybook en nuestra máquina de desarrollo. Ta
 <div class="aside">
 <strong>¿Hiciste los test con Chromatic antes?</strong>
 <br/>
-🎉 Sus historias ya están desplegadas! Chromatic indexa de forma segura sus historias en línea y las rastrea a través de ramas y commits. Salta este capítulo y ve a la <a href="/conclusion">conclusión</a>.
+🎉 Sus historias ya están desplegadas! Chromatic indexa de forma segura sus historias en línea y las rastrea a través de ramas y commits. Salta este capítulo y ve a la <a href="/react/es/conclusion">conclusión</a>.
 </div>
 
 ## Exportando como una app estática

--- a/content/react/pt/deploy.md
+++ b/content/react/pt/deploy.md
@@ -12,7 +12,7 @@ Neste tutorial o Storybook foi executado na máquina local. Poderá ser necessá
     <strong>Foram seguidos os passos para implementar os teste com Chromatic, tal como mencionado anteriormente?</strong>
     <br/>
     Então as estórias já se encontram implementadas!🎉 O Chromatic indexa-as e segue-as ao longo das ramificações feitas e dos commits
-    Pode saltar-se este capítulo e seguir para <a href="/conclusion">conclusão</a>.
+    Pode saltar-se este capítulo e seguir para <a href="/react/pt/conclusion">conclusão</a>.
 </div>
 
 ## Exportação sob a forma de uma app estática

--- a/content/react/zh-CN/deploy.md
+++ b/content/react/zh-CN/deploy.md
@@ -10,7 +10,7 @@ description: "使用 GitHub 和 Netlify 发布 Storybook网站 "
 <div class="aside">
 <strong>您之前是否安装过Chromatic 测试？?</strong>
 <br/>
-🎉 你的故事已经部署好了！ Chromatic 在线安全地为您的故事编制索引，并在分支和提交中跟踪它们。 跳过这一章，然后转到 <a href="/conclusion">总结</a>.
+🎉 你的故事已经部署好了！ Chromatic 在线安全地为您的故事编制索引，并在分支和提交中跟踪它们。 跳过这一章，然后转到 <a href="/react/zh-CN/conclusion">总结</a>.
 </div>
 
 ## 导出为静态应用程序

--- a/content/react/zh-TW/deploy.md
+++ b/content/react/zh-TW/deploy.md
@@ -10,7 +10,7 @@ description: "使用 GitHub 和 Netlify 发布 Storybook网站 "
 <div class="aside">
 <strong>您之前是否安装过Chromatic 测试？?</strong>
 <br/>
-🎉 你的故事已经部署好了！ Chromatic 在线安全地为您的故事编制索引，并在分支和提交中跟踪它们。 跳过这一章，然后转到 <a href="/conclusion">总结</a>.
+🎉 你的故事已经部署好了！ Chromatic 在线安全地为您的故事编制索引，并在分支和提交中跟踪它们。 跳过这一章，然后转到 <a href="/react/zh-TW/conclusion">总结</a>.
 </div>
 
 ## 导出为静态应用程序


### PR DESCRIPTION
The following pull request addresses a issue with the link with text:
> Skip this chapter and go to the conclusion.

in the deploy document leading to a 404. instead of the desired document

As of now, the _conclusion_ link points to `https://www.learnstorybook.com/conclusion` and should point to `https://www.learnstorybook.com/react/en/conclusion/` .
I have to believe that this was done before any translations and content folder restructuring.
