### PR TITLE
Fix Storybook Config Example in Distribute

### DIFF
--- a/content/design-systems-for-developers/react/en/distribute.md
+++ b/content/design-systems-for-developers/react/en/distribute.md
@@ -92,7 +92,8 @@ dist
 
 Finally, let’s make a couple of changes to `package.json` to ensure consumers of the package get all the information we need. The easiest way to do that is to run `yarn init` -- a command that initializes the package for publication:
 
-```yarn init
+```bash
+yarn init
 
 yarn init v1.16.0
 question name (learnstorybook-design-system):
@@ -324,7 +325,7 @@ configure(
       '../node_modules/<your-username>-learnstorybook-design-system/dist',
       true,
       /\.stories\.(js|mdx)$/
-    )
+    ),
   ],
   module
 );

--- a/content/design-systems-for-developers/react/en/distribute.md
+++ b/content/design-systems-for-developers/react/en/distribute.md
@@ -343,7 +343,7 @@ Navigate to the UserItem.js component in your editor. Also, find UserItem in the
 Import the Avatar component.
 
 ```javascript
-import { Avatar } from '<your-username>-learnstorybook-design-sys
+import { Avatar } from "<your-username>-learnstorybook-design-system";
 ```
 
 We want to render the Avatar beside the username.

--- a/content/design-systems-for-developers/react/en/distribute.md
+++ b/content/design-systems-for-developers/react/en/distribute.md
@@ -305,9 +305,9 @@ Now, let’s update the example app’s `.storybook/config.js` to list the desig
 ```javascript
 import React from "react";
 import { configure, addDecorator } from "@storybook/react";
-import { global } from "<your-username>-learnstorybook-design-system";
+import { global as designSystemGlobal } from "<your-username>-learnstorybook-design-system";
 
-const { GlobalStyle } = global;
+const { GlobalStyle } = designSystemGlobal;
 
 addDecorator(story => (
   <>

--- a/content/design-systems-for-developers/react/en/distribute.md
+++ b/content/design-systems-for-developers/react/en/distribute.md
@@ -1,7 +1,7 @@
 ---
-title: 'Distribute UI across an organization'
-tocTitle: 'Distribute'
-description: 'Learn to package and import your design system into other apps'
+title: "Distribute UI across an organization"
+tocTitle: "Distribute"
+description: "Learn to package and import your design system into other apps"
 commit: 3a5cd35
 ---
 
@@ -44,18 +44,18 @@ Learn more at [Learn Storybook](https://learnstorybook.com).
 Then, let’s create a `src/index.js` file to create a common entry point for using our design system. From this file we’ll export all our design tokens and the components:
 
 ```javascript
-import * as styles from './shared/styles';
-import * as global from './shared/global';
-import * as animation from './shared/animation';
-import * as icons from './shared/icons';
+import * as styles from "./shared/styles";
+import * as global from "./shared/global";
+import * as animation from "./shared/animation";
+import * as icons from "./shared/icons";
 
 export { styles, global, animation, icons };
 
-export * from './Avatar';
-export * from './Badge';
-export * from './Button';
-export * from './Icon';
-export * from './Link';
+export * from "./Avatar";
+export * from "./Badge";
+export * from "./Button";
+export * from "./Icon";
+export * from "./Link";
 ```
 
 Let’s add a development dependency on `@babel/cli` to compile our JavaScript for release:
@@ -303,20 +303,28 @@ yarn add <your-username>-learnstorybook-design-system
 Now, let’s update the example app’s `.storybook/config.js` to list the design system components, and to use the global styles defined by the design system. Edit `.storybook/config.js` to:
 
 ```javascript
-import React from ‘react’;
-import { configure. addDecorator } from '@storybook/react';
-import { GlobalStyles } from ‘<your-username>-learnstorybook-design-system’;
-addDecorator(s => <><GlobalStyles/>{s()}</>);
+import React from "react";
+import { configure, addDecorator } from "@storybook/react";
+import { global } from "<your-username>-learnstorybook-design-system";
+
+const { GlobalStyle } = global;
+
+addDecorator(story => (
+  <>
+    <GlobalStyle />
+    {story()}
+  </>
+));
 
 // automatically import all files ending in *.stories.js
 configure(
   [
-    require.context('../src', true, /\.stories\.js$/),
+    require.context("../src", true, /\.stories\.js$/),
     require.context(
-      '../node_modules/<your-username>-learnstorybook-design-system/dist',
+      "../node_modules/<your-username>-learnstorybook-design-system/dist",
       true,
       /\.stories\.(js|mdx)$/
-    ),
+    )
   ],
   module
 );
@@ -341,9 +349,9 @@ import { Avatar } from '<your-username>-learnstorybook-design-sys
 We want to render the Avatar beside the username.
 
 ```javascript
-import React from 'react';
-import styled from 'styled-components';
-import { Avatar } from 'learnstorybook-design-system';
+import React from "react";
+import styled from "styled-components";
+import { Avatar } from "learnstorybook-design-system";
 
 const Container = styled.div`
   background: #eee;

