### PR TITLE
Rename test variable

### DIFF
--- a/content/intro-to-storybook/vue/en/composite-component.md
+++ b/content/intro-to-storybook/vue/en/composite-component.md
@@ -247,10 +247,10 @@ it('renders pinned tasks at the start of the list', () => {
   const vm = new Constructor({
     propsData: { tasks: withPinnedTasks },
   }).$mount();
-  const lastTaskInput = vm.$el.querySelector('.list-item:nth-child(1).TASK_PINNED');
+  const firstTaskPinned = vm.$el.querySelector('.list-item:nth-child(1).TASK_PINNED');
 
   // We expect the pinned task to be rendered first, not at the end
-  expect(lastTaskInput).not.toBe(null);
+  expect(firstTaskPinned).not.toBe(null);
 });
 ```
 


### PR DESCRIPTION
Previously there was a disconnect between the code and variable name. This commit changes the variable name to be more in line with it's value and purpose.