### PR TITLE
Fixed quotation mark on configuration snippet that leads to compile e…

### DIFF
--- a/content/design-systems-for-developers/react/en/document.md
+++ b/content/design-systems-for-developers/react/en/document.md
@@ -325,7 +325,7 @@ To get it to appear first, we have to tell Storybook to load the Introduction fi
 ```javascript
 configure(
  [
-   require.context('../src’, false, /Intro\.stories\.mdx/),
+   require.context('../src', false, /Intro\.stories\.mdx/),
    require.context('../src', true, /\.stories\.(js|mdx)$/),
  ],
  module


### PR DESCRIPTION
The code block uses a closing back tick instead of a matching single quote which leads to a compile error.