### PR TITLE
removed  extra ticks and corrected quotation marks

### DIFF
--- a/content/design-systems-for-developers/react/en/document.md
+++ b/content/design-systems-for-developers/react/en/document.md
@@ -342,8 +342,8 @@ In a previous chapter, we published Storybook online for visual review. It’s e
 
 ```json
 {
-  “scripts”: {
-     `"build-storybook-docs": "build-storybook -s public --docs",`
+  "scripts": {
+     "build-storybook-docs": "build-storybook -s public --docs",
    }
 }
 ```


### PR DESCRIPTION
While translating the documentation for "Design systems for Developers", reaching the documentation page i was presented with the following:
```json
{
  “scripts”: {
     `"build-storybook-docs": "build-storybook -s public --docs",`
   }
}
```
To be considered valid json, the quotation marks should be corrected and the extra ticks removed transforming the snippet into something like:

```
{
  "scripts": {
     "build-storybook-docs": "build-storybook -s public --docs",
   }
}
```

This small pr addresses this small fix, in order to improve the existing documentation, so that the reader won't be confused when copying the code excerpt.

Feel free to provide feedback