### PR TITLE
Add loading indicator using Gatsby hooks for slow reqs

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,7 +1,24 @@
-/**
- * Implement Gatsby's Browser APIs in this file.
- *
- * See: https://www.gatsbyjs.org/docs/browser-apis/
- */
+const React = require('react');
+const ReactDOM = require('react-dom');
+const { Spinner } = require('@storybook/design-system');
 
-// You can delete this file if you're not using it
+const LOADING_ID = '___loading';
+
+exports.onRouteUpdateDelayed = () => {
+  const loadingElement = document.createElement('div');
+  loadingElement.id = LOADING_ID;
+  loadingElement.style = 'position: fixed; bottom: 32px; right: 32px;';
+  document.body.appendChild(loadingElement);
+
+  ReactDOM.render(<Spinner />, document.getElementById(LOADING_ID));
+};
+
+exports.onRouteUpdate = () => {
+  const loadingElement = document.getElementById(LOADING_ID);
+
+  if (!loadingElement) {
+    return;
+  }
+
+  loadingElement.parentNode.removeChild(loadingElement);
+};

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "build-storybook": "build-storybook -s ./static",
     "chromatic": "CHROMATIC_APP_CODE=92d6oc1qsrc chromatic test",
     "dev": "gatsby develop",
+    "serve": "gatsby serve",
     "format": "prettier-eslint --write '**/*.js'",
     "lint": "eslint .",
     "storybook": "start-storybook -s ./static -p 6006",


### PR DESCRIPTION
Adds a loading indicator for page requests that are taking a while. Typically, this will only happen for users on slow networks.

https://www.loom.com/share/c37a41fa75644765a9a9e133cbe3b45a