### PR TITLE
Update addons.md - Fix link to the test chapter

### DIFF
--- a/content/react/en/addons.md
+++ b/content/react/en/addons.md
@@ -8,7 +8,7 @@ commit: "dac373a"
 # Addons
 
 Storybook boasts a robust system of [addons](https://storybook.js.org/addons/introduction/) with which you can enhance the developer experience for
-everybody in your team. If you've been following along with this tutorial linearly, we have referenced multiple addons so far, and you will have already implemented one in the [Testing chapter](/test).
+everybody in your team. If you've been following along with this tutorial linearly, we have referenced multiple addons so far, and you will have already implemented one in the [Testing chapter](https://www.learnstorybook.com/react/en/test/).
 
 <div class="aside">
 <strong>Looking for a list of potential addons?</strong>
@@ -136,7 +136,7 @@ Now we've added the story, we can reproduce this edge-case with ease whenever we
 
 ![Here it is in Storybook.](/addon-knobs-demo-edge-case-in-storybook.png)
 
-If we are using [visual regression testing](/test), we will also be informed if we ever break our ellipsizing solution. Such obscure edge-cases are always liable to be forgotten!
+If we are using [visual regression testing](https://www.learnstorybook.com/react/en/test/), we will also be informed if we ever break our ellipsizing solution. Such obscure edge-cases are always liable to be forgotten!
 
 ### Merge Changes
 


### PR DESCRIPTION
This is to fix the link to test chapter appearing in 2 different places of the document.