### PR TITLE
Add customized logic for Twitter sharing by guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ contributors:
 
 An animation to use on the guide's hero image which corresponds with a named export from the [animation styles file](https://github.com/chromaui/learnstorybook.com/tree/master/src/styles/animations.js). The export must contain the entire CSS property and value for the animation.
 
+#### `twitterShareText`
+
+The text content for the tweet that is auto-populated when people choose to share the guide on Twitter. The URL that is included in the tweet is auto-generated based on the guide, but the individual guide can control the messaging before the link.
+
 ### Chapter frontmatter
 
 ---

--- a/content/design-systems-for-developers/index.md
+++ b/content/design-systems-for-developers/index.md
@@ -62,6 +62,7 @@ contributors: [
       detail: "UX Development at Shopify",
     },
 ]
+twitterShareText: "I’m learning about building design systems! They're great for scaling frontend code on large teams."
 ---
 
 <h2>What you'll build</h2>

--- a/content/intro-to-storybook/index.md
+++ b/content/intro-to-storybook/index.md
@@ -64,6 +64,7 @@ contributors:
       detail: "Engineer at Squarespace",
     },
   ]
+twitterShareText: "I’m learning Storybook! It’s a great dev tool for UI components."
 ---
 
 <h2>What you'll build</h2>

--- a/src/components/screens/ChapterScreen/ChapterLinks.js
+++ b/src/components/screens/ChapterScreen/ChapterLinks.js
@@ -56,8 +56,17 @@ const BoxLinkMessage = styled.div`
   }
 `;
 
-const ChapterLinks = ({ codeGithubUrl, commit }) => {
+const buildTwitterUrl = (guide, text) =>
+  `https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Flearnstorybook.com%2F&ref_src=twsrc%5Etfw&text=${encodeURI(
+    text
+  )}&tw_p=tweetbutton&url=https%3A%2F%2Flearnstorybook.com%2F${guide}&via=chromaui`;
+
+const ChapterLinks = ({ codeGithubUrl, commit, guide, twitterShareText }) => {
   const withCommitLink = !isNil(codeGithubUrl) && !isNil(commit);
+
+  if (!withCommitLink && !twitterShareText) {
+    return null;
+  }
 
   return (
     <BoxLinksWrapper withMultiple={withCommitLink}>
@@ -73,15 +82,17 @@ const ChapterLinks = ({ codeGithubUrl, commit }) => {
         </BoxLink>
       )}
 
-      <BoxLink to="https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Flearnstorybook.com%2F&ref_src=twsrc%5Etfw&text=I%E2%80%99m%20learning%20Storybook!%20It%E2%80%99s%20a%20great%20dev%20tool%20for%20UI%20components.%20&tw_p=tweetbutton&url=https%3A%2F%2Flearnstorybook.com&via=chromaui">
-        <BoxLinkContent>
-          <BoxLinkIcon icon="twitter" />
+      {twitterShareText && (
+        <BoxLink to={buildTwitterUrl(guide, twitterShareText)}>
+          <BoxLinkContent>
+            <BoxLinkIcon icon="twitter" />
 
-          <BoxLinkMessage>
-            Is this free guide helping you? Tweet to give kudos and help other devs find it.
-          </BoxLinkMessage>
-        </BoxLinkContent>
-      </BoxLink>
+            <BoxLinkMessage>
+              Is this free guide helping you? Tweet to give kudos and help other devs find it.
+            </BoxLinkMessage>
+          </BoxLinkContent>
+        </BoxLink>
+      )}
     </BoxLinksWrapper>
   );
 };
@@ -89,11 +100,14 @@ const ChapterLinks = ({ codeGithubUrl, commit }) => {
 ChapterLinks.propTypes = {
   codeGithubUrl: PropTypes.string,
   commit: PropTypes.string,
+  guide: PropTypes.string.isRequired,
+  twitterShareText: PropTypes.string,
 };
 
 ChapterLinks.defaultProps = {
   codeGithubUrl: null,
   commit: null,
+  twitterShareText: null,
 };
 
 export default ChapterLinks;

--- a/src/components/screens/ChapterScreen/ChapterLinks.stories.js
+++ b/src/components/screens/ChapterScreen/ChapterLinks.stories.js
@@ -2,6 +2,10 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import ChapterLinks from './ChapterLinks';
 
+const guide = 'guide';
+
 storiesOf('Screens|ChapterScreen/ChapterLinks', module)
-  .add('with commit', () => <ChapterLinks codeGithubUrl="https://github.com" commit="AAAAAA" />)
-  .add('without commit', () => <ChapterLinks />);
+  .add('with commit', () => (
+    <ChapterLinks codeGithubUrl="https://github.com" commit="AAAAAA" guide={guide} />
+  ))
+  .add('without commit', () => <ChapterLinks guide={guide} />);

--- a/src/components/screens/ChapterScreen/index.js
+++ b/src/components/screens/ChapterScreen/index.js
@@ -62,7 +62,7 @@ const Chapter = ({
       fields: { framework, guide, language, slug, chapter, permalink },
     },
     currentGuide: {
-      frontmatter: { codeGithubUrl, title: currentGuideTitle, toc },
+      frontmatter: { codeGithubUrl, title: currentGuideTitle, toc, twitterShareText },
     },
     site: { siteMetadata },
     tocPages,
@@ -116,7 +116,12 @@ const Chapter = ({
         <Title>{title}</Title>
         <Description>{description}</Description>
         <HighlightWrapper>{html}</HighlightWrapper>
-        <ChapterLinks codeGithubUrl={codeGithubUrl} commit={commit} />
+        <ChapterLinks
+          codeGithubUrl={codeGithubUrl}
+          commit={commit}
+          guide={guide}
+          twitterShareText={twitterShareText}
+        />
         <Pagination nextEntry={nextEntry} />
         <GithubLink githubFileUrl={githubFileUrl} />
       </Content>
@@ -147,6 +152,7 @@ Chapter.propTypes = {
         codeGithubUrl: PropTypes.string,
         title: PropTypes.string.isRequired,
         toc: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+        twitterShareText: PropTypes.string,
       }).isRequired,
     }).isRequired,
     tocPages: PropTypes.shape({
@@ -220,6 +226,7 @@ export const query = graphql`
         codeGithubUrl
         toc
         title
+        twitterShareText
       }
     }
     site {


### PR DESCRIPTION
New logic to customize the Twitter sharing message by the guide. If a guide does not have the `twitterShareText` in the guide frontmatter, the Twitter share link will not be shown. It is done that way right now to account for the Visual Testing Handbook which does not yet have content so it felt weird to encourage people to share it yet.

I decided to do `twitterShareText` rather than `twitterShareUrl` because the URL encoding makes having the whole URL in the frontmatter quite messy. The URL that we end up including in the tweet is auto-generated based on the guide you are on (so we link directly to the guide), but you can customize the messaging that comes before that.