### PR TITLE
Fix width of GitHub nav item. Too small now that we have more stars

### DIFF
--- a/src/components/composite/Header.js
+++ b/src/components/composite/Header.js
@@ -121,7 +121,12 @@ const MobileMenuNavItem = styled(NavItem)`
 `;
 
 const GithubNavItem = styled(NavItem)`
-  width: 109px;
+  display: none;
+  min-width: 118px;
+
+  @media (min-width: 375px) {
+    display: inline-flex;
+  }
 `;
 
 const Nav = styled.div`


### PR DESCRIPTION
Broken:

![Screen Shot 2019-10-07 at 9 03 12 AM](https://user-images.githubusercontent.com/3035355/66323621-5140d600-e8e1-11e9-8319-5acc738251ab.png)

Fixed in this PR:

![Screen Shot 2019-10-07 at 9 03 08 AM](https://user-images.githubusercontent.com/3035355/66323636-56058a00-e8e1-11e9-9456-d587a6117284.png)
