### PR TITLE
Remove extra semicolon in the global.js codeblock

### DIFF
--- a/content/design-systems-for-developers/react/en/build.md
+++ b/content/design-systems-for-developers/react/en/build.md
@@ -80,7 +80,7 @@ export const GlobalStyle = createGlobalStyle`
  body {
    ${bodyStyles}
  }
-`;
+;
 ```
 
 To use the `GlobalStyle` “component” in Storybook, we can make use of a decorator (a component wrapper). In an app we’d place that component in the top-level app layout.


### PR DESCRIPTION
There was an extra semicolon in the pre-formatted code on line 83 which prevents that code from working; So I figured I would remove it.

Thanks for the write up guys! This is an excellent resource.