### PR TITLE
Update addons.md for EN, PT to fix invalid relative link to testing chapter

### DIFF
--- a/content/react/en/addons.md
+++ b/content/react/en/addons.md
@@ -8,7 +8,7 @@ commit: "dac373a"
 # Addons
 
 Storybook boasts a robust system of [addons](https://storybook.js.org/addons/introduction/) with which you can enhance the developer experience for
-everybody in your team. If you've been following along with this tutorial linearly, we have referenced multiple addons so far, and you will have already implemented one in the [Testing chapter](/test).
+everybody in your team. If you've been following along with this tutorial linearly, we have referenced multiple addons so far, and you will have already implemented one in the [Testing chapter](https://www.learnstorybook.com/react/en/test/).
 
 <div class="aside">
 <strong>Looking for a list of potential addons?</strong>
@@ -136,7 +136,7 @@ Now we've added the story, we can reproduce this edge-case with ease whenever we
 
 ![Here it is in Storybook.](/addon-knobs-demo-edge-case-in-storybook.png)
 
-If we are using [visual regression testing](/test), we will also be informed if we ever break our ellipsizing solution. Such obscure edge-cases are always liable to be forgotten!
+If we are using [visual regression testing](https://www.learnstorybook.com/react/en/test/), we will also be informed if we ever break our ellipsizing solution. Such obscure edge-cases are always liable to be forgotten!
 
 ### Merge Changes
 

--- a/content/react/en/addons.md
+++ b/content/react/en/addons.md
@@ -8,7 +8,7 @@ commit: "dac373a"
 # Addons
 
 Storybook boasts a robust system of [addons](https://storybook.js.org/addons/introduction/) with which you can enhance the developer experience for
-everybody in your team. If you've been following along with this tutorial linearly, we have referenced multiple addons so far, and you will have already implemented one in the [Testing chapter](https://www.learnstorybook.com/react/en/test/).
+everybody in your team. If you've been following along with this tutorial linearly, we have referenced multiple addons so far, and you will have already implemented one in the [Testing chapter](/react/en/test/).
 
 <div class="aside">
 <strong>Looking for a list of potential addons?</strong>
@@ -136,7 +136,7 @@ Now we've added the story, we can reproduce this edge-case with ease whenever we
 
 ![Here it is in Storybook.](/addon-knobs-demo-edge-case-in-storybook.png)
 
-If we are using [visual regression testing](https://www.learnstorybook.com/react/en/test/), we will also be informed if we ever break our ellipsizing solution. Such obscure edge-cases are always liable to be forgotten!
+If we are using [visual regression testing](/react/en/test/), we will also be informed if we ever break our ellipsizing solution. Such obscure edge-cases are always liable to be forgotten!
 
 ### Merge Changes
 

--- a/content/react/pt/addons.md
+++ b/content/react/pt/addons.md
@@ -7,7 +7,7 @@ commit: "dac373a"
 
 # Extras
 
-Storybook possui um sistema robusto de [extras](https://storybook.js.org/addons/introduction/) com o qual se pode aumentar a experiência de desenvolvimento para qualquer elemento da sua equipa. Se estiver a seguir este tutorial, pode ter reparado que já foram mencionados múltiplos extras e já terá implementado um no [capitulo de testes](/test).
+Storybook possui um sistema robusto de [extras](https://storybook.js.org/addons/introduction/) com o qual se pode aumentar a experiência de desenvolvimento para qualquer elemento da sua equipa. Se estiver a seguir este tutorial, pode ter reparado que já foram mencionados múltiplos extras e já terá implementado um no [capitulo de testes](https://www.learnstorybook.com/react/pt/test/).
 
 <div class="aside">
     <strong>Á procura de uma lista de extras?</strong>
@@ -128,7 +128,7 @@ Agora que foi adicionada a estória, podemos reproduzir este caso extremo com re
 
 [Aqui está ele no Storybook](/addon-knobs-demo-edge-case-in-storybook.png)
 
-Se estiverem a ser usados [testes de regressão visual](/test), iremos ser informados se a nossa solução eliptica for quebrada.
+Se estiverem a ser usados [testes de regressão visual](https://www.learnstorybook.com/react/pt/test/), iremos ser informados se a nossa solução eliptica for quebrada.
 Tais casos extremos considerados obscuros têm tendência a ser esquecidos!
 
 ## Fusão das alterações

--- a/content/react/pt/addons.md
+++ b/content/react/pt/addons.md
@@ -7,7 +7,7 @@ commit: "dac373a"
 
 # Extras
 
-Storybook possui um sistema robusto de [extras](https://storybook.js.org/addons/introduction/) com o qual se pode aumentar a experiência de desenvolvimento para qualquer elemento da sua equipa. Se estiver a seguir este tutorial, pode ter reparado que já foram mencionados múltiplos extras e já terá implementado um no [capitulo de testes](https://www.learnstorybook.com/react/pt/test/).
+Storybook possui um sistema robusto de [extras](https://storybook.js.org/addons/introduction/) com o qual se pode aumentar a experiência de desenvolvimento para qualquer elemento da sua equipa. Se estiver a seguir este tutorial, pode ter reparado que já foram mencionados múltiplos extras e já terá implementado um no [capitulo de testes](/react/pt/test/).
 
 <div class="aside">
     <strong>Á procura de uma lista de extras?</strong>
@@ -128,7 +128,7 @@ Agora que foi adicionada a estória, podemos reproduzir este caso extremo com re
 
 [Aqui está ele no Storybook](/addon-knobs-demo-edge-case-in-storybook.png)
 
-Se estiverem a ser usados [testes de regressão visual](https://www.learnstorybook.com/react/pt/test/), iremos ser informados se a nossa solução eliptica for quebrada.
+Se estiverem a ser usados [testes de regressão visual](/react/pt/test/), iremos ser informados se a nossa solução eliptica for quebrada.
 Tais casos extremos considerados obscuros têm tendência a ser esquecidos!
 
 ## Fusão das alterações


### PR DESCRIPTION
This is to fix invalid link to testing chapter, which is used in multiple places in `addons.md` chapter.