### PR TITLE
Fix JSdoc Example In Document.md [REACT]

### DIFF
--- a/content/design-systems-for-developers/react/en/document.md
+++ b/content/design-systems-for-developers/react/en/document.md
@@ -75,8 +75,7 @@ Next add JSdoc to the Avatar component (in `src/components/Avatar.js`) that prov
 ```javascript
 /**
 - Use an avatar for attributing actions or content to specific users.
-- The user's name should always be present when using Avatar – either printed beside
-- the avatar or in a tooltip.
+- The user's name should always be present when using Avatar – either printed beside the avatar or in a tooltip.
 **/
 
 export function Avatar({ loading, username, src, size, ...props }) {


### PR DESCRIPTION
## Description
Fixes JSdoc example in which the line wrap of the text was creating a separate bullet for the same point.

**[Check out the deploy preview](https://deploy-preview-164--tender-kilby-05eed0.netlify.com/design-systems-for-developers/react/en/document/)**
## Visual Change

**Previous implementation**:
![Screen Shot 2019-10-07 at 2 06 26 PM](https://user-images.githubusercontent.com/22504731/66336761-b9a4ad00-e90b-11e9-8844-4c48beb69291.png)
**Proposed Change**:
![Screen Shot 2019-10-07 at 2 06 40 PM](https://user-images.githubusercontent.com/22504731/66336781-c3c6ab80-e90b-11e9-978b-c6babe787b47.png)
