### PR TITLE
Use a colon on the "Simple component" page

### DIFF
--- a/content/angular/en/simple-component.md
+++ b/content/angular/en/simple-component.md
@@ -113,7 +113,7 @@ storiesOf('Task', module)
 
 ```
 
-There are two basic levels of organization in Storybook. The component and its child stories. Think of each story as a permutation of a component. You can have as many stories per component as you need.
+There are two basic levels of organization in Storybook: the component and its child stories. Think of each story as a permutation of a component. You can have as many stories per component as you need.
 
 * **Component**
   * Story

--- a/content/react/en/simple-component.md
+++ b/content/react/en/simple-component.md
@@ -73,7 +73,7 @@ storiesOf('Task', module)
   .add('archived', () => <Task task={{ ...task, state: 'TASK_ARCHIVED' }} {...actions} />);
 ```
 
-There are two basic levels of organization in Storybook. The component and its child stories. Think of each story as a permutation of a component. You can have as many stories per component as you need.
+There are two basic levels of organization in Storybook: the component and its child stories. Think of each story as a permutation of a component. You can have as many stories per component as you need.
 
 * **Component**
   * Story

--- a/content/vue/en/simple-component.md
+++ b/content/vue/en/simple-component.md
@@ -97,7 +97,7 @@ storiesOf('Task', module)
   });
 ```
 
-There are two basic levels of organization in Storybook. The component and its child stories. Think of each story as a permutation of a component. You can have as many stories per component as you need.
+There are two basic levels of organization in Storybook: the component and its child stories. Think of each story as a permutation of a component. You can have as many stories per component as you need.
 
 * **Component**
   * Story


### PR DESCRIPTION
A colon may be a better choice here, especially because the second
sentence is incomplete on its own. grammarbook.com provides a good
overview of this topic:

https://www.grammarbook.com/punctuation/colons.asp