### PR TITLE
Fixes to the documentation

### DIFF
--- a/content/design-systems-for-developers/react/en/distribute.md
+++ b/content/design-systems-for-developers/react/en/distribute.md
@@ -92,7 +92,7 @@ dist
 
 Finally, let’s make a couple of changes to `package.json` to ensure consumers of the package get all the information we need. The easiest way to do that is to run `yarn init` -- a command that initializes the package for publication:
 
-```yarn init
+```bash
 
 yarn init v1.16.0
 question name (learnstorybook-design-system):
@@ -143,7 +143,7 @@ For npm, you can create a token at the URL: https://www.npmjs.com/settings/&lt;y
 
 You’ll need a token with “Read and Publish” permissions.
 
-Let’s add that token to a file called `.env` in our project::
+Let’s add that token to a file called `.env` in our project:
 
 ```
 GH_TOKEN=<value you just got from GitHub>
@@ -300,12 +300,12 @@ Add your published design system as a dependency.
 yarn add <your-username>-learnstorybook-design-system
 ```
 
-Now, let’s update the example app’s `.storybook/config.js` to list the design system components, and to use the global styles defined by the design system. Edit `.storybook/config.js` to:
+Now, let’s update the example app’s `.storybook/config.js` to list the design system components, and to use the global styles defined by the design system. Make the following change to the file:
 
 ```javascript
-import React from ‘react’;
+import React from 'react';
 import { configure. addDecorator } from '@storybook/react';
-import { GlobalStyles } from ‘<your-username>-learnstorybook-design-system’;
+import { GlobalStyles } from '<your-username>-learnstorybook-design-system';
 addDecorator(s => <><GlobalStyles/>{s()}</>);
 
 // automatically import all files ending in *.stories.js
@@ -335,7 +335,7 @@ Navigate to the UserItem.js component in your editor. Also, find UserItem in the
 Import the Avatar component.
 
 ```javascript
-import { Avatar } from '<your-username>-learnstorybook-design-sys
+import { Avatar } from '<your-username>-learnstorybook-design-system'
 ```
 
 We want to render the Avatar beside the username.

--- a/content/design-systems-for-developers/react/en/workflow.md
+++ b/content/design-systems-for-developers/react/en/workflow.md
@@ -165,7 +165,7 @@ The tests were successfully updated. In the future, regressions will have a toug
 
 ## Distribute
 
-We have an open pull request that adds AvatarList to the design system. Our stories are written, the tests pass, and documentation exists. At last, we’re ready to update our design system package with Auto and npm.\*\* \*\*
+We have an open pull request that adds AvatarList to the design system. Our stories are written, the tests pass, and documentation exists. At last, we’re ready to update our design system package with Auto and npm.
 
 Add the `minor` label to the PR. This tells Auto to update the minor version of the package on merge.
 


### PR DESCRIPTION
While proofreading the translation for "Design Systems for Developers",   i came across with some lingering issues with the documentation and applied some fixes to it:

In the "Distribute" document:
- Changed the "```yarn init" to bash, despite being a yarn command, it runs on the console and it should be in conformity with the rest of the documentation.
-  Updated the sentence "Let’s add that token to a file called `.env` in our project::" it had a extra `:`
- The sentence: "Now, let’s update the example app’s .storybook/config.js to list the design system components, and to use the global styles defined by the design system. Edit .storybook/config.js to:", was simplified the wording to make it more streamlined and avoid the duplication.
- The snippet below the sentence above had a problem with the imports, it had `import React from ‘react’;` and it should be `import React from 'react';`
- Updated the import relative to the Avatar it was `import { Avatar } from '<your-username>-learnstorybook-design-sys` and it should be: `import { Avatar } from '<your-username>-learnstorybook-design-system`

In the "Workflow" document:
- Under the "Distribute" section removed the extra `.** **` as probably they were copied over from google docs to markdown.

Feel free to provide feedback