### PR TITLE
Chromatic import in .storybook/config.js

### DIFF
--- a/content/react/en/test.md
+++ b/content/react/en/test.md
@@ -64,7 +64,7 @@ Import Chromatic in your `.storybook/config.js` file.
 
 import { configure } from '@storybook/react';
 import requireContext from 'require-context.macro';
-import 'react-chromatic/storybook-addon';
+import 'storybook-chromatic';
 
 import '../src/index.css';
 


### PR DESCRIPTION
Should this be `import 'storybook-chromatic';`?
'react-chromatic/storybook-addon' wasn't found.