### PR TITLE
Upgrade prettier, fix "format" CLI action, format files

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build": "gatsby build",
     "develop": "gatsby develop",
     "dev": "yarn develop",
-    "format": "prettier --write 'src/**/*.js'",
+    "format": "prettier-eslint --write 'src/**/*.js'",
     "lint": "eslint .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -44,8 +44,8 @@
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.7.0",
-    "prettier": "^1.11.1",
-    "prettier-eslint": "^8.8.1",
+    "prettier": "^1.17.1",
+    "prettier-eslint": "^8.8.2",
     "prettier-eslint-cli": "^4.7.1"
   }
 }

--- a/src/components/Subheading.js
+++ b/src/components/Subheading.js
@@ -1,6 +1,6 @@
-import React from "react";
-import styled from "styled-components";
-import { typography } from "./shared/styles";
+import React from 'react';
+import styled from 'styled-components';
+import { typography } from './shared/styles';
 
 // prettier-ignore
 const Heading = styled.span`

--- a/src/components/shared/global.js
+++ b/src/components/shared/global.js
@@ -1,5 +1,5 @@
-import { injectGlobal, css } from "styled-components";
-import { background, color, typography } from "./styles";
+import { injectGlobal, css } from 'styled-components';
+import { background, color, typography } from './styles';
 
 export const bodyStyles = css`
   font-family: ${typography.type.primary};

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 
 const NotFoundPage = () => (
   <div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -247,27 +247,32 @@ export default ({ data: { site: { siteMetadata: { toc, defaultTranslation } }, p
             <Actions>
               <Link isGatsby to={`/react/en/${firstChapter}`}>
                 <Button inverse>
-                  <ViewLayerImage src="/logo-react.svg" alt="React" />English
+                  <ViewLayerImage src="/logo-react.svg" alt="React" />
+                  English
                 </Button>
               </Link>
               <Link isGatsby to={`/react/es/${firstChapter}`}>
                 <Button inverse>
-                  <ViewLayerImage src="/logo-react.svg" alt="React" />Español
+                  <ViewLayerImage src="/logo-react.svg" alt="React" />
+                  Español
                 </Button>
               </Link>
               <Link isGatsby to={`/react/zh-CN/${firstChapter}`}>
                 <Button inverse>
-                  <ViewLayerImage src="/logo-react.svg" alt="React" />简体中文
+                  <ViewLayerImage src="/logo-react.svg" alt="React" />
+                  简体中文
                 </Button>
               </Link>
               <Link isGatsby to={`/react/zh-TW/${firstChapter}`}>
                 <Button inverse>
-                  <ViewLayerImage src="/logo-react.svg" alt="React" />繁體中文
+                  <ViewLayerImage src="/logo-react.svg" alt="React" />
+                  繁體中文
                 </Button>
               </Link>
               <Link isGatsby to={`react/pt/${firstChapter}`}>
                 <Button inverse>
-                  <ViewLayerImage src="/logo-react.svg" alt="React" />Português
+                  <ViewLayerImage src="/logo-react.svg" alt="React" />
+                  Português
                 </Button>
               </Link>
             </Actions>
@@ -275,17 +280,20 @@ export default ({ data: { site: { siteMetadata: { toc, defaultTranslation } }, p
             <Actions>
               <Link isGatsby to={`/angular/en/${firstChapter}`}>
                 <Button inverse>
-                  <ViewLayerImage src="/logo-angular.svg" alt="Angular" />English
+                  <ViewLayerImage src="/logo-angular.svg" alt="Angular" />
+                  English
                 </Button>
               </Link>
               <Link isGatsby to={`/angular/es/${firstChapter}`}>
                 <Button inverse>
-                  <ViewLayerImage src="/logo-angular.svg" alt="Angular" />Español
+                  <ViewLayerImage src="/logo-angular.svg" alt="Angular" />
+                  Español
                 </Button>
               </Link>
               <Link isGatsby to={`/angular/pt/${firstChapter}`}>
                 <Button inverse>
-                  <ViewLayerImage src="/logo-angular.svg" alt="Angular" />Português
+                  <ViewLayerImage src="/logo-angular.svg" alt="Angular" />
+                  Português
                 </Button>
               </Link>
             </Actions>
@@ -293,12 +301,14 @@ export default ({ data: { site: { siteMetadata: { toc, defaultTranslation } }, p
             <Actions>
               <Link isGatsby to={`/vue/en/${firstChapter}`}>
                 <Button inverse>
-                  <ViewLayerImage src="/logo-vue.svg" alt="Vue" />English
+                  <ViewLayerImage src="/logo-vue.svg" alt="Vue" />
+                  English
                 </Button>
               </Link>
               <Link isGatsby to={`/vue/pt/${firstChapter}`}>
                 <Button inverse>
-                  <ViewLayerImage src="/logo-vue.svg" alt="Vue"/>Português
+                  <ViewLayerImage src="/logo-vue.svg" alt="Vue" />
+                  Português
                 </Button>
               </Link>
             </Actions>
@@ -352,7 +362,8 @@ export default ({ data: { site: { siteMetadata: { toc, defaultTranslation } }, p
             you{' '}
             <strong>
               develop and design UI components outside your app in an isolated environment
-            </strong>.
+            </strong>
+            .
           </p>
           <p>
             Professional developers at Airbnb, Dropbox, and Lonely Planet use Storybook to build

--- a/yarn.lock
+++ b/yarn.lock
@@ -3130,7 +3130,7 @@ esniff@^1.1:
     d "1"
     es5-ext "^0.10.12"
 
-espree@^3.5.4:
+espree@^3.5.2, espree@^3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
   dependencies:
@@ -7229,7 +7229,7 @@ prettier-eslint-cli@^4.7.1:
     rxjs "^5.3.0"
     yargs "10.0.3"
 
-prettier-eslint@^8.5.0, prettier-eslint@^8.8.1:
+prettier-eslint@^8.5.0:
   version "8.8.1"
   resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-8.8.1.tgz#38505163274742f2a0b31653c39e40f37ebd07da"
   dependencies:
@@ -7246,7 +7246,31 @@ prettier-eslint@^8.5.0, prettier-eslint@^8.8.1:
     typescript "^2.5.1"
     typescript-eslint-parser "^11.0.0"
 
-prettier@^1.11.1, prettier@^1.7.0:
+prettier-eslint@^8.8.2:
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-8.8.2.tgz#fcb29a48ab4524e234680797fe70e9d136ccaf0b"
+  integrity sha512-2UzApPuxi2yRoyMlXMazgR6UcH9DKJhNgCviIwY3ixZ9THWSSrUww5vkiZ3C48WvpFl1M1y/oU63deSy1puWEA==
+  dependencies:
+    babel-runtime "^6.26.0"
+    common-tags "^1.4.0"
+    dlv "^1.1.0"
+    eslint "^4.0.0"
+    indent-string "^3.2.0"
+    lodash.merge "^4.6.0"
+    loglevel-colored-level-prefix "^1.0.0"
+    prettier "^1.7.0"
+    pretty-format "^23.0.1"
+    require-relative "^0.8.7"
+    typescript "^2.5.1"
+    typescript-eslint-parser "^16.0.0"
+    vue-eslint-parser "^2.0.2"
+
+prettier@^1.17.1:
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.1.tgz#ed64b4e93e370cb8a25b9ef7fef3e4fd1c0995db"
+  integrity sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==
+
+prettier@^1.7.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
 
@@ -7264,6 +7288,14 @@ pretty-error@^2.1.1:
 pretty-format@^22.0.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.4.3.tgz#f873d780839a9c02e9664c8a082e9ee79eaac16f"
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
+
+pretty-format@^23.0.1:
+  version "23.6.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.6.0.tgz#5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760"
+  integrity sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
@@ -8286,7 +8318,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@5.5.0, semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -9240,6 +9272,14 @@ typescript-eslint-parser@^11.0.0:
     lodash.unescape "4.0.1"
     semver "5.4.1"
 
+typescript-eslint-parser@^16.0.0:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-16.0.1.tgz#b40681c7043b222b9772748b700a000b241c031b"
+  integrity sha512-IKawLTu4A2xN3aN/cPLxvZ0bhxZHILGDKTZWvWNJ3sLNhJ3PjfMEDQmR2VMpdRPrmWOadgWXRwjLBzSA8AGsaQ==
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.5.0"
+
 typescript@^2.5.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624"
@@ -9599,6 +9639,18 @@ vm-browserify@0.0.4:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
+
+vue-eslint-parser@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz#c268c96c6d94cfe3d938a5f7593959b0ca3360d1"
+  integrity sha512-ZezcU71Owm84xVF6gfurBQUGg8WQ+WZGxgDEQu1IHFBZNx7BFZg3L1yHxrCBNNwbwFtE1GuvfJKMtb6Xuwc/Bw==
+  dependencies:
+    debug "^3.1.0"
+    eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.2"
+    esquery "^1.0.0"
+    lodash "^4.17.4"
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
I originally thought that this repo needed a `.prettierrc` as I was getting inconsistent results between my editor and the `npm run format` command. Now that I know that the repo is using eslint to run the `prettier` checks, it makes sense to have `npm run format` use the `prettier-eslint` CLI rather than just `prettier` as the latter does not know where to look for the config!

That is fixed in this PR along with a few old, offending files. Also, I updated a few `prettier` packages.