### PR TITLE
fix comment line that falls of canvas

### DIFF
--- a/content/react/en/data.md
+++ b/content/react/en/data.md
@@ -38,7 +38,7 @@ export const actions = {
   PIN_TASK: 'PIN_TASK',
 };
 
-// The action creators are how you bundle actions with the data required to execute them
+// The action creators bundle actions with the data required to execute them
 export const archiveTask = id => ({ type: actions.ARCHIVE_TASK, id });
 export const pinTask = id => ({ type: actions.PIN_TASK, id });
 

--- a/content/react/pt/data.md
+++ b/content/react/pt/data.md
@@ -38,7 +38,7 @@ export const actions = {
   PIN_TASK: 'PIN_TASK',
 };
 
-// The action creators are how you bundle actions with the data required to execute them
+// The action creators bundle actions with the data required to execute them
 export const archiveTask = id => ({ type: actions.ARCHIVE_TASK, id });
 export const pinTask = id => ({ type: actions.PIN_TASK, id });
 


### PR DESCRIPTION
The end of this comment can't be seen in the container. This makes it a little shorter without changing the meaning.