--- a/content/design-systems-for-developers/react/en/distribute.md
+++ b/content/design-systems-for-developers/react/en/distribute.md
@@ -1,7 +1,7 @@
 ---
-title: "Distribute UI across an organization"
-tocTitle: "Distribute"
-description: "Learn to package and import your design system into other apps"
+title: 'Distribute UI across an organization'
+tocTitle: 'Distribute'
+description: 'Learn to package and import your design system into other apps'
 commit: 3a5cd35
 ---
 
@@ -44,18 +44,18 @@ Learn more at [Learn Storybook](https://learnstorybook.com).
 Then, let’s create a `src/index.js` file to create a common entry point for using our design system. From this file we’ll export all our design tokens and the components:
 
 ```javascript
-import * as styles from "./shared/styles";
-import * as global from "./shared/global";
-import * as animation from "./shared/animation";
-import * as icons from "./shared/icons";
+import * as styles from './shared/styles';
+import * as global from './shared/global';
+import * as animation from './shared/animation';
+import * as icons from './shared/icons';
 
 export { styles, global, animation, icons };
 
-export * from "./Avatar";
-export * from "./Badge";
-export * from "./Button";
-export * from "./Icon";
-export * from "./Link";
+export * from './Avatar';
+export * from './Badge';
+export * from './Button';
+export * from './Icon';
+export * from './Link';
 ```
 
 Let’s add a development dependency on `@babel/cli` to compile our JavaScript for release:
@@ -143,7 +143,7 @@ For npm, you can create a token at the URL: https://www.npmjs.com/settings/&lt;y
 
 You’ll need a token with “Read and Publish” permissions.
 
-Let’s add that token to a file called `.env` in our project::
+Let’s add that token to a file called `.env` in our project:
 
 ```
 GH_TOKEN=<value you just got from GitHub>
@@ -300,12 +300,12 @@ Add your published design system as a dependency.
 yarn add <your-username>-learnstorybook-design-system
 ```
 
-Now, let’s update the example app’s `.storybook/config.js` to list the design system components, and to use the global styles defined by the design system. Edit `.storybook/config.js` to:
+Now, let’s update the example app’s `.storybook/config.js` to list the design system components, and to use the global styles defined by the design system. Make the following change to the file:
 
 ```javascript
-import React from "react";
-import { configure, addDecorator } from "@storybook/react";
-import { global as designSystemGlobal } from "<your-username>-learnstorybook-design-system";
+import React from 'react';
+import { configure, addDecorator } from '@storybook/react';
+import { global as designSystemGlobal } from '<your-username>-learnstorybook-design-system';
 
 const { GlobalStyle } = designSystemGlobal;
 
@@ -319,9 +319,9 @@ addDecorator(story => (
 // automatically import all files ending in *.stories.js
 configure(
   [
-    require.context("../src", true, /\.stories\.js$/),
+    require.context('../src', true, /\.stories\.js$/),
     require.context(
-      "../node_modules/<your-username>-learnstorybook-design-system/dist",
+      '../node_modules/<your-username>-learnstorybook-design-system/dist',
       true,
       /\.stories\.(js|mdx)$/
     )
@@ -343,15 +343,15 @@ Navigate to the UserItem.js component in your editor. Also, find UserItem in the
 Import the Avatar component.
 
 ```javascript
-import { Avatar } from "<your-username>-learnstorybook-design-system";
+import { Avatar } from '<your-username>-learnstorybook-design-system';
 ```
 
 We want to render the Avatar beside the username.
 
 ```javascript
-import React from "react";
-import styled from "styled-components";
-import { Avatar } from "learnstorybook-design-system";
+import React from 'react';
+import styled from 'styled-components';
+import { Avatar } from 'learnstorybook-design-system';
 
 const Container = styled.div`
   background: #eee;


### PR DESCRIPTION
**[Check out the deploy preview](https://deploy-preview-175--tender-kilby-05eed0.netlify.com/design-systems-for-developers/react/en/distribute/)**
## Description
The current example for including the packages' stories into the example app causes an error due to `GlobalStyles` being an incorrect imported value. Whats being exported in the design system is actually everything from `shared` namespaced as `global`. I imported `global` from the package and destructured `GlobalStyle` from that and it seems to work correctly.

**NOTE**: Prettier is currently enforcing double quotes and formatting fixes. I know there is currently an issue to reformat based on Prettier, so I left those changes in.

## Error
![Screen Shot 2019-10-09 at 11 45 26 AM](https://user-images.githubusercontent.com/22504731/66497646-c8fe3480-ea8a-11e9-9bac-05bfcc22fbbd.png)

## 👀
**Current implementation**:
![Screen Shot 2019-10-09 at 11 52 10 AM](https://user-images.githubusercontent.com/22504731/66512137-5438f380-eaa6-11e9-8df4-dee1e83f30ca.png)
**Proposed Change**:
![Screen Shot 2019-10-09 at 11 53 19 AM](https://user-images.githubusercontent.com/22504731/66512158-60bd4c00-eaa6-11e9-84b3-85250316f4db.png)
