### PR TITLE
All markdown files are properly formatted now

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,5 @@
+const prettierConfig = require('./.prettierrc');
+
 module.exports = {
   parser: 'babel-eslint',
   extends: ['airbnb', 'prettier', 'plugin:jest/recommended'],
@@ -23,17 +25,7 @@ module.exports = {
         specialLink: ['to'],
       },
     ],
-    'prettier/prettier': [
-      'warn',
-      {
-        printWidth: 100,
-        tabWidth: 2,
-        bracketSpacing: true,
-        trailingComma: 'es5',
-        singleQuote: true,
-        jsxBracketSameLine: false,
-      },
-    ],
+    'prettier/prettier': ['warn', prettierConfig],
     'react/jsx-filename-extension': [
       1,
       {

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+yarn.lock
+package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "bracketSpacing": true,
+  "trailingComma": "es5",
+  "singleQuote": true
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "printWidth": 100,
-  "tabWidth": 2,
-  "bracketSpacing": true,
-  "trailingComma": "es5",
-  "singleQuote": true
-}

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  printWidth: 100,
+  tabWidth: 2,
+  bracketSpacing: true,
+  trailingComma: 'es5',
+  singleQuote: true,
+  jsxBracketSameLine: false,
+};

--- a/content/design-systems-for-developers/index.md
+++ b/content/design-systems-for-developers/index.md
@@ -1,67 +1,68 @@
 ---
-title: "Design Systems for Developers"
-description: "Discover how to build and maintain design systems using Storybook."
-heroDescription: "A guide that teaches professional developers how to transform component libraries into design systems and set up the production infrastructure used by leading frontend teams."
+title: 'Design Systems for Developers'
+description: 'Discover how to build and maintain design systems using Storybook.'
+heroDescription: 'A guide that teaches professional developers how to transform component libraries into design systems and set up the production infrastructure used by leading frontend teams.'
 overview: "Design systems power the frontend teams of Shopify, IBM, Salesforce, Airbnb, Twitter,  and many more. This guide for professional developers examines how the smartest teams engineer design systems at scale and why they use the tools they use. We'll walk through setting up core services, libraries, and workflows to develop a design system from scratch."
 order: 2
-themeColor: "#0079FF"
-codeGithubUrl: "https://github.com/chromaui/learnstorybook-design-system"
+themeColor: '#0079FF'
+codeGithubUrl: 'https://github.com/chromaui/learnstorybook-design-system'
 heroAnimationName: null
 toc:
   [
-    "introduction",
-    "architecture",
-    "build",
-    "review",
-    "test",
-    "document",
-    "distribute",
-    "workflow",
-    "conclusion",
+    'introduction',
+    'architecture',
+    'build',
+    'review',
+    'test',
+    'document',
+    'distribute',
+    'workflow',
+    'conclusion',
   ]
-coverImagePath: "/guide-cover/design-system.svg"
-thumbImagePath: "/guide-thumb/design-system.svg"
-contributorCount: "+38"
+coverImagePath: '/guide-cover/design-system.svg'
+thumbImagePath: '/guide-thumb/design-system.svg'
+contributorCount: '+38'
 authors:
   [
     {
-      src: "https://avatars2.githubusercontent.com/u/263385",
-      name: "Dominic Nguyen",
-      detail: "Storybook design",
+      src: 'https://avatars2.githubusercontent.com/u/263385',
+      name: 'Dominic Nguyen',
+      detail: 'Storybook design',
     },
     {
-      src: "https://avatars2.githubusercontent.com/u/132554",
-      name: "Tom Coleman",
-      detail: "Storybook core",
+      src: 'https://avatars2.githubusercontent.com/u/132554',
+      name: 'Tom Coleman',
+      detail: 'Storybook core',
     },
   ]
-contributors: [
-  {
-      src: "https://avatars2.githubusercontent.com/u/239215",
-      name: "Fernando Carrettoni",
-      detail: "Design Systems at Auth0",
+contributors:
+  [
+    {
+      src: 'https://avatars2.githubusercontent.com/u/239215',
+      name: 'Fernando Carrettoni',
+      detail: 'Design Systems at Auth0',
     },
     {
-      src: "https://avatars2.githubusercontent.com/u/8339031",
-      name: "Jessie Wu",
-      detail: "Engineer at New York Times",
+      src: 'https://avatars2.githubusercontent.com/u/8339031',
+      name: 'Jessie Wu',
+      detail: 'Engineer at New York Times',
     },
     {
-      src: "https://avatars2.githubusercontent.com/u/21959607",
-      name: "John Crisp",
-      detail: "Engineer at Acivilate",
+      src: 'https://avatars2.githubusercontent.com/u/21959607',
+      name: 'John Crisp',
+      detail: 'Engineer at Acivilate',
     },
     {
-      src: "https://avatars2.githubusercontent.com/u/1474548",
-      name: "Daniel Duan",
-      detail: "Engineer at Squarespace",
+      src: 'https://avatars2.githubusercontent.com/u/1474548',
+      name: 'Daniel Duan',
+      detail: 'Engineer at Squarespace',
     },
     {
-      src: "https://avatars2.githubusercontent.com/u/85783",
-      name: "Kaelig Deloumeau-Prigent",
-      detail: "UX Development at Shopify",
+      src: 'https://avatars2.githubusercontent.com/u/85783',
+      name: 'Kaelig Deloumeau-Prigent',
+      detail: 'UX Development at Shopify',
     },
-]
+  ]
 twitterShareText: "I’m learning about building design systems! They're great for scaling frontend code on large teams."
 ---
 

--- a/content/design-systems-for-developers/react/en/build.md
+++ b/content/design-systems-for-developers/react/en/build.md
@@ -166,13 +166,13 @@ And update your webpack config in `.storybook/webpack.config.js`:
 
 ```javascript
 module.exports = function({ config }) {
- config.module.rules.unshift({
-   test: /\.stories\.jsx?$/,
-   loaders: [require.resolve('@storybook/addon-storysource/loader')],
-   enforce: 'pre',
- });
+  config.module.rules.unshift({
+    test: /\.stories\.jsx?$/,
+    loaders: [require.resolve('@storybook/addon-storysource/loader')],
+    enforce: 'pre',
+  });
 
- return config;
+  return config;
 };
 ```
 

--- a/content/design-systems-for-developers/react/en/conclusion.md
+++ b/content/design-systems-for-developers/react/en/conclusion.md
@@ -1,7 +1,7 @@
 ---
-title: "Conclusion"
-tocTitle: "Conclusion"
-description: "Thriving design systems save time and increase productivity"
+title: 'Conclusion'
+tocTitle: 'Conclusion'
+description: 'Thriving design systems save time and increase productivity'
 ---
 
 Research-backed studies suggest reusing code can yield [42–81% time savings](https://www.researchgate.net/publication/3188437_Evaluating_Software_Reuse_Alternatives_A_Model_and_Its_Application_to_an_Industrial_Case_Study?ev=publicSearchHeader&_sg=g8WraNGZNGPw0R-1-jGpy0XwUDeAr3qb472J6lhisyQ3l24pSmndO6anMdX2L3HdWHifsczPegR9wjA) and boost productivity by [40%](http://www.cin.ufpe.br/~in1045/papers/art03.pdf). It should come as no surprise then that design systems, which facilitate sharing **user interface code**, are surging in popularity amongst developers.

--- a/content/design-systems-for-developers/react/en/distribute.md
+++ b/content/design-systems-for-developers/react/en/distribute.md
@@ -93,7 +93,7 @@ dist
 Finally, let’s make a couple of changes to `package.json` to ensure consumers of the package get all the information we need. The easiest way to do that is to run `yarn init` -- a command that initializes the package for publication:
 
 ```bash
-yarn init 
+yarn init
 
 yarn init v1.16.0
 question name (learnstorybook-design-system):
@@ -336,7 +336,7 @@ Navigate to the UserItem.js component in your editor. Also, find UserItem in the
 Import the Avatar component.
 
 ```javascript
-import { Avatar } from '<your-username>-learnstorybook-design-system'
+import { Avatar } from '<your-username>-learnstorybook-design-system';
 ```
 
 We want to render the Avatar beside the username.

--- a/content/design-systems-for-developers/react/en/introduction.md
+++ b/content/design-systems-for-developers/react/en/introduction.md
@@ -1,7 +1,7 @@
 ---
-title: "Introduction to design systems"
-tocTitle: "Introduction"
-description: "A guide to the latest production-ready tools for design systems"
+title: 'Introduction to design systems'
+tocTitle: 'Introduction'
+description: 'A guide to the latest production-ready tools for design systems'
 ---
 
 <div class="aside">This guide is made for <b>professional developers</b> learning how to build design systems. Intermediate experience in JavaScript, Git, and continuous integration is recommended. You should also know Storybook basics, such as writing a story and editing config files (<a href="/intro-to-storybook">Intro to Storybook</a> teaches basics).

--- a/content/design-systems-for-developers/react/en/test.md
+++ b/content/design-systems-for-developers/react/en/test.md
@@ -1,7 +1,7 @@
 ---
-title: "Test to maintain quality"
-tocTitle: "Test"
-description: "How to test design system appearance, functionality, and accessibility"
+title: 'Test to maintain quality'
+tocTitle: 'Test'
+description: 'How to test design system appearance, functionality, and accessibility'
 commit: 5b71208
 ---
 
@@ -68,9 +68,9 @@ Chromatic captured a baseline image of every story! Subsequent test runs will ca
 export const typography = {
   // ...
   size: {
-    s1: "13"
+    s1: '13',
     // ...
-  }
+  },
 };
 // ...
 ```
@@ -92,29 +92,29 @@ Let’s add visual testing to the continuous integration job. Open `.circleci/co
 ```yml
 version: 2
 jobs:
- build:
-   docker:
-     - image: circleci/node:8.10.0
+  build:
+    docker:
+      - image: circleci/node:8.10.0
 
-   working_directory: ~/repo
+    working_directory: ~/repo
 
-   steps:
-     - checkout
+    steps:
+      - checkout
 
-     - restore_cache:
-         keys:
-           - v1-dependencies-{{ checksum "package.json" }}
-           - v1-dependencies-
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
 
-     - run: yarn install
+      - run: yarn install
 
-     - save_cache:
-         paths:
-           - node_modules
-         key: v1-dependencies-{{ checksum "package.json" }}
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
 
-     - run: yarn test
-     - run: yarn chromatic test --app-code=<app-code> --exit-zero-on-changes
+      - run: yarn test
+      - run: yarn chromatic test --app-code=<app-code> --exit-zero-on-changes
 ```
 
 Save and `git commit`. Congratulations you just set up visual testing in CI!
@@ -136,16 +136,16 @@ Visually, it isn’t possible to see if the `href` attribute is there and points
 Let’s add a unit test for our `Link` component. create-react-app has set up a unit test environment for us already, so we can simply create a file `src/Link.test.js`:
 
 ```javascript
-import React from "react";
-import ReactDOM from "react-dom";
-import { Link } from "./Link";
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Link } from './Link';
 
 // A straightforward link wrapper that renders an <a> with the passed props. What we are testing
 // here is that the Link component passes the right props to the wrapper and itselfs
 const LinkWrapper = props => <a {...props} />; // eslint-disable-line jsx-a11y/anchor-has-content
 
-it("has a href attribute when rendering with linkWrapper", () => {
-  const div = document.createElement("div");
+it('has a href attribute when rendering with linkWrapper', () => {
+  const div = document.createElement('div');
   ReactDOM.render(
     <Link href="https://learnstorybook.com" LinkWrapper={LinkWrapper}>
       Link Text
@@ -153,10 +153,8 @@ it("has a href attribute when rendering with linkWrapper", () => {
     div
   );
 
-  expect(
-    div.querySelector('a[href="https://learnstorybook.com"]')
-  ).not.toBeNull();
-  expect(div.textContent).toEqual("Link Text");
+  expect(div.querySelector('a[href="https://learnstorybook.com"]')).not.toBeNull();
+  expect(div.textContent).toEqual('Link Text');
 
   ReactDOM.unmountComponentAtNode(div);
 });
@@ -192,22 +190,22 @@ yarn add --dev @storybook/addon-a11y
 Register the addon in `.storybook/addons.js`:
 
 ```javascript
-import "@storybook/addon-actions/register";
-import "@storybook/addon-links/register";
-import "@storybook/addon-storysource/register";
-import "@storybook/addon-knobs/register";
-import "@storybook/addon-a11y/register";
+import '@storybook/addon-actions/register';
+import '@storybook/addon-links/register';
+import '@storybook/addon-storysource/register';
+import '@storybook/addon-knobs/register';
+import '@storybook/addon-a11y/register';
 ```
 
 And add the `withA11y` decorator to our `.storybook/config.js`:
 
 ```javascript
-import React from "react";
-import { configure, addDecorator } from "@storybook/react";
-import { withA11y } from "@storybook/addon-a11y";
-import "storybook-chromatic";
+import React from 'react';
+import { configure, addDecorator } from '@storybook/react';
+import { withA11y } from '@storybook/addon-a11y';
+import 'storybook-chromatic';
 
-import { GlobalStyle } from "../src/components/shared/global";
+import { GlobalStyle } from '../src/components/shared/global';
 
 addDecorator(withA11y);
 addDecorator(story => (
@@ -218,7 +216,7 @@ addDecorator(story => (
 ));
 
 // automatically import all files ending in \*.stories.js
-configure(require.context("../src", true, /\.stories\.js\$/), module);
+configure(require.context('../src', true, /\.stories\.js\$/), module);
 ```
 
 Once installed, you’ll see a new “Accessibility” tab in the Storybook addons panel.

--- a/content/intro-to-storybook/angular/en/composite-component.md
+++ b/content/intro-to-storybook/angular/en/composite-component.md
@@ -1,7 +1,7 @@
 ---
-title: "Assemble a composite component"
-tocTitle: "Composite component"
-description: "Assemble a composite component out of simpler components"
+title: 'Assemble a composite component'
+tocTitle: 'Composite component'
+description: 'Assemble a composite component out of simpler components'
 commit: d3abd86
 ---
 
@@ -88,7 +88,7 @@ storiesOf('TaskList', module)
     moduleMetadata({
       declarations: [TaskListComponent, TaskComponent],
       imports: [CommonModule],
-    }),
+    })
   )
   .add('default', () => {
     return {
@@ -179,11 +179,9 @@ import { Task } from './task.model';
       </div>
 
       <div *ngIf="loading">
-        <div *ngFor="let i of [1,2,3,4,5,6]" class="loading-item">
+        <div *ngFor="let i of [1, 2, 3, 4, 5, 6]" class="loading-item">
           <span class="glow-checkbox"></span>
-          <span class="glow-text">
-            <span>Loading</span> <span>cool</span> <span>state</span>
-          </span>
+          <span class="glow-text"> <span>Loading</span> <span>cool</span> <span>state</span> </span>
         </div>
       </div>
     </div>
@@ -254,13 +252,11 @@ describe('TaskList component', () => {
   let component: TaskListComponent;
   let fixture: ComponentFixture<TaskListComponent>;
 
-  beforeEach(
-    async(() => {
-      TestBed.configureTestingModule({
-        declarations: [TaskComponent, TaskListComponent],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [TaskComponent, TaskListComponent],
+    }).compileComponents();
+  }));
 
   it('renders pinned tasks at the start of the list', () => {
     fixture = TestBed.createComponent(TaskListComponent);
@@ -268,9 +264,7 @@ describe('TaskList component', () => {
     component.tasks = withPinnedTasks;
 
     fixture.detectChanges();
-    const lastTaskInput = fixture.debugElement.query(
-      By.css('.list-item:nth-child(1)'),
-    );
+    const lastTaskInput = fixture.debugElement.query(By.css('.list-item:nth-child(1)'));
 
     // We expect the task titled "Task 6 (pinned)" to be rendered first, not at the end
     expect(lastTaskInput.nativeElement.id).toEqual('6');

--- a/content/intro-to-storybook/angular/en/conclusion.md
+++ b/content/intro-to-storybook/angular/en/conclusion.md
@@ -1,6 +1,6 @@
 ---
-title: "Conclusion"
-description: "Put all your knowledge together and learn more Storybook techniques"
+title: 'Conclusion'
+description: 'Put all your knowledge together and learn more Storybook techniques'
 ---
 
 Congratulations! You created your first UI in Storybook. Along the way you learned how to build, compose, test, and deploy UI components. If you’ve been following, your repo and deployed Storybook should look like this:
@@ -15,11 +15,11 @@ Storybook is a powerful tool for React, Vue, and Angular. It has a thriving deve
 
 Want to dive deeper? Here are helpful resources.
 
-* [**Official Storybook documentation**](https://storybook.js.org/basics/introduction/) has API documentation, community links, and the addon gallery.
+- [**Official Storybook documentation**](https://storybook.js.org/basics/introduction/) has API documentation, community links, and the addon gallery.
 
-* [**The Delightful Storybook Workflow**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07) highlights workflow best practices used by high-velocity teams at Squarespace, Major League Soccer, Discovery Network, and Apollo GraphQL.
+- [**The Delightful Storybook Workflow**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07) highlights workflow best practices used by high-velocity teams at Squarespace, Major League Soccer, Discovery Network, and Apollo GraphQL.
 
-* [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) dives deep into using Storybook to visual test components. Free 31-page ebook.
+- [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) dives deep into using Storybook to visual test components. Free 31-page ebook.
 
 ## Who made LearnStorybook.com?
 

--- a/content/intro-to-storybook/angular/en/contribute.md
+++ b/content/intro-to-storybook/angular/en/contribute.md
@@ -1,6 +1,6 @@
 ---
-title: "Contribute"
-description: "Help share Storybook with the world"
+title: 'Contribute'
+description: 'Help share Storybook with the world'
 ---
 
 Contributions to Learn Storybook are encouraged! If it’s something small like grammar or punctuation, open up a pull request. If it’s a bigger change, [add an issue](https://github.com/chromaui/learnstorybook.com/issues) for discussion.

--- a/content/intro-to-storybook/angular/en/data.md
+++ b/content/intro-to-storybook/angular/en/data.md
@@ -1,7 +1,7 @@
 ---
-title: "Wire in data"
-tocTitle: "Data"
-description: "Learn how to wire in data to your UI component"
+title: 'Wire in data'
+tocTitle: 'Data'
+description: 'Learn how to wire in data to your UI component'
 commit: 34f1938
 ---
 
@@ -67,10 +67,7 @@ export class TasksState {
   }
 
   @Action(PinTask)
-  pinTask(
-    { patchState, getState }: StateContext<TaskStateModel>,
-    { payload }: PinTask,
-  ) {
+  pinTask({ patchState, getState }: StateContext<TaskStateModel>, { payload }: PinTask) {
     const state = getState().entities;
 
     const entities = {
@@ -84,10 +81,7 @@ export class TasksState {
   }
 
   @Action(ArchiveTask)
-  archiveTask(
-    { patchState, getState }: StateContext<TaskStateModel>,
-    { payload }: ArchiveTask,
-  ) {
+  archiveTask({ patchState, getState }: StateContext<TaskStateModel>, { payload }: ArchiveTask) {
     const state = getState().entities;
 
     const entities = {
@@ -153,7 +147,11 @@ import { Observable } from 'rxjs';
 @Component({
   selector: 'task-list',
   template: `
-    <pure-task-list [tasks]="tasks$ | async" (onArchiveTask)="archiveTask($event)" (onPinTask)="pinTask($event)"></pure-task-list>
+    <pure-task-list
+      [tasks]="tasks$ | async"
+      (onArchiveTask)="archiveTask($event)"
+      (onPinTask)="pinTask($event)"
+    ></pure-task-list>
   `,
 })
 export class TaskListComponent implements OnInit {
@@ -212,7 +210,7 @@ storiesOf('TaskList', module)
     moduleMetadata({
       declarations: [PureTaskListComponent, TaskComponent],
       imports: [CommonModule],
-    }),
+    })
   )
   .add('default', () => {
     return {
@@ -280,13 +278,11 @@ describe('TaskList component', () => {
   let component: PureTaskListComponent;
   let fixture: ComponentFixture<PureTaskListComponent>;
 
-  beforeEach(
-    async(() => {
-      TestBed.configureTestingModule({
-        declarations: [TaskComponent, PureTaskListComponent],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [TaskComponent, PureTaskListComponent],
+    }).compileComponents();
+  }));
 
   it('renders pinned tasks at the start of the list', () => {
     fixture = TestBed.createComponent(PureTaskListComponent);
@@ -294,9 +290,7 @@ describe('TaskList component', () => {
     component.tasks = withPinnedTasks;
 
     fixture.detectChanges();
-    const lastTaskInput = fixture.debugElement.query(
-      By.css('.list-item:nth-child(1)'),
-    );
+    const lastTaskInput = fixture.debugElement.query(By.css('.list-item:nth-child(1)'));
 
     // We expect the task titled "Task 6 (pinned)" to be rendered first, not at the end
     expect(lastTaskInput.nativeElement.id).toEqual('6');

--- a/content/intro-to-storybook/angular/en/deploy.md
+++ b/content/intro-to-storybook/angular/en/deploy.md
@@ -1,7 +1,7 @@
 ---
-title: "Deploy Storybook"
-tocTitle: "Deploy"
-description: "Deploy Storybook online with GitHub and Netlify"
+title: 'Deploy Storybook'
+tocTitle: 'Deploy'
+description: 'Deploy Storybook online with GitHub and Netlify'
 ---
 
 In this tutorial we ran Storybook on our development machine. You may also want to share that Storybook with the team, especially the non-technical members. Thankfully, it’s easy to deploy Storybook online.

--- a/content/intro-to-storybook/angular/en/get-started.md
+++ b/content/intro-to-storybook/angular/en/get-started.md
@@ -1,7 +1,7 @@
 ---
-title: "Storybook for Angular tutorial"
-tocTitle: "Get started"
-description: "Setup Angular Storybook in your development environment"
+title: 'Storybook for Angular tutorial'
+tocTitle: 'Get started'
+description: 'Setup Angular Storybook in your development environment'
 commit: 0818d47
 ---
 

--- a/content/intro-to-storybook/angular/en/screen.md
+++ b/content/intro-to-storybook/angular/en/screen.md
@@ -1,7 +1,7 @@
 ---
-title: "Construct a screen"
-tocTitle: "Screens"
-description: "Construct a screen out of components"
+title: 'Construct a screen'
+tocTitle: 'Screens'
+description: 'Construct a screen out of components'
 commit: deff6cb
 ---
 
@@ -14,17 +14,17 @@ In this chapter we continue to increase the sophistication by combining componen
 As our app is very simple, the screen we’ll build is pretty trivial, simply wrapping the `TaskListComponent` (which supplies its own data via ngxs) in some layout and pulling a top-level `error` field out of our store (let's assume we'll set that field if we have some problem connecting to our server). Create `inbox-screen.component.ts` in your `src/tasks/containers` folder:
 
 ```typescript
-import { Component, OnInit, Input } from "@angular/core";
-import { Select, Store } from "@ngxs/store";
-import { TasksState, ArchiveTask, PinTask } from "../state/task.state";
-import { Task } from "../task.model";
-import { Observable } from "rxjs";
+import { Component, OnInit, Input } from '@angular/core';
+import { Select, Store } from '@ngxs/store';
+import { TasksState, ArchiveTask, PinTask } from '../state/task.state';
+import { Task } from '../task.model';
+import { Observable } from 'rxjs';
 
 @Component({
-  selector: "inbox-screen",
+  selector: 'inbox-screen',
   template: `
     <pure-inbox-screen [error]="error$ | async"></pure-inbox-screen>
-  `
+  `,
 })
 export class InboxScreenComponent implements OnInit {
   @Select(TasksState.getError) error$: Observable<any>;
@@ -38,10 +38,10 @@ export class InboxScreenComponent implements OnInit {
 Then, we need to create the `PureInboxScreenComponent` inside the `src/tasks/components` folder:
 
 ```typescript
-import { Component, OnInit, Input } from "@angular/core";
+import { Component, OnInit, Input } from '@angular/core';
 
 @Component({
-  selector: "pure-inbox-screen",
+  selector: 'pure-inbox-screen',
   template: `
     <div *ngIf="error" class="page lists-show">
       <div class="wrapper-message">
@@ -59,7 +59,7 @@ import { Component, OnInit, Input } from "@angular/core";
       </nav>
       <task-list></task-list>
     </div>
-  `
+  `,
 })
 export class PureInboxScreenComponent implements OnInit {
   @Input() error: any;
@@ -73,16 +73,16 @@ export class PureInboxScreenComponent implements OnInit {
 We also need to change the `AppComponent` to render the `InboxScreenComponent` (eventually we would use a router to choose the correct screen, but let's not worry about that here):
 
 ```typescript
-import { Component } from "@angular/core";
+import { Component } from '@angular/core';
 
 @Component({
-  selector: "app-root",
+  selector: 'app-root',
   template: `
     <inbox-screen></inbox-screen>
-  `
+  `,
 })
 export class AppComponent {
-  title = "app";
+  title = 'app';
 }
 ```
 
@@ -135,29 +135,29 @@ As an aside, passing data down the hierarchy is a legitimate approach, especiall
 The easiest way to do this is to supply the `Store` to our module and initialise the state as if this were a full app:
 
 ```typescript
-import { storiesOf, moduleMetadata } from "@storybook/angular";
-import { Store, NgxsModule } from "@ngxs/store";
-import { TasksState, ErrorFromServer } from "../state/task.state";
-import { TaskModule } from "../task.module";
+import { storiesOf, moduleMetadata } from '@storybook/angular';
+import { Store, NgxsModule } from '@ngxs/store';
+import { TasksState, ErrorFromServer } from '../state/task.state';
+import { TaskModule } from '../task.module';
 
-storiesOf("InboxScreen", module)
+storiesOf('InboxScreen', module)
   .addDecorator(
     moduleMetadata({
       imports: [TaskModule, NgxsModule.forRoot([TasksState])],
-      providers: [Store]
+      providers: [Store],
     })
   )
-  .add("default", () => {
+  .add('default', () => {
     return {
-      template: `<inbox-screen></inbox-screen>`
+      template: `<inbox-screen></inbox-screen>`,
     };
   })
-  .add("error", () => {
+  .add('error', () => {
     return {
       template: `<pure-inbox-screen [error]="error"></pure-inbox-screen>`,
       props: {
-        error: "Something!"
-      }
+        error: 'Something!',
+      },
     };
   });
 ```
@@ -181,48 +181,48 @@ You may be asking yourself why we created a new `PureInboxScreenComponent` just 
 This is a very simple example so adding these pure components might seem like an overkill. In Storybook for Angular there's another way of writing stories for the `InboxScreenComponent`:
 
 ```typescript
-import { storiesOf, moduleMetadata } from "@storybook/angular";
-import { Store, NgxsModule } from "@ngxs/store";
-import { TasksState, ErrorFromServer } from "../state/task.state";
-import { TaskModule } from "../task.module";
+import { storiesOf, moduleMetadata } from '@storybook/angular';
+import { Store, NgxsModule } from '@ngxs/store';
+import { TasksState, ErrorFromServer } from '../state/task.state';
+import { TaskModule } from '../task.module';
 
-import { Component } from "@angular/core";
+import { Component } from '@angular/core';
 
 @Component({
   template: `
     <inbox-screen></inbox-screen>
-  `
+  `,
 })
 class HostDispatchErrorComponent {
   constructor(store: Store) {
-    store.dispatch(new ErrorFromServer("Error"));
+    store.dispatch(new ErrorFromServer('Error'));
   }
 }
 
-storiesOf("InboxScreen", module)
+storiesOf('InboxScreen', module)
   .addDecorator(
     moduleMetadata({
       declarations: [HostDispatchErrorComponent],
       imports: [TaskModule, NgxsModule.forRoot([TasksState])],
-      providers: [Store]
+      providers: [Store],
     })
   )
-  .add("default", () => {
+  .add('default', () => {
     return {
-      template: `<inbox-screen></inbox-screen>`
+      template: `<inbox-screen></inbox-screen>`,
     };
   })
-  .add("error", () => {
+  .add('error', () => {
     return {
       template: `<pure-inbox-screen [error]="error"></pure-inbox-screen>`,
       props: {
-        error: "Something!"
-      }
+        error: 'Something!',
+      },
     };
   })
-  .add("Connected Error", () => {
+  .add('Connected Error', () => {
     return {
-      component: HostDispatchErrorComponent
+      component: HostDispatchErrorComponent,
     };
   });
 ```

--- a/content/intro-to-storybook/angular/en/simple-component.md
+++ b/content/intro-to-storybook/angular/en/simple-component.md
@@ -1,7 +1,7 @@
 ---
-title: "Build a simple component"
-tocTitle: "Simple component"
-description: "Build a simple component in isolation"
+title: 'Build a simple component'
+tocTitle: 'Simple component'
+description: 'Build a simple component in isolation'
 commit: 1a14919
 ---
 
@@ -13,8 +13,8 @@ We’ll build our UI following a [Component-Driven Development](https://blog.hic
 
 `TaskComponent` is the core component in our app. Each task displays slightly differently depending on exactly what state it’s in. We display a checked (or unchecked) checkbox, some information about the task, and a “pin” button, allowing us to move tasks up and down the list. Putting this together, we’ll need these props:
 
-* `title` – a string describing the task
-* `state` - which list is the task currently in and is it checked off?
+- `title` – a string describing the task
+- `state` - which list is the task currently in and is it checked off?
 
 As we start to build `TaskComponent`, we first write our test states that correspond to the different types of tasks sketch above. Then we use Storybook to build the component in isolation using mocked data. We’ll “visual test” the component’s appearance given each state as we go.
 
@@ -47,7 +47,6 @@ export class TaskComponent implements OnInit {
 
   ngOnInit() {}
 }
-
 ```
 
 Above, we render straightforward markup for `TaskComponent` based on the existing HTML structure of the Todos app.
@@ -76,7 +75,7 @@ storiesOf('Task', module)
   .addDecorator(
     moduleMetadata({
       declarations: [TaskComponent],
-    }),
+    })
   )
   .add('default', () => {
     return {
@@ -108,15 +107,14 @@ storiesOf('Task', module)
       },
     };
   });
-
 ```
 
 There are two basic levels of organization in Storybook: the component and its child stories. Think of each story as a permutation of a component. You can have as many stories per component as you need.
 
-* **Component**
-  * Story
-  * Story
-  * Story
+- **Component**
+  - Story
+  - Story
+  - Story
 
 To initiate Storybook we first call the `storiesOf()` function to register the component. We add a display name for the component –the name that appears on the sidebar in the Storybook app.
 
@@ -137,9 +135,7 @@ When creating a story we use a base task (`task`) to build out the shape of the 
 We also have to make one small change to the Storybook configuration setup (`.storybook/config.js`) so it notices our `.stories.ts` files and uses our LESS file. By default Storybook looks for stories in a `/stories` directory; this tutorial uses a naming scheme that is similar to the `.type.extension` naming scheme favoured when developing Angular apps.
 
 ```typescript
-import {
-  configure
-} from '@storybook/angular';
+import { configure } from '@storybook/angular';
 
 import '../src/styles.less';
 
@@ -151,25 +147,26 @@ function loadStories() {
 }
 
 configure(loadStories, module);
-
 ```
 
 In order to support that LESS import we'll need to play around a bit with webpack. Just create a `webpack.config.js` file inside the `.storybook` folder and paste the following:
 
 ```javascript
-const path = require("path");
+const path = require('path');
 
 module.exports = {
   module: {
-    rules: [{
-      test: /\.less$/,
-      loaders: ["style-loader", "css-loader", "less-loader"],
-      include: path.resolve(__dirname, "../")
-    }]
-  }
+    rules: [
+      {
+        test: /\.less$/,
+        loaders: ['style-loader', 'css-loader', 'less-loader'],
+        include: path.resolve(__dirname, '../'),
+      },
+    ],
+  },
 };
-
 ```
+
 You'll also need to install the corresponding loaders:
 
 ```
@@ -213,9 +210,9 @@ import { Task } from './task.model';
       </div>
 
       <div class="actions">
-          <a *ngIf="task?.state !== 'TASK_ARCHIVED'" (click)="onPin(task.id)">
-            <span class="icon-star"></span>
-          </a>
+        <a *ngIf="task?.state !== 'TASK_ARCHIVED'" (click)="onPin(task.id)">
+          <span class="icon-star"></span>
+        </a>
       </div>
     </div>
   `,
@@ -289,18 +286,16 @@ Then create an `src/storybook.test.ts` file with the following in it:
 
 ```typescript
 import * as path from 'path';
-import initStoryshots, {
-  multiSnapshotWithOptions,
-} from '@storybook/addon-storyshots';
+import initStoryshots, { multiSnapshotWithOptions } from '@storybook/addon-storyshots';
 
 initStoryshots({
   framework: 'angular',
   configPath: path.join(__dirname, '../.storybook'),
   test: multiSnapshotWithOptions(),
 });
-
 ```
-After that, create a `src/jest-config` folder with two files inside, `globalMocks.ts`: 
+
+After that, create a `src/jest-config` folder with two files inside, `globalMocks.ts`:
 
 ```typescript
 const mock = () => {
@@ -318,15 +313,15 @@ Object.defineProperty(window, 'sessionStorage', { value: mock() });
 Object.defineProperty(window, 'getComputedStyle', {
   value: () => ['-webkit-appearance'],
 });
-
 ```
+
 and `setup.ts`:
 
 ```typescript
 import 'jest-preset-angular';
 import './globalMocks';
-
 ```
+
 Then we need to add a new field to our `package.json`,
 
 ```json
@@ -353,16 +348,18 @@ Then we need to add a new field to our `package.json`,
       "\\.(css|less)$": "identity-obj-proxy"
     }
   },
-  ```
+```
+
 a couple of new scripts to run `jest`
 
-  ```json
-  "scripts": {
-    ...
-    "jest": "jest",
-    "jest:watch": "jest --watch"
-  }
-  ```
+```json
+"scripts": {
+  ...
+  "jest": "jest",
+  "jest:watch": "jest --watch"
+}
+```
+
 and update `src/tsconfig.app.json` to exclude `.test.ts` files
 
 ```json

--- a/content/intro-to-storybook/angular/en/test.md
+++ b/content/intro-to-storybook/angular/en/test.md
@@ -1,7 +1,7 @@
 ---
-title: "Test UI components"
-tocTitle: "Testing"
-description: "Learn the ways to test UI components"
+title: 'Test UI components'
+tocTitle: 'Testing'
+description: 'Learn the ways to test UI components'
 commit: 8fdc779
 ---
 
@@ -65,12 +65,12 @@ yarn add storybook-chromatic
 Import Chromatic in your `.storybook/config.js` file.
 
 ```javascript
-import { configure } from "@storybook/angular";
-import "storybook-chromatic";
-import "../src/styles.less";
+import { configure } from '@storybook/angular';
+import 'storybook-chromatic';
+import '../src/styles.less';
 
 // automatically import all files ending in *.stories.ts
-const req = require.context("../src/", true, /.stories.ts$/);
+const req = require.context('../src/', true, /.stories.ts$/);
 
 function loadStories() {
   req.keys().forEach(filename => req(filename));

--- a/content/intro-to-storybook/angular/es/composite-component.md
+++ b/content/intro-to-storybook/angular/es/composite-component.md
@@ -1,7 +1,7 @@
 ---
-title: "Ensambla un componente compuesto"
-tocTitle: "Componente Compuesto"
-description: "Ensambla un componente compuesto a partir de componentes simples"
+title: 'Ensambla un componente compuesto'
+tocTitle: 'Componente Compuesto'
+description: 'Ensambla un componente compuesto a partir de componentes simples'
 commit: d3abd86
 ---
 
@@ -88,7 +88,7 @@ storiesOf('TaskList', module)
     moduleMetadata({
       declarations: [TaskListComponent, TaskComponent],
       imports: [CommonModule],
-    }),
+    })
   )
   .add('default', () => {
     return {
@@ -179,11 +179,9 @@ import { Task } from './task.model';
       </div>
 
       <div *ngIf="loading">
-        <div *ngFor="let i of [1,2,3,4,5,6]" class="loading-item">
+        <div *ngFor="let i of [1, 2, 3, 4, 5, 6]" class="loading-item">
           <span class="glow-checkbox"></span>
-          <span class="glow-text">
-            <span>Loading</span> <span>cool</span> <span>state</span>
-          </span>
+          <span class="glow-text"> <span>Loading</span> <span>cool</span> <span>state</span> </span>
         </div>
       </div>
     </div>
@@ -254,13 +252,11 @@ describe('TaskList component', () => {
   let component: TaskListComponent;
   let fixture: ComponentFixture<TaskListComponent>;
 
-  beforeEach(
-    async(() => {
-      TestBed.configureTestingModule({
-        declarations: [TaskComponent, TaskListComponent],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [TaskComponent, TaskListComponent],
+    }).compileComponents();
+  }));
 
   it('renders pinned tasks at the start of the list', () => {
     fixture = TestBed.createComponent(TaskListComponent);
@@ -268,9 +264,7 @@ describe('TaskList component', () => {
     component.tasks = withPinnedTasks;
 
     fixture.detectChanges();
-    const lastTaskInput = fixture.debugElement.query(
-      By.css('.list-item:nth-child(1)'),
-    );
+    const lastTaskInput = fixture.debugElement.query(By.css('.list-item:nth-child(1)'));
 
     // We expect the task titled "Task 6 (pinned)" to be rendered first, not at the end
     expect(lastTaskInput.nativeElement.id).toEqual('6');

--- a/content/intro-to-storybook/angular/es/conclusion.md
+++ b/content/intro-to-storybook/angular/es/conclusion.md
@@ -1,6 +1,6 @@
 ---
-title: "Conclusión"
-description: "Pon todo tu conocimiento junto y aprende más técnicas de Storybook"
+title: 'Conclusión'
+description: 'Pon todo tu conocimiento junto y aprende más técnicas de Storybook'
 ---
 
 ¡Felicitaciones! Creaste tu primer interfaz de usuario en Storybook. Mientras la hacías, aprendiste a construir, componer, probar e implementar componentes de interfaz de usuario. Si has estado siguiendo todos los pasos, tu repositorio y Storybook desplegado deberían verse así:
@@ -15,11 +15,11 @@ Storybook es una poderosa herramienta para React, Vue y Angular. Cuenta con una 
 
 ¿Quieres profundizar tus conocimientos? Aquí encontrarás algunos recursos útiles:
 
-* [**Documentación oficial de Storybook**](https://storybook.js.org/basics/introduction/) contiene la documentación del API, links comunitarios y una galería de complementos.
+- [**Documentación oficial de Storybook**](https://storybook.js.org/basics/introduction/) contiene la documentación del API, links comunitarios y una galería de complementos.
 
-* **El delicioso flujo de trabajo de Storybook** (¡Próximamente!) destaca las mejores prácticas del flujo de trabajo utilizado por equipos de alta velocidad en Squarespace, Major League Soccer, Discovery Network y Apollo GraphQL.
+- **El delicioso flujo de trabajo de Storybook** (¡Próximamente!) destaca las mejores prácticas del flujo de trabajo utilizado por equipos de alta velocidad en Squarespace, Major League Soccer, Discovery Network y Apollo GraphQL.
 
-* [**Manual de pruebas visuales**](https://www.chromaticqa.com/book/visual-testing-handbook) profundiza en el uso de Storybook para probar componentes visuales. Libro electrónico gratuito de 31 páginas.
+- [**Manual de pruebas visuales**](https://www.chromaticqa.com/book/visual-testing-handbook) profundiza en el uso de Storybook para probar componentes visuales. Libro electrónico gratuito de 31 páginas.
 
 ## ¿Quién creó LearnStorybook.com?
 

--- a/content/intro-to-storybook/angular/es/contribute.md
+++ b/content/intro-to-storybook/angular/es/contribute.md
@@ -1,6 +1,6 @@
 ---
-title: "Contribuir"
-description: "Ayuda a compartir Storybook con el mundo"
+title: 'Contribuir'
+description: 'Ayuda a compartir Storybook con el mundo'
 ---
 
 # Contribuir

--- a/content/intro-to-storybook/angular/es/data.md
+++ b/content/intro-to-storybook/angular/es/data.md
@@ -1,7 +1,7 @@
 ---
-title: "Introducir datos"
-tocTitle: "Datos"
-description: "Aprende como introducir datos a tus componentes interfaz gráfica"
+title: 'Introducir datos'
+tocTitle: 'Datos'
+description: 'Aprende como introducir datos a tus componentes interfaz gráfica'
 commit: 34f1938
 ---
 
@@ -67,10 +67,7 @@ export class TasksState {
   }
 
   @Action(PinTask)
-  pinTask(
-    { patchState, getState }: StateContext<TaskStateModel>,
-    { payload }: PinTask,
-  ) {
+  pinTask({ patchState, getState }: StateContext<TaskStateModel>, { payload }: PinTask) {
     const state = getState().entities;
 
     const entities = {
@@ -84,10 +81,7 @@ export class TasksState {
   }
 
   @Action(ArchiveTask)
-  archiveTask(
-    { patchState, getState }: StateContext<TaskStateModel>,
-    { payload }: ArchiveTask,
-  ) {
+  archiveTask({ patchState, getState }: StateContext<TaskStateModel>, { payload }: ArchiveTask) {
     const state = getState().entities;
 
     const entities = {
@@ -153,7 +147,11 @@ import { Observable } from 'rxjs';
 @Component({
   selector: 'task-list',
   template: `
-    <pure-task-list [tasks]="tasks$ | async" (onArchiveTask)="archiveTask($event)" (onPinTask)="pinTask($event)"></pure-task-list>
+    <pure-task-list
+      [tasks]="tasks$ | async"
+      (onArchiveTask)="archiveTask($event)"
+      (onPinTask)="pinTask($event)"
+    ></pure-task-list>
   `,
 })
 export class TaskListComponent implements OnInit {
@@ -212,7 +210,7 @@ storiesOf('TaskList', module)
     moduleMetadata({
       declarations: [PureTaskListComponent, TaskComponent],
       imports: [CommonModule],
-    }),
+    })
   )
   .add('default', () => {
     return {
@@ -280,13 +278,11 @@ describe('TaskList component', () => {
   let component: PureTaskListComponent;
   let fixture: ComponentFixture<PureTaskListComponent>;
 
-  beforeEach(
-    async(() => {
-      TestBed.configureTestingModule({
-        declarations: [TaskComponent, PureTaskListComponent],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [TaskComponent, PureTaskListComponent],
+    }).compileComponents();
+  }));
 
   it('renders pinned tasks at the start of the list', () => {
     fixture = TestBed.createComponent(PureTaskListComponent);
@@ -294,9 +290,7 @@ describe('TaskList component', () => {
     component.tasks = withPinnedTasks;
 
     fixture.detectChanges();
-    const lastTaskInput = fixture.debugElement.query(
-      By.css('.list-item:nth-child(1)'),
-    );
+    const lastTaskInput = fixture.debugElement.query(By.css('.list-item:nth-child(1)'));
 
     // We expect the task titled "Task 6 (pinned)" to be rendered first, not at the end
     expect(lastTaskInput.nativeElement.id).toEqual('6');

--- a/content/intro-to-storybook/angular/es/deploy.md
+++ b/content/intro-to-storybook/angular/es/deploy.md
@@ -1,7 +1,7 @@
 ---
-title: "Desplegar Storybook"
-tocTitle: "Desplegar"
-description: "Desplegar Storybook online con GitHub y Netlify"
+title: 'Desplegar Storybook'
+tocTitle: 'Desplegar'
+description: 'Desplegar Storybook online con GitHub y Netlify'
 ---
 
 En este tutorial hemos ejecutado Storybook en nuestra máquina de desarrollo. Es probable que quieras compartir ese Storybook con tu equipo, especialmente con los miembros no técnicos. Afortunadamente, es fácil desplegar Storybook en línea.

--- a/content/intro-to-storybook/angular/es/get-started.md
+++ b/content/intro-to-storybook/angular/es/get-started.md
@@ -1,7 +1,7 @@
 ---
-title: "Storybook para o Angular tutorial"
-tocTitle: "Empezando"
-description: "Configurar Angular Storybook en tu entorno de desarrollo"
+title: 'Storybook para o Angular tutorial'
+tocTitle: 'Empezando'
+description: 'Configurar Angular Storybook en tu entorno de desarrollo'
 commit: 0818d47
 ---
 

--- a/content/intro-to-storybook/angular/es/screen.md
+++ b/content/intro-to-storybook/angular/es/screen.md
@@ -1,7 +1,7 @@
 ---
-title: "Construir una pantalla"
-tocTitle: "Pantallas"
-description: "Construir una pantalla utilizando componentes"
+title: 'Construir una pantalla'
+tocTitle: 'Pantallas'
+description: 'Construir una pantalla utilizando componentes'
 commit: deff6cb
 ---
 
@@ -14,14 +14,14 @@ En este capítulo aumentaremos la sofisticación al combinar los componentes que
 Como nuestra aplicación es muy simple, la pantalla que construiremos es bastante trivial, simplemente envolviendo un `TaskListComponent` y sacando un campo `error` de nuestro contenedor de estado. Ahora crearemos `inbox-screen.component.ts` dentro de `src/tasks/containers`:
 
 ```typescript
-import { Component, OnInit, Input } from "@angular/core";
-import { Select, Store } from "@ngxs/store";
-import { TasksState, ArchiveTask, PinTask } from "../state/task.state";
-import { Task } from "../task.model";
-import { Observable } from "rxjs";
+import { Component, OnInit, Input } from '@angular/core';
+import { Select, Store } from '@ngxs/store';
+import { TasksState, ArchiveTask, PinTask } from '../state/task.state';
+import { Task } from '../task.model';
+import { Observable } from 'rxjs';
 
 @Component({
-  selector: "inbox-screen",
+  selector: 'inbox-screen',
   template: `
     <div *ngIf="error$ | async" class="page lists-show">
       <div class="wrapper-message">
@@ -39,7 +39,7 @@ import { Observable } from "rxjs";
       </nav>
       <task-list></task-list>
     </div>
-  `
+  `,
 })
 export class InboxScreenComponent implements OnInit {
   @Select(TasksState.getError) error$: Observable<any>;
@@ -53,16 +53,16 @@ export class InboxScreenComponent implements OnInit {
 También cambiamos nuestro `AppComponent` para que incluya el `InboxScreenComponent` (en una aplicación real esto sería manejado por el enrutador pero podemos obviarlo):
 
 ```typescript
-import { Component } from "@angular/core";
+import { Component } from '@angular/core';
 
 @Component({
-  selector: "app-root",
+  selector: 'app-root',
   template: `
     <inbox-screen></inbox-screen>
-  `
+  `,
 })
 export class AppComponent {
-  title = "app";
+  title = 'app';
 }
 ```
 
@@ -73,29 +73,29 @@ Como vimos anteriormente, el `InboxScreenComponent` es un **contenedor** que ren
 Sin embargo, para el `InboxScreenComponent` tenemos un problema porque depende de nuestro contenedor de estado global. Afortunadamente, Storybook para Angular provee el decorador `moduleMetadata` que nos permite configurar el módulo de Angular e inyectar los `provider`s que necesitamos:
 
 ```typescript
-import { storiesOf, moduleMetadata } from "@storybook/angular";
-import { Store, NgxsModule } from "@ngxs/store";
-import { TasksState, ErrorFromServer } from "../state/task.state";
-import { TaskModule } from "../task.module";
+import { storiesOf, moduleMetadata } from '@storybook/angular';
+import { Store, NgxsModule } from '@ngxs/store';
+import { TasksState, ErrorFromServer } from '../state/task.state';
+import { TaskModule } from '../task.module';
 
-import { Component } from "@angular/core";
+import { Component } from '@angular/core';
 
-storiesOf("InboxScreen", module)
+storiesOf('InboxScreen', module)
   .addDecorator(
     moduleMetadata({
       declarations: [],
       imports: [TaskModule, NgxsModule.forRoot([TasksState])],
-      providers: [Store]
+      providers: [Store],
     })
   )
-  .add("default", () => {
+  .add('default', () => {
     return {
-      template: `<inbox-screen></inbox-screen>`
+      template: `<inbox-screen></inbox-screen>`,
     };
   })
-  .add("error", () => {
+  .add('error', () => {
     return {
-      template: `<inbox-screen></inbox-screen>`
+      template: `<inbox-screen></inbox-screen>`,
     };
   });
 ```
@@ -117,40 +117,40 @@ Por otro lado, la transmisión de datos a nivel jerárquico es un enfoque legít
 La forma más sencilla de hacer esto es crear un componente que incluya nuestro `InboxScreenComponent` e incluirlo dentro de los meta datos del módulo. De esa forma, las instancias de los `provider`s que hemos configurado estarán disponibles en el constructor del componente que hemos creado. Una vez que tengamos este componente listo, es sencillo enviar una acción a nuestro contenedor de estado para que cree un error:
 
 ```typescript
-import { storiesOf, moduleMetadata } from "@storybook/angular";
-import { Store, NgxsModule } from "@ngxs/store";
-import { TasksState, ErrorFromServer } from "../state/task.state";
-import { TaskModule } from "../task.module";
+import { storiesOf, moduleMetadata } from '@storybook/angular';
+import { Store, NgxsModule } from '@ngxs/store';
+import { TasksState, ErrorFromServer } from '../state/task.state';
+import { TaskModule } from '../task.module';
 
-import { Component } from "@angular/core";
+import { Component } from '@angular/core';
 
 @Component({
   template: `
     <inbox-screen></inbox-screen>
-  `
+  `,
 })
 class HostDispatchErrorComponent {
   constructor(store: Store) {
-    store.dispatch(new ErrorFromServer("Error"));
+    store.dispatch(new ErrorFromServer('Error'));
   }
 }
 
-storiesOf("InboxScreen", module)
+storiesOf('InboxScreen', module)
   .addDecorator(
     moduleMetadata({
       declarations: [HostDispatchErrorComponent],
       imports: [TaskModule, NgxsModule.forRoot([TasksState])],
-      providers: [Store]
+      providers: [Store],
     })
   )
-  .add("default", () => {
+  .add('default', () => {
     return {
-      template: `<inbox-screen></inbox-screen>`
+      template: `<inbox-screen></inbox-screen>`,
     };
   })
-  .add("error", () => {
+  .add('error', () => {
     return {
-      component: HostDispatchErrorComponent
+      component: HostDispatchErrorComponent,
     };
   });
 ```

--- a/content/intro-to-storybook/angular/es/simple-component.md
+++ b/content/intro-to-storybook/angular/es/simple-component.md
@@ -1,7 +1,7 @@
 ---
-title: "Construye un componente simple"
-tocTitle: "Componente Simple"
-description: "Construye un componente simple en aislamiento"
+title: 'Construye un componente simple'
+tocTitle: 'Componente Simple'
+description: 'Construye un componente simple en aislamiento'
 commit: 1a14919
 ---
 
@@ -13,8 +13,8 @@ Construiremos nuestra interfaz gráfica siguiendo la metodología CDD: [Componen
 
 `TaskComponent` (o Tarea) es el componente principal de nuestra aplicación. Cada tarea se muestra de forma ligeramente diferente según el estado en el que se encuentre. Mostramos un checkbox marcado (o sin marcar), información sobre la tarea y un botón “pin” que nos permite fijar dicha tarea en la parte superior de la lista. Con estas especificaciones en mente, necesitaremos las siguientes propiedades propiedades (props):
 
-* `title` – una cadena de caracteres que describe la tarea
-* `state` - ¿en qué lista se encuentra la tarea actualmente? y, ¿está marcado el checkbox?
+- `title` – una cadena de caracteres que describe la tarea
+- `state` - ¿en qué lista se encuentra la tarea actualmente? y, ¿está marcado el checkbox?
 
 Para construir nuestro `TaskComponent`, primero escribiremos tests para los estados que corresponden a los distintos tipos de tareas descritas anteriormente. Luego, utilizaremos Storybook para construir el componente en aislamiento utilizando únicamente datos de prueba. Vamos a “testear visualmente” la apariencia del componente dependiendo de cada estado.
 
@@ -75,7 +75,7 @@ storiesOf('Task', module)
   .addDecorator(
     moduleMetadata({
       declarations: [TaskComponent],
-    }),
+    })
   )
   .add('default', () => {
     return {
@@ -111,10 +111,10 @@ storiesOf('Task', module)
 
 Existen dos niveles básicos de organización en Storybook. El componente y sus historias hijas. Puedes pensar en cada historia como una permutación del componente (todos lo estados posibles que puede tener, basándose en las las entradas que se le pueden proporcionar). Puedes crear tantas historias por componente como sean necesarias.
 
-* **Component**
-  * Story
-  * Story
-  * Story
+- **Component**
+  - Story
+  - Story
+  - Story
 
 Para iniciar Storybook, primero invocamos a la función `storiesOf()` que registra el componente. Agregamos un nombre para el componente que se muestra en la barra lateral de la aplicación Storybook.
 
@@ -210,9 +210,9 @@ import { Task } from './task.model';
       </div>
 
       <div class="actions">
-          <a *ngIf="task?.state !== 'TASK_ARCHIVED'" (click)="onPin(task.id)">
-            <span class="icon-star"></span>
-          </a>
+        <a *ngIf="task?.state !== 'TASK_ARCHIVED'" (click)="onPin(task.id)">
+          <span class="icon-star"></span>
+        </a>
       </div>
     </div>
   `,
@@ -286,9 +286,7 @@ Luego crea un archivo `src/storybook.test.ts` con el siguiente contenido:
 
 ```typescript
 import * as path from 'path';
-import initStoryshots, {
-  multiSnapshotWithOptions,
-} from '@storybook/addon-storyshots';
+import initStoryshots, { multiSnapshotWithOptions } from '@storybook/addon-storyshots';
 
 initStoryshots({
   framework: 'angular',

--- a/content/intro-to-storybook/angular/es/test.md
+++ b/content/intro-to-storybook/angular/es/test.md
@@ -1,7 +1,7 @@
 ---
-title: "Testear Componentes interfaz gráfica"
-tocTitle: "Testing"
-description: "Aprende las formas de probar los componentes de la interfaz gráfica"
+title: 'Testear Componentes interfaz gráfica'
+tocTitle: 'Testing'
+description: 'Aprende las formas de probar los componentes de la interfaz gráfica'
 commit: 8fdc779
 ---
 
@@ -65,12 +65,12 @@ yarn add -D storybook-chromatic
 Importa Chromatic en tu archivo `.storybook/config.js`.
 
 ```javascript
-import { configure } from "@storybook/angular";
-import "storybook-chromatic";
-import "../src/styles.less";
+import { configure } from '@storybook/angular';
+import 'storybook-chromatic';
+import '../src/styles.less';
 
 // automatically import all files ending in *.stories.ts
-const req = require.context("../src/", true, /.stories.ts$/);
+const req = require.context('../src/', true, /.stories.ts$/);
 
 function loadStories() {
   req.keys().forEach(filename => req(filename));

--- a/content/intro-to-storybook/angular/pt/composite-component.md
+++ b/content/intro-to-storybook/angular/pt/composite-component.md
@@ -1,7 +1,7 @@
 ---
-title: "Construção de um componente composto"
-tocTitle: "Componente composto"
-description: "Construção de um componente composto a partir de componentes simples"
+title: 'Construção de um componente composto'
+tocTitle: 'Componente composto'
+description: 'Construção de um componente composto a partir de componentes simples'
 ---
 
 No capitulo anterior, construímos o nosso primeiro componente, neste capitulo iremos estender o que foi dito até agora, para que possamos construir a nossa TaskListComponent, ou seja uma lista de TaskComponents. Vamos combinar componentes e ver o que irá acontecer quando é adicionada alguma complexidade.
@@ -20,7 +20,7 @@ Visto que os dados para a `TaskComponent` podem ser enviados de forma assíncron
 
 ## Preparação
 
-Um componente composto não é em nada diferente do componente básico contido dentro deste. Comece por criar um componente `TaskListComponent` e o ficheiro estória que o acompanha em: 
+Um componente composto não é em nada diferente do componente básico contido dentro deste. Comece por criar um componente `TaskListComponent` e o ficheiro estória que o acompanha em:
 `src/tasks/task-list.component.ts` e `src/tasks/task-list.stories.ts` respetivamente.
 
 Comece por uma implementação em bruto da `TaskListComponent`. Será necessário importar o componente `TaskComponent` criado anteriormente e injetar os atributos e as respetivas ações como inputs, assim como os eventos.
@@ -90,7 +90,7 @@ storiesOf('TaskList', module)
     moduleMetadata({
       declarations: [TaskListComponent, TaskComponent],
       imports: [CommonModule],
-    }),
+    })
   )
   .add('default', () => {
     return {
@@ -181,11 +181,9 @@ import { Task } from './task.model';
       </div>
 
       <div *ngIf="loading">
-        <div *ngFor="let i of [1,2,3,4,5,6]" class="loading-item">
+        <div *ngFor="let i of [1, 2, 3, 4, 5, 6]" class="loading-item">
           <span class="glow-checkbox"></span>
-          <span class="glow-text">
-            <span>Loading</span> <span>cool</span> <span>state</span>
-          </span>
+          <span class="glow-text"> <span>Loading</span> <span>cool</span> <span>state</span> </span>
         </div>
       </div>
     </div>
@@ -235,12 +233,12 @@ No capitulo anterior, aprendeu-se a usar o Storyshots para implementar estórias
 
 ## Testes unitários com Jest
 
-As estórias criadas com o Storybook em conjunção com os testes visuais manuais e testes de snapshot (tal como mencionado acima) irão prevenir em larga escala problemas futuros no interface de utilizador. Se as estórias definidas abrangerem uma ampla variedade de casos do componente e forem usadas ferramentas que garantam verificações por parte humana, irá resultar num decréscimo de erros. 
+As estórias criadas com o Storybook em conjunção com os testes visuais manuais e testes de snapshot (tal como mencionado acima) irão prevenir em larga escala problemas futuros no interface de utilizador. Se as estórias definidas abrangerem uma ampla variedade de casos do componente e forem usadas ferramentas que garantam verificações por parte humana, irá resultar num decréscimo de erros.
 
-No entanto, por vezes o diabo encontra-se nos detalhes. É necessária uma framework de testes explicita acerca deste tipo de detalhes. O que nos leva aos testes unitários. 
+No entanto, por vezes o diabo encontra-se nos detalhes. É necessária uma framework de testes explicita acerca deste tipo de detalhes. O que nos leva aos testes unitários.
 
-Neste caso pretende-se que o nosso `TaskListComponent` faça a renderização de quaisquer tarefas que foram confirmadas **antes** das não confirmadas que são fornecidas ao adereço (prop) `tasks`. 
-Apesar de existir uma estória (`withPinnedTasks`) que testa este cenário em particular; este poderá levar a alguma ambiguidade da parte humana, ou seja se o componente **parar** de ordenar as tarefas desta forma, logo existe um problema. Mas ao olho destreinado não irá gritar **"Erro!"**. 
+Neste caso pretende-se que o nosso `TaskListComponent` faça a renderização de quaisquer tarefas que foram confirmadas **antes** das não confirmadas que são fornecidas ao adereço (prop) `tasks`.
+Apesar de existir uma estória (`withPinnedTasks`) que testa este cenário em particular; este poderá levar a alguma ambiguidade da parte humana, ou seja se o componente **parar** de ordenar as tarefas desta forma, logo existe um problema. Mas ao olho destreinado não irá gritar **"Erro!"**.
 
 De forma a evitar este problema em concreto, podemos usar o Jest, de forma que este renderize a estória na DOM e efetue pesquisas de forma a verificar o output.
 
@@ -258,13 +256,11 @@ describe('TaskList component', () => {
   let component: TaskListComponent;
   let fixture: ComponentFixture<TaskListComponent>;
 
-  beforeEach(
-    async(() => {
-      TestBed.configureTestingModule({
-        declarations: [TaskComponent, TaskListComponent],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [TaskComponent, TaskListComponent],
+    }).compileComponents();
+  }));
 
   it('renders pinned tasks at the start of the list', () => {
     fixture = TestBed.createComponent(TaskListComponent);
@@ -272,9 +268,7 @@ describe('TaskList component', () => {
     component.tasks = withPinnedTasks;
 
     fixture.detectChanges();
-    const lastTaskInput = fixture.debugElement.query(
-      By.css('.list-item:nth-child(1)'),
-    );
+    const lastTaskInput = fixture.debugElement.query(By.css('.list-item:nth-child(1)'));
 
     // We expect the task titled "Task 6 (pinned)" to be rendered first, not at the end
     expect(lastTaskInput.nativeElement.id).toEqual('6');
@@ -284,6 +278,6 @@ describe('TaskList component', () => {
 
 ![Execução de testes da TaskList](/intro-to-storybook/tasklist-testrunner.png)
 
-Podemos verificar que foi possível reutilizar a lista de tarefas `withPinnedTasks` quer na estória, quer no teste unitário. Desta forma podemos continuar a aproveitar um recurso existente (os exemplos que representam configurações de um componente) de cada vez mais formas. 
+Podemos verificar que foi possível reutilizar a lista de tarefas `withPinnedTasks` quer na estória, quer no teste unitário. Desta forma podemos continuar a aproveitar um recurso existente (os exemplos que representam configurações de um componente) de cada vez mais formas.
 
 Mas também que este teste é algo frágil. É possível que á medida que o projeto amadurece, a implementação concreta do componente `TaskComponent` seja alterada; isto quer pelo uso de uma classe com um nome diferente ou um elemento `textarea` ao invés de um `input`, por exemplo--com isto, este teste específico irá falhar e será necessária uma atualização. Isto não é necessariamente um problema, mas um indicador para ser cuidadoso no uso liberal de testes unitários para o interface de utilizador. Visto que não são de fácil manutenção. Ao invés deste tipo de testes, é preferível depender de testes visuais, snapshot ou de regressão visual (ver [capitulo de testes](/angular/pt/test/)) sempre que for possível.

--- a/content/intro-to-storybook/angular/pt/conclusion.md
+++ b/content/intro-to-storybook/angular/pt/conclusion.md
@@ -1,6 +1,6 @@
 ---
-title: "Conclusão"
-description: "Fusão de todo o conhecimento adquirido e aprendizagem de técnicas extra de Storybook"
+title: 'Conclusão'
+description: 'Fusão de todo o conhecimento adquirido e aprendizagem de técnicas extra de Storybook'
 ---
 
 Parabéns! Acabaste de criar o teu primeiro interface de utilizador com Storybook. Durante esta jornada aprendeste como construir, compor, testar e implementar componentes de interface de utilizador.
@@ -10,20 +10,19 @@ Se estiveste a seguir o tutorial, o repositório e o Storybook implementado irá
 <br/>
 [🌎 **Storybook implementado**](https://clever-banach-415c03.netlify.com/)
 
-O Storybook é uma ferramenta bastante poderosa para React, Vue, Angular. 
+O Storybook é uma ferramenta bastante poderosa para React, Vue, Angular.
 É composta por uma comunidade de desenvolvimento próspera e um número grande de extras. Esta introdução somente arranha a superfície das potencialidades existentes. Estamos confiantes que depois da adoção do Storybook, irá ficar impressionado com o quanto é produtivo a construção de interfaces de utilizador duradouros.
 
 ## Saber mais
 
 Pretende saber mais? Aqui ficam alguns recursos que irão ajudar.
 
-* [**Documentação Oficial Storybook**](https://storybook.js.org/basics/introduction/) contem a documentação da API, links da comunidade e a galeria de extras.
+- [**Documentação Oficial Storybook**](https://storybook.js.org/basics/introduction/) contem a documentação da API, links da comunidade e a galeria de extras.
 
-* [**Manual de testes visuais**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07) 
-enumera as boas práticas de fluxo de trabalho, usadas por equipas que operam a alta velocidade, tal como por exemplo a SquareSpace, a Major League Soccer, a Discovery Network e Apollo GraphQL.
+- [**Manual de testes visuais**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07)
+  enumera as boas práticas de fluxo de trabalho, usadas por equipas que operam a alta velocidade, tal como por exemplo a SquareSpace, a Major League Soccer, a Discovery Network e Apollo GraphQL.
 
-* [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) aprofunda o uso de Storybook para testes visuais. Livro eletrónico livre de 31 páginas.
-
+- [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) aprofunda o uso de Storybook para testes visuais. Livro eletrónico livre de 31 páginas.
 
 ## Quem fez LearnStorybook.com?
 

--- a/content/intro-to-storybook/angular/pt/contribute.md
+++ b/content/intro-to-storybook/angular/pt/contribute.md
@@ -1,6 +1,6 @@
 ---
-title: "Contribuições"
-description: "Ajudem na partilha do Storybook com o mundo"
+title: 'Contribuições'
+description: 'Ajudem na partilha do Storybook com o mundo'
 ---
 
 # Contribuições

--- a/content/intro-to-storybook/angular/pt/data.md
+++ b/content/intro-to-storybook/angular/pt/data.md
@@ -1,7 +1,7 @@
 ---
-title: "Ligação de dados"
-tocTitle: "Dados"
-description: "Aprendizagem da metodologia de ligação de dados ao componente interface utilizador"
+title: 'Ligação de dados'
+tocTitle: 'Dados'
+description: 'Aprendizagem da metodologia de ligação de dados ao componente interface utilizador'
 ---
 
 Até agora foram criados componentes sem estado e isolados, o que é fantástico para Storybook, mas em última análise não são úteis até que for fornecido algum tipo de dados da aplicação
@@ -67,10 +67,7 @@ export class TasksState {
   }
 
   @Action(PinTask)
-  pinTask(
-    { patchState, getState }: StateContext<TaskStateModel>,
-    { payload }: PinTask,
-  ) {
+  pinTask({ patchState, getState }: StateContext<TaskStateModel>, { payload }: PinTask) {
     const state = getState().entities;
 
     const entities = {
@@ -84,10 +81,7 @@ export class TasksState {
   }
 
   @Action(ArchiveTask)
-  archiveTask(
-    { patchState, getState }: StateContext<TaskStateModel>,
-    { payload }: ArchiveTask,
-  ) {
+  archiveTask({ patchState, getState }: StateContext<TaskStateModel>, { payload }: ArchiveTask) {
     const state = getState().entities;
 
     const entities = {
@@ -153,7 +147,11 @@ import { Observable } from 'rxjs';
 @Component({
   selector: 'task-list',
   template: `
-    <pure-task-list [tasks]="tasks$ | async" (onArchiveTask)="archiveTask($event)" (onPinTask)="pinTask($event)"></pure-task-list>
+    <pure-task-list
+      [tasks]="tasks$ | async"
+      (onArchiveTask)="archiveTask($event)"
+      (onPinTask)="pinTask($event)"
+    ></pure-task-list>
   `,
 })
 export class TaskListComponent implements OnInit {
@@ -172,7 +170,8 @@ export class TaskListComponent implements OnInit {
   }
 }
 ```
-É de notar que o ficheiro antigo `TaskListComponent` residente em `src/tasks/components/task-list.component.ts` foi renomeado para `src/tasks/components/pure-task-list.component.ts`, mas também alterado o seu `selector` de `task-list` para `pure-task-list` e o nome da classe de `TaskListComponent` para `PureTaskListComponent`. Todas estas alterações foram feitas para proporcionar um sentido de clareza: existe agora um componente puro que recebe uma lista de tarefas, alguns eventos e efetua a renderização de um resultado, assim como um componente contentor que depende da loja para obter os dados necessários, que são fornecidos ao componente puro. Não esquecer de renomear o ficheiro `task-list.stories.ts` também. 
+
+É de notar que o ficheiro antigo `TaskListComponent` residente em `src/tasks/components/task-list.component.ts` foi renomeado para `src/tasks/components/pure-task-list.component.ts`, mas também alterado o seu `selector` de `task-list` para `pure-task-list` e o nome da classe de `TaskListComponent` para `PureTaskListComponent`. Todas estas alterações foram feitas para proporcionar um sentido de clareza: existe agora um componente puro que recebe uma lista de tarefas, alguns eventos e efetua a renderização de um resultado, assim como um componente contentor que depende da loja para obter os dados necessários, que são fornecidos ao componente puro. Não esquecer de renomear o ficheiro `task-list.stories.ts` também.
 
 Nesta altura os testes com Storybook terão deixado de funcionar, visto que `TaskListComponent` é agora um contentor e como tal não está á espera de receber qualquer tipo de adereços (props), ao invés disso conecta-se á loja e define os adereços (props) para o componente `PureTaskListComponent` que está a envolver.
 
@@ -211,7 +210,7 @@ storiesOf('TaskList', module)
     moduleMetadata({
       declarations: [PureTaskListComponent, TaskComponent],
       imports: [CommonModule],
-    }),
+    })
   )
   .add('default', () => {
     return {
@@ -279,13 +278,11 @@ describe('TaskList component', () => {
   let component: PureTaskListComponent;
   let fixture: ComponentFixture<PureTaskListComponent>;
 
-  beforeEach(
-    async(() => {
-      TestBed.configureTestingModule({
-        declarations: [TaskComponent, PureTaskListComponent],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [TaskComponent, PureTaskListComponent],
+    }).compileComponents();
+  }));
 
   it('renders pinned tasks at the start of the list', () => {
     fixture = TestBed.createComponent(PureTaskListComponent);
@@ -293,9 +290,7 @@ describe('TaskList component', () => {
     component.tasks = withPinnedTasks;
 
     fixture.detectChanges();
-    const lastTaskInput = fixture.debugElement.query(
-      By.css('.list-item:nth-child(1)'),
-    );
+    const lastTaskInput = fixture.debugElement.query(By.css('.list-item:nth-child(1)'));
     // Pretende-se que a tarefa denominada "Task 6 (pinned), seja renderizada em primeiro lugar não no fim
     expect(lastTaskInput.nativeElement.id).toEqual('6');
   });

--- a/content/intro-to-storybook/angular/pt/deploy.md
+++ b/content/intro-to-storybook/angular/pt/deploy.md
@@ -1,7 +1,7 @@
 ---
-title: "Implementar Storybook"
-tocTitle: "Implementação"
-descrição: "Implemntação online do Storybook com GitHub e Netlify"
+title: 'Implementar Storybook'
+tocTitle: 'Implementação'
+descrição: 'Implemntação online do Storybook com GitHub e Netlify'
 ---
 
 Neste tutorial o Storybook foi executado na máquina local. Poderá ser necessária a partilha com o resto da equipa, em particular com membros considerados não técnicos. Felizmente, é bastante fácil implementar o Storybook online.

--- a/content/intro-to-storybook/angular/pt/get-started.md
+++ b/content/intro-to-storybook/angular/pt/get-started.md
@@ -1,7 +1,7 @@
 ---
-title: "Storybook para o Angular tutorial"
-tocTitle: "Introdução"
-description: "Configuração do Angular Storybook no ambiente de desenvolvimento"
+title: 'Storybook para o Angular tutorial'
+tocTitle: 'Introdução'
+description: 'Configuração do Angular Storybook no ambiente de desenvolvimento'
 ---
 
 Storybook funciona em paralelo á aplicação em modo de desenvolvimento.

--- a/content/intro-to-storybook/angular/pt/screen.md
+++ b/content/intro-to-storybook/angular/pt/screen.md
@@ -1,7 +1,7 @@
 ---
-title: "Construção de um ecrã"
-tocTitle: "Ecrãs"
-description: "Construção de um ecrã a partir de componentes"
+title: 'Construção de um ecrã'
+tocTitle: 'Ecrãs'
+description: 'Construção de um ecrã a partir de componentes'
 ---
 
 Tem sido focada a construção de interfaces de utilizador da base para o topo.
@@ -14,17 +14,17 @@ Neste capitulo, irá ser acrescida um pouco mais a sofisticação, através da c
 Visto que a aplicação é deveras simples, o ecrã a ser construído é bastante trivial, simplesmente envolvendo o componente `TaskListComponent` (que fornece os seus dados via ngxs), a um qualquer layout e extraindo o campo de topo `erro` oriundo do loja(assumindo que este irá ser definido caso exista algum problema na ligação ao servidor). Dentro da pasta `src/tasks/containers` vai ser adicionado o ficheiro `inbox-screen.component.ts`:
 
 ```typescript
-import { Component, OnInit, Input } from "@angular/core";
-import { Select, Store } from "@ngxs/store";
-import { TasksState, ArchiveTask, PinTask } from "../state/task.state";
-import { Task } from "../task.model";
-import { Observable } from "rxjs";
+import { Component, OnInit, Input } from '@angular/core';
+import { Select, Store } from '@ngxs/store';
+import { TasksState, ArchiveTask, PinTask } from '../state/task.state';
+import { Task } from '../task.model';
+import { Observable } from 'rxjs';
 
 @Component({
-  selector: "inbox-screen",
+  selector: 'inbox-screen',
   template: `
     <pure-inbox-screen [error]="error$ | async"></pure-inbox-screen>
-  `
+  `,
 })
 export class InboxScreenComponent implements OnInit {
   @Select(TasksState.getError) error$: Observable<any>;
@@ -38,10 +38,10 @@ export class InboxScreenComponent implements OnInit {
 Em seguida vai ser necessária a criação do componente `PureInboxScreenComponent` dentro da pasta `src/tasks/components` com o seguinte código:
 
 ```typescript
-import { Component, OnInit, Input } from "@angular/core";
+import { Component, OnInit, Input } from '@angular/core';
 
 @Component({
-  selector: "pure-inbox-screen",
+  selector: 'pure-inbox-screen',
   template: `
     <div *ngIf="error" class="page lists-show">
       <div class="wrapper-message">
@@ -59,7 +59,7 @@ import { Component, OnInit, Input } from "@angular/core";
       </nav>
       <task-list></task-list>
     </div>
-  `
+  `,
 })
 export class PureInboxScreenComponent implements OnInit {
   @Input() error: any;
@@ -73,16 +73,16 @@ export class PureInboxScreenComponent implements OnInit {
 Vai ser necessário alterar o `AppComponent` de forma a ser possível renderizar o `InboxScreenComponent` (eventualmente iria ser usado um roteador para escolher o ecrã apropriado, mas não e necessário preocupar-se com isso agora):
 
 ```typescript
-import { Component } from "@angular/core";
+import { Component } from '@angular/core';
 
 @Component({
-  selector: "app-root",
+  selector: 'app-root',
   template: `
     <inbox-screen></inbox-screen>
-  `
+  `,
 })
 export class AppComponent {
-  title = "app";
+  title = 'app';
 }
 ```
 
@@ -136,29 +136,29 @@ No entanto, algum programador **irá querer** renderizar contentores num nível 
 A forma mais fácil de se atingir isto consiste em fornecer a `Store` ao módulo e inicializar o estado, partindo do pressuposto que é uma aplicação completa:
 
 ```typescript
-import { storiesOf, moduleMetadata } from "@storybook/angular";
-import { Store, NgxsModule } from "@ngxs/store";
-import { TasksState, ErrorFromServer } from "../state/task.state";
-import { TaskModule } from "../task.module";
+import { storiesOf, moduleMetadata } from '@storybook/angular';
+import { Store, NgxsModule } from '@ngxs/store';
+import { TasksState, ErrorFromServer } from '../state/task.state';
+import { TaskModule } from '../task.module';
 
-storiesOf("InboxScreen", module)
+storiesOf('InboxScreen', module)
   .addDecorator(
     moduleMetadata({
       imports: [TaskModule, NgxsModule.forRoot([TasksState])],
-      providers: [Store]
+      providers: [Store],
     })
   )
-  .add("default", () => {
+  .add('default', () => {
     return {
-      template: `<inbox-screen></inbox-screen>`
+      template: `<inbox-screen></inbox-screen>`,
     };
   })
-  .add("error", () => {
+  .add('error', () => {
     return {
       template: `<pure-inbox-screen [error]="error"></pure-inbox-screen>`,
       props: {
-        error: "Something!"
-      }
+        error: 'Something!',
+      },
     };
   });
 ```
@@ -182,48 +182,48 @@ Poderá estar a perguntar-se porque foi criado o novo `PureInboxScreenComponent`
 Este é um exemplo extremamente simples e como tal adicionar estes componentes puros poderá sugerir algo excessivo. Mas com o Storybook para Angular existe uma outra forma de escrever estórias para o `InboxScreenComponent`:
 
 ```typescript
-import { storiesOf, moduleMetadata } from "@storybook/angular";
-import { Store, NgxsModule } from "@ngxs/store";
-import { TasksState, ErrorFromServer } from "../state/task.state";
-import { TaskModule } from "../task.module";
+import { storiesOf, moduleMetadata } from '@storybook/angular';
+import { Store, NgxsModule } from '@ngxs/store';
+import { TasksState, ErrorFromServer } from '../state/task.state';
+import { TaskModule } from '../task.module';
 
-import { Component } from "@angular/core";
+import { Component } from '@angular/core';
 
 @Component({
   template: `
     <inbox-screen></inbox-screen>
-  `
+  `,
 })
 class HostDispatchErrorComponent {
   constructor(store: Store) {
-    store.dispatch(new ErrorFromServer("Error"));
+    store.dispatch(new ErrorFromServer('Error'));
   }
 }
 
-storiesOf("InboxScreen", module)
+storiesOf('InboxScreen', module)
   .addDecorator(
     moduleMetadata({
       declarations: [HostDispatchErrorComponent],
       imports: [TaskModule, NgxsModule.forRoot([TasksState])],
-      providers: [Store]
+      providers: [Store],
     })
   )
-  .add("default", () => {
+  .add('default', () => {
     return {
-      template: `<inbox-screen></inbox-screen>`
+      template: `<inbox-screen></inbox-screen>`,
     };
   })
-  .add("error", () => {
+  .add('error', () => {
     return {
       template: `<pure-inbox-screen [error]="error"></pure-inbox-screen>`,
       props: {
-        error: "Something!"
-      }
+        error: 'Something!',
+      },
     };
   })
-  .add("Connected Error", () => {
+  .add('Connected Error', () => {
     return {
-      component: HostDispatchErrorComponent
+      component: HostDispatchErrorComponent,
     };
   });
 ```

--- a/content/intro-to-storybook/angular/pt/simple-component.md
+++ b/content/intro-to-storybook/angular/pt/simple-component.md
@@ -1,7 +1,7 @@
 ---
-title: "Construção de um componente siples"
-tocTitle: "Componente simples"
-description: "Construção de um componente simples isolado"
+title: 'Construção de um componente siples'
+tocTitle: 'Componente simples'
+description: 'Construção de um componente simples isolado'
 ---
 
 Iremos construir o interface de utilizador de acordo com a metodologia de [Desenvolvimento orientada a componentes](https://blog.hichroma.com/component-driven-development-ce1109d56c8e), ou nativamente por (CDD, Component-Driven Development). É um processo que cria interfaces de utilizador a partir da base para o topo, iniciando com componentes e terminando com ecrãs. O DOC(CDD nativamente) ajuda no escalonamento da complexidade á qual o programador é sujeito á medida que constrói o interface de utilizador.
@@ -10,12 +10,12 @@ Iremos construir o interface de utilizador de acordo com a metodologia de [Desen
 
 ![Componente Task ao longo de três estados](/intro-to-storybook/task-states-learnstorybook.png)
 
-`TaskComponent` é o componente nuclear da nossa aplicação. Cada tarefa é apresentada de forma diferente dependendo do estado em que se encontra. 
-O que vai ser apresentado é uma caixa de confirmação, selecionada (ou não), alguma informação adicional acerca da tarefa e um botão "fixador", que permite a movimentação para cima e para baixo das tarefas ao longo da lista. 
+`TaskComponent` é o componente nuclear da nossa aplicação. Cada tarefa é apresentada de forma diferente dependendo do estado em que se encontra.
+O que vai ser apresentado é uma caixa de confirmação, selecionada (ou não), alguma informação adicional acerca da tarefa e um botão "fixador", que permite a movimentação para cima e para baixo das tarefas ao longo da lista.
 Para que seja possível implementar isto serão necessárias os seguintes adereços (props):
 
-* `title` - uma cadeia de caracteres que descreve a tarefa
-* `state` - qual a lista em que a tarefa se encontra e se está confirmada?
+- `title` - uma cadeia de caracteres que descreve a tarefa
+- `state` - qual a lista em que a tarefa se encontra e se está confirmada?
 
 Á medida que construimos a `TaskComponent`, é necessário definir os três estados que correspondem os três tipos de tarefa delineados acima.
 Em seguida usa-se o Storybook para construir este componente isolado, usando dados predefinidos. Irá "testar-se visualmente" a aparência do componente para cada estado á medida que prosseguimos.
@@ -50,7 +50,6 @@ export class TaskComponent implements OnInit {
 
   ngOnInit() {}
 }
-
 ```
 
 O bloco de código acima, quando renderizado, não é nada mais nada menos que a estrutura HTML da `TaskComponent` na aplicação Todos.
@@ -79,7 +78,7 @@ storiesOf('Task', module)
   .addDecorator(
     moduleMetadata({
       declarations: [TaskComponent],
-    }),
+    })
   )
   .add('default', () => {
     return {
@@ -111,15 +110,14 @@ storiesOf('Task', module)
       },
     };
   });
-
 ```
 
 Existem dois tipos de organização com Storybook. O componente em si e as estórias associadas. É preferível pensar em cada estória como uma permutação de um componente. Como tal podem existir tantas estórias, tantas as que forem necessárias.
 
-* **Component**
-  * Story
-  * Story
-  * Story
+- **Component**
+  - Story
+  - Story
+  - Story
 
 Ao ser invocada a função `storiesOf()`, está a registar-se o componente, e com isto o processo de arranque do Storybook. É adicionado um nome, nome esse que será usado na barra lateral da aplicação Storybook para identificar o componente.
 
@@ -141,9 +139,7 @@ Será necessária uma alteração minúscula ao ficheiro de configuração do St
 Por norma o Storybook pesquisa numa pasta denominada `/stories` para conter as estórias; este tutorial usa uma nomenclatura similar a `.type.extension`, cuja qual favorecida quando se está a desenvolver uma aplicação Angular.
 
 ```typescript
-import {
-  configure
-} from '@storybook/angular';
+import { configure } from '@storybook/angular';
 
 import '../src/styles.less';
 
@@ -155,24 +151,24 @@ function loadStories() {
 }
 
 configure(loadStories, module);
-
 ```
 
 De forma a que seja possível o suporte ao conteúdo do ficheiro LESS definido acima, será necessário uma pequena modificação no webpack. Para tal será necessário criar um ficheiro denominado `webpack.config.js` dentro da pasta `.storybook` com o seguinte conteúdo:
 
 ```javascript
-const path = require("path");
+const path = require('path');
 
 module.exports = {
   module: {
-    rules: [{
-      test: /\.less$/,
-      loaders: ["style-loader", "css-loader", "less-loader"],
-      include: path.resolve(__dirname, "../")
-    }]
-  }
+    rules: [
+      {
+        test: /\.less$/,
+        loaders: ['style-loader', 'css-loader', 'less-loader'],
+        include: path.resolve(__dirname, '../'),
+      },
+    ],
+  },
 };
-
 ```
 
 Assim como os loaders necessários terão que ser adicionados, através do seguinte comando:
@@ -180,6 +176,7 @@ Assim como os loaders necessários terão que ser adicionados, através do segui
 ```
 yarn add -D less-loader css-loader style-loader
 ```
+
 Assim que esta operação for concluída, ao reiniciar o servidor Storybook, deverá produzir os casos de teste que foram definidos para o componente TaskComponent:
 
 <video autoPlay muted playsInline controls >
@@ -217,9 +214,9 @@ import { Task } from './task.model';
       </div>
 
       <div class="actions">
-          <a *ngIf="task?.state !== 'TASK_ARCHIVED'" (click)="onPin(task.id)">
-            <span class="icon-star"></span>
-          </a>
+        <a *ngIf="task?.state !== 'TASK_ARCHIVED'" (click)="onPin(task.id)">
+          <span class="icon-star"></span>
+        </a>
       </div>
     </div>
   `,
@@ -264,6 +261,7 @@ export interface Task {
   state: string;
 }
 ```
+
 ## Componente construido!
 
 Foi construído com sucesso, sem ser necessário qualquer tipo de servidor, ou que seja necessário executar a aplicação frontend. O próximo passo é construir os restantes componentes da Taskbox um por um de forma similar.
@@ -293,16 +291,13 @@ Em seguida é criado o ficheiro `src/storybook.test.ts` com o conteúdo:
 
 ```typescript
 import * as path from 'path';
-import initStoryshots, {
-  multiSnapshotWithOptions,
-} from '@storybook/addon-storyshots';
+import initStoryshots, { multiSnapshotWithOptions } from '@storybook/addon-storyshots';
 
 initStoryshots({
   framework: 'angular',
   configPath: path.join(__dirname, '../.storybook'),
   test: multiSnapshotWithOptions(),
 });
-
 ```
 
 Quando este processo estiver concluído, será necessário criar uma pasta denominada `jest-config` dentro da pasta `src`, com dois ficheiros dentro desta, `globalMocks.ts` com o conteúdo:
@@ -323,17 +318,16 @@ Object.defineProperty(window, 'sessionStorage', { value: mock() });
 Object.defineProperty(window, 'getComputedStyle', {
   value: () => ['-webkit-appearance'],
 });
-
 ```
+
 e o ficheiro `setup.ts`, com o seguinte conteúdo:
 
 ```typescript
 import 'jest-preset-angular';
 import './globalMocks';
-
 ```
-Em seguida será necessário adicionar um novo campo ao ficheiro`package.json`,
 
+Em seguida será necessário adicionar um novo campo ao ficheiro`package.json`,
 
 ```json
 "jest": {
@@ -359,7 +353,7 @@ Em seguida será necessário adicionar um novo campo ao ficheiro`package.json`,
       "\\.(css|less)$": "identity-obj-proxy"
     }
   },
-  ```
+```
 
 Além disto, serão necessários alguns scripts novos para que o `jest` possa ser executado:
 

--- a/content/intro-to-storybook/angular/pt/test.md
+++ b/content/intro-to-storybook/angular/pt/test.md
@@ -1,7 +1,7 @@
 ---
-title: "Teste de componentes de interface de utilizador"
-tocTitle: "Testes"
-description: "Aprendizagem das formas de teste dos componentes interface utilizador"
+title: 'Teste de componentes de interface de utilizador'
+tocTitle: 'Testes'
+description: 'Aprendizagem das formas de teste dos componentes interface utilizador'
 ---
 
 Qualquer tutorial de Storybook não estaria completo sem serem mencionados os testes. Estes são essenciais na criação de interfaces de utilizador de alta qualidade. Nos sistemas modulares, ajustes minúsculos poderão levar a regressões gigantescas. Até agora foram descritos três tipos de testes:
@@ -66,12 +66,12 @@ yarn add storybook-chromatic
 O Chromatic é importado no ficheiro `.storybook/config.js`.
 
 ```javascript
-import { configure } from "@storybook/angular";
-import "storybook-chromatic";
-import "../src/styles.less";
+import { configure } from '@storybook/angular';
+import 'storybook-chromatic';
+import '../src/styles.less';
 
 // automatically import all files ending in *.stories.ts
-const req = require.context("../src/", true, /.stories.ts$/);
+const req = require.context('../src/', true, /.stories.ts$/);
 
 function loadStories() {
   req.keys().forEach(filename => req(filename));

--- a/content/intro-to-storybook/index.md
+++ b/content/intro-to-storybook/index.md
@@ -1,71 +1,71 @@
 ---
-title: "Intro to Storybook"
+title: 'Intro to Storybook'
 description: "Learn to create bulletproof UI components, along the way you'll build an app UI from scratch."
-heroDescription: "Storybook is the most popular UI component development tool for React, Vue, and Angular. It helps you develop and design UI components outside your app in an isolated environment. Learn Storybook to create bulletproof UI components, along the way you’ll build an app UI from scratch."
-overview: "Intro to Storybook teaches tried-and-true patterns for component development using Storybook. You’ll walk through essential UI component techniques while building a UI from scratch in React, Vue, or Angular. The info here is sourced from professional teams, core maintainers, and the awesome Storybook community. Professional developers at Airbnb, Dropbox, and Lonely Planet use Storybook to build durable documented UIs faster."
+heroDescription: 'Storybook is the most popular UI component development tool for React, Vue, and Angular. It helps you develop and design UI components outside your app in an isolated environment. Learn Storybook to create bulletproof UI components, along the way you’ll build an app UI from scratch.'
+overview: 'Intro to Storybook teaches tried-and-true patterns for component development using Storybook. You’ll walk through essential UI component techniques while building a UI from scratch in React, Vue, or Angular. The info here is sourced from professional teams, core maintainers, and the awesome Storybook community. Professional developers at Airbnb, Dropbox, and Lonely Planet use Storybook to build durable documented UIs faster.'
 order: 1
-themeColor: "#6F2CAC"
-codeGithubUrl: "https://github.com/chromaui/learnstorybook-code"
-heroAnimationName: "float"
+themeColor: '#6F2CAC'
+codeGithubUrl: 'https://github.com/chromaui/learnstorybook-code'
+heroAnimationName: 'float'
 toc:
   [
-    "get-started",
-    "simple-component",
-    "composite-component",
-    "data",
-    "screen",
-    "test",
-    "using-addons",
-    "creating-addons",
-    "deploy",
-    "conclusion",
-    "contribute",
+    'get-started',
+    'simple-component',
+    'composite-component',
+    'data',
+    'screen',
+    'test',
+    'using-addons',
+    'creating-addons',
+    'deploy',
+    'conclusion',
+    'contribute',
   ]
-coverImagePath: "/guide-cover/intro.svg"
-thumbImagePath: "/guide-thumb/intro.svg"
-contributorCount: "+42"
+coverImagePath: '/guide-cover/intro.svg'
+thumbImagePath: '/guide-thumb/intro.svg'
+contributorCount: '+42'
 authors:
   [
     {
-      src: "https://avatars2.githubusercontent.com/u/132554",
-      name: "Tom Coleman",
-      detail: "Storybook core",
+      src: 'https://avatars2.githubusercontent.com/u/132554',
+      name: 'Tom Coleman',
+      detail: 'Storybook core',
     },
     {
-      src: "https://avatars2.githubusercontent.com/u/263385",
-      name: "Dominic Nguyen",
-      detail: "Storybook design",
+      src: 'https://avatars2.githubusercontent.com/u/263385',
+      name: 'Dominic Nguyen',
+      detail: 'Storybook design',
     },
   ]
 contributors:
   [
     {
-      src: "https://avatars2.githubusercontent.com/u/22988955",
-      name: "João Cardoso",
-      detail: "Engineer",
+      src: 'https://avatars2.githubusercontent.com/u/22988955',
+      name: 'João Cardoso',
+      detail: 'Engineer',
     },
     {
-      src: "https://avatars2.githubusercontent.com/u/1593752",
-      name: "Carlos Vega",
-      detail: "Engineer",
+      src: 'https://avatars2.githubusercontent.com/u/1593752',
+      name: 'Carlos Vega',
+      detail: 'Engineer',
     },
     {
-      src: "https://avatars2.githubusercontent.com/u/5649014",
-      name: "Carlos Iván Suarez",
-      detail: "Engineer",
+      src: 'https://avatars2.githubusercontent.com/u/5649014',
+      name: 'Carlos Iván Suarez',
+      detail: 'Engineer',
     },
     {
-      src: "https://avatars2.githubusercontent.com/u/9523719",
-      name: "Kyle Holmberg",
-      detail: "Engineer at Acorns",
+      src: 'https://avatars2.githubusercontent.com/u/9523719',
+      name: 'Kyle Holmberg',
+      detail: 'Engineer at Acorns',
     },
     {
-      src: "https://avatars2.githubusercontent.com/u/1474548",
-      name: "Daniel Duan",
-      detail: "Engineer at Squarespace",
+      src: 'https://avatars2.githubusercontent.com/u/1474548',
+      name: 'Daniel Duan',
+      detail: 'Engineer at Squarespace',
     },
   ]
-twitterShareText: "I’m learning Storybook! It’s a great dev tool for UI components."
+twitterShareText: 'I’m learning Storybook! It’s a great dev tool for UI components.'
 ---
 
 <h2>What you'll build</h2>

--- a/content/intro-to-storybook/react/en/composite-component.md
+++ b/content/intro-to-storybook/react/en/composite-component.md
@@ -1,7 +1,7 @@
 ---
-title: "Assemble a composite component"
-tocTitle: "Composite component"
-description: "Assemble a composite component out of simpler components"
+title: 'Assemble a composite component'
+tocTitle: 'Composite component'
+description: 'Assemble a composite component out of simpler components'
 commit: '8db511e'
 ---
 
@@ -46,7 +46,9 @@ function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
 
   return (
     <div className="list-items">
-      {tasks.map(task => <Task key={task.id} task={task} {...events} />)}
+      {tasks.map(task => (
+        <Task key={task.id} task={task} {...events} />
+      ))}
     </div>
   );
 }
@@ -162,7 +164,9 @@ function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
 
   return (
     <div className="list-items">
-      {tasksInOrder.map(task => <Task key={task.id} task={task} {...events} />)}
+      {tasksInOrder.map(task => (
+        <Task key={task.id} task={task} {...events} />
+      ))}
     </div>
   );
 }

--- a/content/intro-to-storybook/react/en/conclusion.md
+++ b/content/intro-to-storybook/react/en/conclusion.md
@@ -1,6 +1,6 @@
 ---
-title: "Conclusion"
-description: "Put all your knowledge together and learn more Storybook techniques"
+title: 'Conclusion'
+description: 'Put all your knowledge together and learn more Storybook techniques'
 ---
 
 Congratulations! You created your first UI in Storybook. Along the way you learned how to build, compose, test, and deploy UI components. If you’ve been following, your repo and deployed Storybook should look like this:
@@ -15,11 +15,11 @@ Storybook is a powerful tool for React, Vue, and Angular. It has a thriving deve
 
 Want to dive deeper? Here are helpful resources.
 
-* [**Official Storybook documentation**](https://storybook.js.org/basics/introduction/) has API documentation, community links, and the addon gallery.
+- [**Official Storybook documentation**](https://storybook.js.org/basics/introduction/) has API documentation, community links, and the addon gallery.
 
-* [**The Delightful Storybook Workflow**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07) highlights workflow best practices used by high-velocity teams at Squarespace, Major League Soccer, Discovery Network, and Apollo GraphQL.
+- [**The Delightful Storybook Workflow**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07) highlights workflow best practices used by high-velocity teams at Squarespace, Major League Soccer, Discovery Network, and Apollo GraphQL.
 
-* [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) dives deep into using Storybook to visual test components. Free 31-page ebook.
+- [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) dives deep into using Storybook to visual test components. Free 31-page ebook.
 
 ## Who made LearnStorybook.com?
 

--- a/content/intro-to-storybook/react/en/contribute.md
+++ b/content/intro-to-storybook/react/en/contribute.md
@@ -1,6 +1,6 @@
 ---
-title: "Contribute"
-description: "Help share Storybook with the world"
+title: 'Contribute'
+description: 'Help share Storybook with the world'
 ---
 
 Contributions to Learn Storybook are encouraged! If it’s something small like grammar or punctuation, open up a pull request. If it’s a bigger change, [add an issue](https://github.com/chromaui/learnstorybook.com/issues) for discussion.

--- a/content/intro-to-storybook/react/en/creating-addons.md
+++ b/content/intro-to-storybook/react/en/creating-addons.md
@@ -1,8 +1,8 @@
 ---
-title: "Creating addons"
-tocTitle: "Creating addons"
-description: "Learn how to build your own addons that will super charge your development"
-commit: "dac373a"
+title: 'Creating addons'
+tocTitle: 'Creating addons'
+description: 'Learn how to build your own addons that will super charge your development'
+commit: 'dac373a'
 ---
 
 Storybook's addon architecture allows you to expand it's feature set and customize it to your needs.
@@ -20,6 +20,7 @@ We're going to write an addon that will show our design assets next to our compo
 ![Storybook and your app](/intro-to-storybook/design-assets-addon.png)
 
 **Our addon should**:
+
 - display the design asset in a panel
 - support images, but also urls for embedding
 - should support multiple assets, just in case there will be multiple versions or themes
@@ -67,6 +68,7 @@ import { AddonPanel } from '@storybook/components';
 ```
 
 Now we register a new addon with storybook using and add a panel:
+
 ```js
 addons.register('my/design-assets', () => {
   addons.add(PANEL_ID, {
@@ -100,11 +102,11 @@ export const Content = () => {
   return (
     <Fragment>
       {results.length ? (
-      <ol>
-          {results.map((i) => (
-          <li>{i}</li>
+        <ol>
+          {results.map(i => (
+            <li>{i}</li>
           ))}
-      </ol>
+        </ol>
       ) : null}
     </Fragment>
   );
@@ -112,6 +114,7 @@ export const Content = () => {
 ```
 
 Now all we need to do is connect this component to the rendering of our registered panel and we'll have our working addon:
+
 ```js
 import React, { useMemo } from 'react';
 
@@ -131,11 +134,11 @@ const Content = () => {
   return (
     <Fragment>
       {results.length ? (
-      <ol>
-          {results.map((i) => (
-          <li>{i}</li>
+        <ol>
+          {results.map(i => (
+            <li>{i}</li>
           ))}
-      </ol>
+        </ol>
       ) : null}
     </Fragment>
   );
@@ -158,6 +161,7 @@ addons.register(ADDON_ID, () => {
 At this point we can navigate between stories in storybook and see the list of design assets associated with the selected story.
 
 Let's change the `Content` component so it actually displays the assets:
+
 ```js
 import React, { Fragment, useMemo } from 'react';
 
@@ -168,7 +172,7 @@ import { ActionBar } from '@storybook/components';
 const ADDON_ID = 'storybook/parameter';
 const PARAM_KEY = `assets`;
 
-const getUrl = (input) => {
+const getUrl = input => {
   return typeof input === 'string' ? input : input.url;
 };
 
@@ -205,10 +209,8 @@ export const Content = () => {
   }
 
   const url = getUrl(results[0]).replace('{id}', storyId);
-  
-  return (
-    <Asset url={url} />
-  );
+
+  return <Asset url={url} />;
 };
 ```
 
@@ -241,10 +243,8 @@ export const Content = () => {
   }
 
   const url = getUrl(results[selected]).replace('{id}', storyId);
-  
-  return (
-    <Asset url={url} />
-  );
+
+  return <Asset url={url} />;
 };
 ```
 
@@ -275,7 +275,7 @@ export const Content = () => {
   }
 
   const url = getUrl(results[selected]).replace('{id}', storyId);
-  
+
   return (
     <Fragment>
       <Asset url={url} />
@@ -360,7 +360,7 @@ const Asset = ({ url }) => {
   return <Iframe title={url} src={url} />;
 };
 
-const getUrl = input => typeof input === 'string' ? input : input.url;
+const getUrl = input => (typeof input === 'string' ? input : input.url);
 
 export const Content = () => {
   const results = useParameter(PARAM_KEY, []);
@@ -407,6 +407,7 @@ This is an example of an addon that uses parameters and displays it in a panel, 
 With these principles you're able to display you custom UI in a variety of places in the storybook UI.
 
 You can:
+
 - [add buttons in the storybook toolbar](https://github.com/storybookjs/storybook/blob/next/addons/viewport/src/register.tsx#L8-L15)
 - [communicate through the channel with the iframe](https://github.com/storybookjs/storybook/blob/next/dev-kits/addon-roundtrip/README.md)
 - [send commands and results](https://github.com/storybookjs/storybook/tree/next/addons/events)
@@ -419,7 +420,7 @@ And much more!
 
 # Dev Kits
 
-To help you write addons, the Storybook team has developed `dev-kits`. 
+To help you write addons, the Storybook team has developed `dev-kits`.
 
 These packages are like little starter-sets for you to start developing your own addon.
 The addon we just created is based on the `addon-parameters` dev-kit.
@@ -428,5 +429,3 @@ You can find the dev-kits here:
 https://github.com/storybookjs/storybook/tree/next/dev-kits
 
 More dev-kits will become available in the future.
-
-

--- a/content/intro-to-storybook/react/en/data.md
+++ b/content/intro-to-storybook/react/en/data.md
@@ -1,7 +1,7 @@
 ---
-title: "Wire in data"
-tocTitle: "Data"
-description: "Learn how to wire in data to your UI component"
+title: 'Wire in data'
+tocTitle: 'Data'
+description: 'Learn how to wire in data to your UI component'
 commit: 9c50472
 ---
 
@@ -45,12 +45,12 @@ function taskStateReducer(taskState) {
   return (state, action) => {
     return {
       ...state,
-      tasks: state.tasks.map(
-        task => (task.id === action.id ? { ...task, state: taskState } : task)
+      tasks: state.tasks.map(task =>
+        task.id === action.id ? { ...task, state: taskState } : task
       ),
     };
   };
-};
+}
 
 // The reducer describes how the contents of the store change for each action
 export const reducer = (state, action) => {

--- a/content/intro-to-storybook/react/en/deploy.md
+++ b/content/intro-to-storybook/react/en/deploy.md
@@ -1,7 +1,7 @@
 ---
-title: "Deploy Storybook"
-tocTitle: "Deploy"
-description: "Deploy Storybook online with GitHub and Netlify"
+title: 'Deploy Storybook'
+tocTitle: 'Deploy'
+description: 'Deploy Storybook online with GitHub and Netlify'
 ---
 
 In this tutorial we ran Storybook on our development machine. You may also want to share that Storybook with the team, especially the non-technical members. Thankfully, it’s easy to deploy Storybook online.

--- a/content/intro-to-storybook/react/en/get-started.md
+++ b/content/intro-to-storybook/react/en/get-started.md
@@ -1,7 +1,7 @@
 ---
-title: "Storybook for React tutorial"
-tocTitle: "Get started"
-description: "Setup Storybook in your development environment"
+title: 'Storybook for React tutorial'
+tocTitle: 'Get started'
+description: 'Setup Storybook in your development environment'
 commit: ebe2ae2
 ---
 

--- a/content/intro-to-storybook/react/en/screen.md
+++ b/content/intro-to-storybook/react/en/screen.md
@@ -1,7 +1,7 @@
 ---
-title: "Construct a screen"
-tocTitle: "Screens"
-description: "Construct a screen out of components"
+title: 'Construct a screen'
+tocTitle: 'Screens'
+description: 'Construct a screen out of components'
 commit: e56e345
 ---
 
@@ -16,11 +16,11 @@ As our app is very simple, the screen we’ll build is pretty trivial, simply wr
 ```javascript
 // src/components/InboxScreen.js
 
-import React from "react";
-import PropTypes from "prop-types";
-import { connect } from "react-redux";
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
-import TaskList from "./TaskList";
+import TaskList from './TaskList';
 
 export function PureInboxScreen({ error }) {
   if (error) {
@@ -48,11 +48,11 @@ export function PureInboxScreen({ error }) {
 }
 
 PureInboxScreen.propTypes = {
-  error: PropTypes.string
+  error: PropTypes.string,
 };
 
 PureInboxScreen.defaultProps = {
-  error: null
+  error: null,
 };
 
 export default connect(({ error }) => ({ error }))(PureInboxScreen);
@@ -63,11 +63,11 @@ We also change the `App` component to render the `InboxScreen` (eventually we wo
 ```javascript
 // src/App.js
 
-import React, { Component } from "react";
-import { Provider } from "react-redux";
-import store from "./lib/redux";
+import React, { Component } from 'react';
+import { Provider } from 'react-redux';
+import store from './lib/redux';
 
-import InboxScreen from "./components/InboxScreen";
+import InboxScreen from './components/InboxScreen';
 
 class App extends Component {
   render() {
@@ -93,14 +93,14 @@ However, for the `PureInboxScreen` we have a problem because although the `PureI
 ```javascript
 // src/components/InboxScreen.stories.js
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
+import React from 'react';
+import { storiesOf } from '@storybook/react';
 
-import { PureInboxScreen } from "./InboxScreen";
+import { PureInboxScreen } from './InboxScreen';
 
-storiesOf("InboxScreen", module)
-  .add("default", () => <PureInboxScreen />)
-  .add("error", () => <PureInboxScreen error="Something" />);
+storiesOf('InboxScreen', module)
+  .add('default', () => <PureInboxScreen />)
+  .add('error', () => <PureInboxScreen error="Something" />);
 ```
 
 We see that although the `error` story works just fine, we have an issue in the `default` story, because the `TaskList` has no Redux store to connect to. (You also would encounter similar problems when trying to test the `PureInboxScreen` with a unit test).
@@ -122,29 +122,29 @@ The good news is that it is easy to supply a Redux store to the `InboxScreen` in
 ```javascript
 // src/components/InboxScreen.stories.js
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { action } from "@storybook/addon-actions";
-import { Provider } from "react-redux";
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { Provider } from 'react-redux';
 
-import { PureInboxScreen } from "./InboxScreen";
-import { defaultTasks } from "./TaskList.stories";
+import { PureInboxScreen } from './InboxScreen';
+import { defaultTasks } from './TaskList.stories';
 
 // A super-simple mock of a redux store
 const store = {
   getState: () => {
     return {
-      tasks: defaultTasks
+      tasks: defaultTasks,
     };
   },
   subscribe: () => 0,
-  dispatch: action("dispatch")
+  dispatch: action('dispatch'),
 };
 
-storiesOf("InboxScreen", module)
+storiesOf('InboxScreen', module)
   .addDecorator(story => <Provider store={store}>{story()}</Provider>)
-  .add("default", () => <PureInboxScreen />)
-  .add("error", () => <PureInboxScreen error="Something" />);
+  .add('default', () => <PureInboxScreen />)
+  .add('error', () => <PureInboxScreen error="Something" />);
 ```
 
 Similar approaches exist to provide mocked context for other data libraries, such as [Apollo](https://www.npmjs.com/package/apollo-storybook-decorator), [Relay](https://github.com/orta/react-storybooks-relay-container) and others.

--- a/content/intro-to-storybook/react/en/simple-component.md
+++ b/content/intro-to-storybook/react/en/simple-component.md
@@ -1,7 +1,7 @@
 ---
-title: "Build a simple component"
-tocTitle: "Simple component"
-description: "Build a simple component in isolation"
+title: 'Build a simple component'
+tocTitle: 'Simple component'
+description: 'Build a simple component in isolation'
 commit: 403f19a
 ---
 
@@ -13,8 +13,8 @@ We’ll build our UI following a [Component-Driven Development](https://blog.hic
 
 `Task` is the core component in our app. Each task displays slightly differently depending on exactly what state it’s in. We display a checked (or unchecked) checkbox, some information about the task, and a “pin” button, allowing us to move tasks up and down the list. Putting this together, we’ll need these props:
 
-* `title` – a string describing the task
-* `state` - which list is the task currently in and is it checked off?
+- `title` – a string describing the task
+- `state` - which list is the task currently in and is it checked off?
 
 As we start to build `Task`, we first write our test states that correspond to the different types of tasks sketched above. Then we use Storybook to build the component in isolation using mocked data. We’ll “visual test” the component’s appearance given each state as we go.
 
@@ -73,10 +73,10 @@ storiesOf('Task', module)
 
 There are two basic levels of organization in Storybook: the component and its child stories. Think of each story as a permutation of a component. You can have as many stories per component as you need.
 
-* **Component**
-  * Story
-  * Story
-  * Story
+- **Component**
+  - Story
+  - Story
+  - Story
 
 To initiate Storybook we first call the `storiesOf()` function to register the component. We add a display name for the component –the name that appears on the sidebar in the Storybook app.
 

--- a/content/intro-to-storybook/react/en/test.md
+++ b/content/intro-to-storybook/react/en/test.md
@@ -1,7 +1,7 @@
 ---
-title: "Test UI components"
-tocTitle: "Testing"
-description: "Learn the ways to test UI components"
+title: 'Test UI components'
+tocTitle: 'Testing'
+description: 'Learn the ways to test UI components'
 commit: 78a45d1
 ---
 
@@ -61,13 +61,13 @@ Import Chromatic in your `.storybook/config.js` file.
 ```javascript
 // .storybook/config.js
 
-import { configure } from "@storybook/react";
-import requireContext from "require-context.macro";
-import "storybook-chromatic";
+import { configure } from '@storybook/react';
+import requireContext from 'require-context.macro';
+import 'storybook-chromatic';
 
-import "../src/index.css";
+import '../src/index.css';
 
-const req = requireContext("../src/components", true, /\.stories\.js$/);
+const req = requireContext('../src/components', true, /\.stories\.js$/);
 
 function loadStories() {
   req.keys().forEach(filename => req(filename));

--- a/content/intro-to-storybook/react/en/using-addons.md
+++ b/content/intro-to-storybook/react/en/using-addons.md
@@ -1,8 +1,8 @@
 ---
-title: "Addons"
-tocTitle: "Addons"
-description: "Learn how to integrate and use addons using a popular example"
-commit: "dac373a"
+title: 'Addons'
+tocTitle: 'Addons'
+description: 'Learn how to integrate and use addons using a popular example'
+commit: 'dac373a'
 ---
 
 Storybook boasts a robust system of [addons](https://storybook.js.org/addons/introduction/) with which you can enhance the developer experience for
@@ -40,9 +40,9 @@ Register Knobs in your `.storybook/addons.js` file.
 ```javascript
 // .storybook/addons.js
 
-import "@storybook/addon-actions/register";
-import "@storybook/addon-knobs/register";
-import "@storybook/addon-links/register";
+import '@storybook/addon-actions/register';
+import '@storybook/addon-knobs/register';
+import '@storybook/addon-links/register';
 ```
 
 <div class="aside">
@@ -62,10 +62,10 @@ First, import the `withKnobs` decorator and the `object` knob type to `Task.stor
 ```javascript
 // src/components/Task.stories.js
 
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { action } from "@storybook/addon-actions";
-import { withKnobs, object } from "@storybook/addon-knobs/react";
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withKnobs, object } from '@storybook/addon-knobs/react';
 ```
 
 Next, within the stories of `Task`, pass `withKnobs` as a parameter to the `addDecorator()` function:
@@ -73,7 +73,7 @@ Next, within the stories of `Task`, pass `withKnobs` as a parameter to the `addD
 ```javascript
 // src/components/Task.stories.js
 
-storiesOf("Task", module)
+storiesOf('Task', module)
   .addDecorator(withKnobs)
   .add(/*...*/);
 ```
@@ -83,17 +83,13 @@ Lastly, integrate the `object` knob type within the "default" story:
 ```javascript
 // src/components/Task.stories.js
 
-storiesOf("Task", module)
+storiesOf('Task', module)
   .addDecorator(withKnobs)
-  .add("default", () => {
-    return <Task task={object("task", { ...task })} {...actions} />;
+  .add('default', () => {
+    return <Task task={object('task', { ...task })} {...actions} />;
   })
-  .add("pinned", () => (
-    <Task task={{ ...task, state: "TASK_PINNED" }} {...actions} />
-  ))
-  .add("archived", () => (
-    <Task task={{ ...task, state: "TASK_ARCHIVED" }} {...actions} />
-  ));
+  .add('pinned', () => <Task task={{ ...task, state: 'TASK_PINNED' }} {...actions} />)
+  .add('archived', () => <Task task={{ ...task, state: 'TASK_ARCHIVED' }} {...actions} />);
 ```
 
 Now a new "Knobs" tab should show up next to the "Action Logger" tab in the bottom pane.
@@ -122,7 +118,7 @@ Thanks to quickly being able to try different inputs to a component we can find 
   value={title}
   readOnly={true}
   placeholder="Input title"
-  style={{ textOverflow: "ellipsis" }}
+  style={{ textOverflow: 'ellipsis' }}
 />
 ```
 
@@ -139,17 +135,11 @@ Let's add a story for the long text case in Task.stories.js:
 
 const longTitle = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not`;
 
-storiesOf("Task", module)
-  .add("default", () => <Task task={task} {...actions} />)
-  .add("pinned", () => (
-    <Task task={{ ...task, state: "TASK_PINNED" }} {...actions} />
-  ))
-  .add("archived", () => (
-    <Task task={{ ...task, state: "TASK_ARCHIVED" }} {...actions} />
-  ))
-  .add("long title", () => (
-    <Task task={{ ...task, title: longTitle }} {...actions} />
-  ));
+storiesOf('Task', module)
+  .add('default', () => <Task task={task} {...actions} />)
+  .add('pinned', () => <Task task={{ ...task, state: 'TASK_PINNED' }} {...actions} />)
+  .add('archived', () => <Task task={{ ...task, state: 'TASK_ARCHIVED' }} {...actions} />)
+  .add('long title', () => <Task task={{ ...task, title: longTitle }} {...actions} />);
 ```
 
 Now we've added the story, we can reproduce this edge-case with ease whenever we want to work on it:

--- a/content/intro-to-storybook/react/es/composite-component.md
+++ b/content/intro-to-storybook/react/es/composite-component.md
@@ -1,7 +1,7 @@
 ---
-title: "Ensamblar un componente compuesto"
-tocTitle: "Componente Compuesto"
-description: "Ensamblar un componente compuesto a partir de componentes simples"
+title: 'Ensamblar un componente compuesto'
+tocTitle: 'Componente Compuesto'
+description: 'Ensamblar un componente compuesto a partir de componentes simples'
 commit: 8db511e
 ---
 
@@ -44,7 +44,9 @@ function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
 
   return (
     <div className="list-items">
-      {tasks.map(task => <Task key={task.id} task={task} {...events} />)}
+      {tasks.map(task => (
+        <Task key={task.id} task={task} {...events} />
+      ))}
     </div>
   );
 }
@@ -160,7 +162,9 @@ function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
 
   return (
     <div className="list-items">
-      {tasksInOrder.map(task => <Task key={task.id} task={task} {...events} />)}
+      {tasksInOrder.map(task => (
+        <Task key={task.id} task={task} {...events} />
+      ))}
     </div>
   );
 }

--- a/content/intro-to-storybook/react/es/conclusion.md
+++ b/content/intro-to-storybook/react/es/conclusion.md
@@ -1,6 +1,6 @@
 ---
-title: "Conclusion"
-description: "Pon todo tu conocimiento junto y aprende más técnicas de Storybook"
+title: 'Conclusion'
+description: 'Pon todo tu conocimiento junto y aprende más técnicas de Storybook'
 ---
 
 Felicitaciones! Creaste tu primer interfaz de usuario en Storybook. En el camino, aprendiste a construir, componer, probar e implementar componentes de interfaz de usuario. Si lo has estado siguiendo, tu repositorio y Storybook desplegado debería verse así:
@@ -15,11 +15,11 @@ Storybook es una poderosa herramienta para React, Vue y Angular. Cuenta con una 
 
 Quieres bucear más profundo? Aquí algunos recursos útiles:
 
-* [**Documentación oficial de Storybook**](https://storybook.js.org/basics/introduction/) tiene la documentación del API, links comunitarios y una galería de complementos.
+- [**Documentación oficial de Storybook**](https://storybook.js.org/basics/introduction/) tiene la documentación del API, links comunitarios y una galería de complementos.
 
-* **El delicioso flujo de trabajo de Storybook** (Próximamente!) destaca las mejores prácticas del flujo de trabajo utilizado por equipos de alta velocidad en Squarespace, Major League Soccer y Apollo GraphQL.
+- **El delicioso flujo de trabajo de Storybook** (Próximamente!) destaca las mejores prácticas del flujo de trabajo utilizado por equipos de alta velocidad en Squarespace, Major League Soccer y Apollo GraphQL.
 
-* [**Manual de pruebas visuales**](https://www.chromaticqa.com/book/visual-testing-handbook) se sumerge profundamente en el uso de Storybook para probar componentes visuales. Libro electrónico gratuito de 31 páginas.
+- [**Manual de pruebas visuales**](https://www.chromaticqa.com/book/visual-testing-handbook) se sumerge profundamente en el uso de Storybook para probar componentes visuales. Libro electrónico gratuito de 31 páginas.
 
 ## Quién hizo LearnStorybook.com?
 

--- a/content/intro-to-storybook/react/es/contribute.md
+++ b/content/intro-to-storybook/react/es/contribute.md
@@ -1,6 +1,6 @@
 ---
-title: "Contribuir"
-description: "Ayuda a compartir Storybook con el mundo"
+title: 'Contribuir'
+description: 'Ayuda a compartir Storybook con el mundo'
 ---
 
 # Contribuir

--- a/content/intro-to-storybook/react/es/data.md
+++ b/content/intro-to-storybook/react/es/data.md
@@ -1,7 +1,7 @@
 ---
-title: "Introducir datos"
-tocTitle: "Datos"
-description: "Aprende como introducir datos a tus componentes UI"
+title: 'Introducir datos'
+tocTitle: 'Datos'
+description: 'Aprende como introducir datos a tus componentes UI'
 commit: 9c50472
 ---
 
@@ -43,12 +43,12 @@ function taskStateReducer(taskState) {
   return (state, action) => {
     return {
       ...state,
-      tasks: state.tasks.map(
-        task => (task.id === action.id ? { ...task, state: taskState } : task)
+      tasks: state.tasks.map(task =>
+        task.id === action.id ? { ...task, state: taskState } : task
       ),
     };
   };
-};
+}
 
 // El reducer describe como los contenidos del store cambian por cada acción.
 export const reducer = (state, action) => {
@@ -114,7 +114,6 @@ export default connect(
 En esta etapa, nuestras pruebas de Storybook habrán dejado de funcionar, ya que la `TaskList` ahora es un contenedor y ya no espera ninguna de las props pasadas como parámetros, sino que se conecta a la store y establece las props en el componente `PureTaskList` que envuelve.
 
 Sin embargo, podemos resolver este problema fácilmente renderizando `PureTaskList` --el componente de presentación-- en nuestras historias de Storybook:
-
 
 ```javascript
 import React from 'react';

--- a/content/intro-to-storybook/react/es/deploy.md
+++ b/content/intro-to-storybook/react/es/deploy.md
@@ -1,7 +1,7 @@
 ---
-title: "Desplegar Storybook"
-tocTitle: "Desplegar"
-description: "Desplegar Storybook online con GitHub y Netlify"
+title: 'Desplegar Storybook'
+tocTitle: 'Desplegar'
+description: 'Desplegar Storybook online con GitHub y Netlify'
 ---
 
 En este tutorial hemos ejecutado Storybook en nuestra máquina de desarrollo. También se puede compartir ese Storybook con el equipo, especialmente con los miembros no técnicos. Afortunadamente, es fácil implementar Storybook en línea.

--- a/content/intro-to-storybook/react/es/get-started.md
+++ b/content/intro-to-storybook/react/es/get-started.md
@@ -1,7 +1,7 @@
 ---
-title: "Storybook para React tutorial"
-tocTitle: "Empezando"
-description: "Configurar React Storybook en tu entorno de desarrollo"
+title: 'Storybook para React tutorial'
+tocTitle: 'Empezando'
+description: 'Configurar React Storybook en tu entorno de desarrollo'
 commit: ebe2ae2
 ---
 

--- a/content/intro-to-storybook/react/es/screen.md
+++ b/content/intro-to-storybook/react/es/screen.md
@@ -1,7 +1,7 @@
 ---
-title: "Construir una pantalla"
-tocTitle: "Pantallas"
-description: "Construir una pantalla con componentes"
+title: 'Construir una pantalla'
+tocTitle: 'Pantallas'
+description: 'Construir una pantalla con componentes'
 commit: e56e345
 ---
 
@@ -14,11 +14,11 @@ En este capítulo continuaremos aumentando la sofisticación combinando componen
 Como nuestra aplicación es muy simple, la pantalla que construiremos es bastante trivial, simplemente envolviendo el componente `TaskList` (que proporciona sus propios datos a través de Redux) en alguna maqueta y sacando un campo `error` de primer nivel de redux (asumamos que pondremos ese campo si tenemos algún problema para conectarnos a nuestro servidor):
 
 ```javascript
-import React from "react";
-import PropTypes from "prop-types";
-import { connect } from "react-redux";
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
-import TaskList from "./TaskList";
+import TaskList from './TaskList';
 
 export function PureInboxScreen({ error }) {
   if (error) {
@@ -46,11 +46,11 @@ export function PureInboxScreen({ error }) {
 }
 
 PureInboxScreen.propTypes = {
-  error: PropTypes.string
+  error: PropTypes.string,
 };
 
 PureInboxScreen.defaultProps = {
-  error: null
+  error: null,
 };
 
 export default connect(({ error }) => ({ error }))(PureInboxScreen);
@@ -59,11 +59,11 @@ export default connect(({ error }) => ({ error }))(PureInboxScreen);
 También cambiamos el componente `App` para renderizar la pantalla de la bandeja de entrada `InboxScreen` (normalmente usaríamos un router para elegir la pantalla correcta, pero no nos preocupemos por ello aquí):
 
 ```javascript
-import React, { Component } from "react";
-import { Provider } from "react-redux";
-import store from "./lib/redux";
+import React, { Component } from 'react';
+import { Provider } from 'react-redux';
+import store from './lib/redux';
 
-import InboxScreen from "./components/InboxScreen";
+import InboxScreen from './components/InboxScreen';
 
 class App extends Component {
   render() {
@@ -87,14 +87,14 @@ Al colocar la "Lista de tareas" `TaskList` en Storybook, pudimos esquivar este p
 Sin embargo, para la `PureInboxScreen` tenemos un problema porque aunque la `PureInboxScreen` en si misma es presentacional, su hijo, la `TaskList`, no lo es. En cierto sentido la `PureInboxScreen` ha sido contaminada por la "contenedorización". Así que cuando preparamos nuestras historias:
 
 ```javascript
-import React from "react";
-import { storiesOf } from "@storybook/react";
+import React from 'react';
+import { storiesOf } from '@storybook/react';
 
-import { PureInboxScreen } from "./InboxScreen";
+import { PureInboxScreen } from './InboxScreen';
 
-storiesOf("InboxScreen", module)
-  .add("default", () => <PureInboxScreen />)
-  .add("error", () => <PureInboxScreen error="Something" />);
+storiesOf('InboxScreen', module)
+  .add('default', () => <PureInboxScreen />)
+  .add('error', () => <PureInboxScreen error="Something" />);
 ```
 
 Vemos que aunque la historia de `error` funciona bien, tenemos un problema en la historia `default`, porque la `TaskList` no tiene una store de Redux a la que conectarse. (También encontrarás problemas similares cuando intentes probar la `PureInboxScreen` con un test unitario).
@@ -114,29 +114,29 @@ Por otro lado, la transmisión de datos a nivel jerárquico es un enfoque legít
 La buena noticia es que es fácil suministrar una store de Redux a la `InboxScreen` en una historia! Podemos usar una versión mockeada de la store de Redux provista en un decorador:
 
 ```javascript
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { action } from "@storybook/addon-actions";
-import { Provider } from "react-redux";
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { Provider } from 'react-redux';
 
-import { PureInboxScreen } from "./InboxScreen";
-import { defaultTasks } from "./TaskList.stories";
+import { PureInboxScreen } from './InboxScreen';
+import { defaultTasks } from './TaskList.stories';
 
 // Un mock super simple de un store de redux
 const store = {
   getState: () => {
     return {
-      tasks: defaultTasks
+      tasks: defaultTasks,
     };
   },
   subscribe: () => 0,
-  dispatch: action("dispatch")
+  dispatch: action('dispatch'),
 };
 
-storiesOf("InboxScreen", module)
+storiesOf('InboxScreen', module)
   .addDecorator(story => <Provider store={store}>{story()}</Provider>)
-  .add("default", () => <PureInboxScreen />)
-  .add("error", () => <PureInboxScreen error="Something" />);
+  .add('default', () => <PureInboxScreen />)
+  .add('error', () => <PureInboxScreen error="Something" />);
 ```
 
 Existen enfoques similares para proporcionar un contexto simulado para otras bibliotecas de datos, tales como [Apollo](https://www.npmjs.com/package/apollo-storybook-decorator), [Relay](https://github.com/orta/react-storybooks-relay-container) y algunas otras.

--- a/content/intro-to-storybook/react/es/simple-component.md
+++ b/content/intro-to-storybook/react/es/simple-component.md
@@ -1,7 +1,7 @@
 ---
-title: "Construye un componente simple"
-tocTitle: "Componente Simple"
-description: "Construye un componente simple en aislamiento"
+title: 'Construye un componente simple'
+tocTitle: 'Componente Simple'
+description: 'Construye un componente simple en aislamiento'
 commit: 403f19a
 ---
 
@@ -13,8 +13,8 @@ Construiremos nuestra UI siguiendo la metodología (CDD) [Component-Driven Devel
 
 `Task` (o Tarea) es el componente principal en nuestra app. Cada tarea se muestra de forma ligeramente diferente según el estado en el que se encuentre. Mostramos un checkbox marcado (o no marcado), información sobre la tarea y un botón “pin” que nos permite mover la tarea hacia arriba o abajo en la lista de tareas. Poniendo esto en conjunto, necesitaremos estas propiedades -props- :
 
-* `title` – un string que describe la tarea
-* `state` - ¿en qué lista se encuentra la tarea actualmente y está marcado el checkbox?
+- `title` – un string que describe la tarea
+- `state` - ¿en qué lista se encuentra la tarea actualmente y está marcado el checkbox?
 
 A medida que comencemos a construir `Task`, primero escribiremos nuestros tests para los estados que corresponden a los distintos tipos de tareas descritas anteriormente. Luego, utilizamos Storybook para construir el componente de forma aislada usando datos de prueba. Vamos a “testear visualmente” la apariencia del componente a medida que cambiemos cada estado.
 
@@ -69,10 +69,10 @@ storiesOf('Task', module)
 
 Existen dos niveles básicos de organización en Storybook. El componente y sus historias hijas. Piensa en cada historia como una permutación posible del componente. Puedes tener tantas historias por componente como se necesite.
 
-* **Componente**
-  * Historia
-  * Historia
-  * Historia
+- **Componente**
+  - Historia
+  - Historia
+  - Historia
 
 Para iniciar Storybook, primero invocamos a la función `storiesOf()` para registrar el componente. Agregamos un nombre para mostrar el componente, que se muestra en la barra lateral de la aplicación Storybook.
 
@@ -187,7 +187,7 @@ Task.propTypes = {
 };
 ```
 
-Ahora aparecerá una advertencia en modo desarrollo si el componente Task  se utiliza incorrectamente.
+Ahora aparecerá una advertencia en modo desarrollo si el componente Task se utiliza incorrectamente.
 
 <div class="aside">
 Una forma alternativa de lograr el mismo propósito es utilizando un sistema de tipos de JavaScript como TypeScript, para crear un tipo para las propiedades del componente.

--- a/content/intro-to-storybook/react/es/test.md
+++ b/content/intro-to-storybook/react/es/test.md
@@ -1,7 +1,7 @@
 ---
-title: "Testear Componentes UI"
-tocTitle: "Testing"
-description: "Aprende las formas de hacer test a los componentes de la UI"
+title: 'Testear Componentes UI'
+tocTitle: 'Testing'
+description: 'Aprende las formas de hacer test a los componentes de la UI'
 commit: 78a45d1
 ---
 
@@ -65,13 +65,13 @@ yarn add storybook-chromatic
 Importa Chromatic en tu archivo `.storybook/config.js`.
 
 ```javascript
-import { configure } from "@storybook/react";
-import requireContext from "require-context.macro";
-import "storybook-chromatic";
+import { configure } from '@storybook/react';
+import requireContext from 'require-context.macro';
+import 'storybook-chromatic';
 
-import "../src/index.css";
+import '../src/index.css';
 
-const req = requireContext("../src/components", true, /\.stories\.js$/);
+const req = requireContext('../src/components', true, /\.stories\.js$/);
 
 function loadStories() {
   req.keys().forEach(filename => req(filename));

--- a/content/intro-to-storybook/react/pt/composite-component.md
+++ b/content/intro-to-storybook/react/pt/composite-component.md
@@ -1,7 +1,7 @@
 ---
-title: "Construção de um componente composto"
-tocTitle: "Componente composto"
-description: "Construção de um componente composto a partir de componentes simples"
+title: 'Construção de um componente composto'
+tocTitle: 'Componente composto'
+description: 'Construção de um componente composto a partir de componentes simples'
 commit: 8db511e
 ---
 
@@ -47,7 +47,9 @@ function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
 
   return (
     <div className="list-items">
-      {tasks.map(task => <Task key={task.id} task={task} {...events} />)}
+      {tasks.map(task => (
+        <Task key={task.id} task={task} {...events} />
+      ))}
     </div>
   );
 }
@@ -159,7 +161,9 @@ function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
 
   return (
     <div className="list-items">
-      {tasksInOrder.map(task => <Task key={task.id} task={task} {...events} />)}
+      {tasksInOrder.map(task => (
+        <Task key={task.id} task={task} {...events} />
+      ))}
     </div>
   );
 }

--- a/content/intro-to-storybook/react/pt/conclusion.md
+++ b/content/intro-to-storybook/react/pt/conclusion.md
@@ -1,6 +1,6 @@
 ---
-title: "Conclusão"
-description: "Fusão de todo o conhecimento adquirido e aprendizagem de técnicas extra de Storybook"
+title: 'Conclusão'
+description: 'Fusão de todo o conhecimento adquirido e aprendizagem de técnicas extra de Storybook'
 ---
 
 Parabéns! Acabaste de criar o teu primeiro interface de utilizador com Storybook. Durante esta jornada aprendeste como construir, compor, testar e implementar componentes de interface de utilizador.
@@ -10,20 +10,19 @@ Se estiveste a seguir o tutorial, o repositório e o Storybook implementado irá
 <br/>
 [🌎 **Storybook implementado**](https://clever-banach-415c03.netlify.com/)
 
-O Storybook é uma ferramenta bastante poderosa para React, Vue, Angular. 
+O Storybook é uma ferramenta bastante poderosa para React, Vue, Angular.
 É composta por uma comunidade de desenvolvimento próspera e um número grande de extras. Esta introdução somente arranha a superfície das potencialidades existentes. Estamos confiantes que depois da adoção do Storybook, irá ficar impressionado com o quanto é produtivo a construção de interfaces de utilizador duradouros.
 
 ## Saber mais
 
 Pretende saber mais? Aqui ficam alguns recursos que irão ajudar.
 
-* [**Documentação Oficial Storybook**](https://storybook.js.org/basics/introduction/) contem a documentação da API, links da comunidade e a galeria de extras.
+- [**Documentação Oficial Storybook**](https://storybook.js.org/basics/introduction/) contem a documentação da API, links da comunidade e a galeria de extras.
 
-* [**Manual de testes visuais**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07) 
-enumera as boas práticas de fluxo de trabalho, usadas por equipas que operam a alta velocidade, tal como por exemplo a SquareSpace, a Major League Soccer, a Discovery Network e Apollo GraphQL.
+- [**Manual de testes visuais**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07)
+  enumera as boas práticas de fluxo de trabalho, usadas por equipas que operam a alta velocidade, tal como por exemplo a SquareSpace, a Major League Soccer, a Discovery Network e Apollo GraphQL.
 
-* [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) aprofunda o uso de Storybook para testes visuais. Livro eletrónico livre de 31 páginas.
-
+- [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) aprofunda o uso de Storybook para testes visuais. Livro eletrónico livre de 31 páginas.
 
 ## Quem fez LearnStorybook.com?
 

--- a/content/intro-to-storybook/react/pt/contribute.md
+++ b/content/intro-to-storybook/react/pt/contribute.md
@@ -1,6 +1,6 @@
 ---
-title: "Contribuições"
-description: "Ajudem na partilha do Storybook com o mundo"
+title: 'Contribuições'
+description: 'Ajudem na partilha do Storybook com o mundo'
 ---
 
 # Contribuições

--- a/content/intro-to-storybook/react/pt/data.md
+++ b/content/intro-to-storybook/react/pt/data.md
@@ -1,7 +1,7 @@
 ---
-title: "Ligação de dados"
-tocTitle: "Dados"
-description: "Aprendizagem da metodologia de ligação de dados ao componente interface utilizador"
+title: 'Ligação de dados'
+tocTitle: 'Dados'
+description: 'Aprendizagem da metodologia de ligação de dados ao componente interface utilizador'
 commit: 9c50472
 ---
 
@@ -45,12 +45,12 @@ function taskStateReducer(taskState) {
   return (state, action) => {
     return {
       ...state,
-      tasks: state.tasks.map(
-        task => (task.id === action.id ? { ...task, state: taskState } : task)
+      tasks: state.tasks.map(task =>
+        task.id === action.id ? { ...task, state: taskState } : task
       ),
     };
   };
-};
+}
 
 // The reducer describes how the contents of the store change for each action
 export const reducer = (state, action) => {

--- a/content/intro-to-storybook/react/pt/deploy.md
+++ b/content/intro-to-storybook/react/pt/deploy.md
@@ -1,7 +1,7 @@
 ---
-title: "Implementar Storybook"
-tocTitle: "Implementação"
-descrição: "Implemntação online do Storybook com GitHub e Netlify"
+title: 'Implementar Storybook'
+tocTitle: 'Implementação'
+descrição: 'Implemntação online do Storybook com GitHub e Netlify'
 ---
 
 Neste tutorial o Storybook foi executado na máquina local. Poderá ser necessária a partilha com o resto da equipa, em particular com membros considerados não técnicos. Felizmente, é bastante fácil implementar o Storybook online.

--- a/content/intro-to-storybook/react/pt/get-started.md
+++ b/content/intro-to-storybook/react/pt/get-started.md
@@ -1,7 +1,7 @@
 ---
-title: "Storybook para o React tutorial"
-tocTitle: "Introdução"
-description: "Configuração do React Storybook no ambiente de desenvolvimento"
+title: 'Storybook para o React tutorial'
+tocTitle: 'Introdução'
+description: 'Configuração do React Storybook no ambiente de desenvolvimento'
 commit: ebe2ae2
 ---
 

--- a/content/intro-to-storybook/react/pt/screen.md
+++ b/content/intro-to-storybook/react/pt/screen.md
@@ -1,7 +1,7 @@
 ---
-title: "Construção de um ecrã"
-tocTitle: "Ecrãs"
-description: "Construção de um ecrã a partir de componentes"
+title: 'Construção de um ecrã'
+tocTitle: 'Ecrãs'
+description: 'Construção de um ecrã a partir de componentes'
 commit: e56e345
 ---
 
@@ -15,11 +15,11 @@ Neste capitulo, irá ser acrescida um pouco mais a sofisticação, através da c
 Visto que a aplicação é deveras simples, o ecrã a ser construído é bastante trivial, simplesmente envolvendo o componente `TaskList` (que fornece os seus dados via Redux), a um qualquer layout e extraindo o campo de topo `erro` oriundo do Redux(assumindo que este irá ser definido caso exista algum problema na ligação ao servidor). Dentro da pasta `components` vai ser adicionado o ficheiro `InboxScreen.js`:
 
 ```javascript
-import React from "react";
-import PropTypes from "prop-types";
-import { connect } from "react-redux";
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
-import TaskList from "./TaskList";
+import TaskList from './TaskList';
 
 export function PureInboxScreen({ error }) {
   if (error) {
@@ -47,11 +47,11 @@ export function PureInboxScreen({ error }) {
 }
 
 PureInboxScreen.propTypes = {
-  error: PropTypes.string
+  error: PropTypes.string,
 };
 
 PureInboxScreen.defaultProps = {
-  error: null
+  error: null,
 };
 
 export default connect(({ error }) => ({ error }))(PureInboxScreen);
@@ -60,11 +60,11 @@ export default connect(({ error }) => ({ error }))(PureInboxScreen);
 Vai ser necessário alterar o componente `App` de forma a ser possível renderizar o `InboxScreen` (eventualmente iria ser usado um roteador para escolher o ecrã apropriado, mas não e necessário preocupar-se com isso agora):
 
 ```javascript
-import React, { Component } from "react";
-import { Provider } from "react-redux";
-import store from "./lib/redux";
+import React, { Component } from 'react';
+import { Provider } from 'react-redux';
+import store from './lib/redux';
 
-import InboxScreen from "./components/InboxScreen";
+import InboxScreen from './components/InboxScreen';
 
 class App extends Component {
   render() {
@@ -89,14 +89,14 @@ Irá ser feito algo similar para o `PureInboxScreen` no Storybook também.
 No entanto para o `PureInboxScreen` existe um problema, isto porque apesar deste ser de apresentação, o seu "filho", ou seja a `TaskList` não o é. De certa forma o `PureInboxScreen` foi poluído pelo "container-ness". Com isto as estórias no ficheiro `InboxScreen.stories.js` terão que ser definidas da seguinte forma:
 
 ```javascript
-import React from "react";
-import { storiesOf } from "@storybook/react";
+import React from 'react';
+import { storiesOf } from '@storybook/react';
 
-import { PureInboxScreen } from "./InboxScreen";
+import { PureInboxScreen } from './InboxScreen';
 
-storiesOf("InboxScreen", module)
-  .add("default", () => <PureInboxScreen />)
-  .add("error", () => <PureInboxScreen error="Something" />);
+storiesOf('InboxScreen', module)
+  .add('default', () => <PureInboxScreen />)
+  .add('error', () => <PureInboxScreen error="Something" />);
 ```
 
 Pode verificar-se que apesar da estória `erro` funcionar correctamente, existe um problema na estória `default`, isto porque a `TaskList` não tem uma loja Redux á qual conectar-se. (Poderão surgir problemas similares ao testar o `PureInboxScreen` com um teste unitário).
@@ -116,29 +116,29 @@ No entanto, algum programador **irá querer** renderizar contentores num nível 
 As boas noticias é que é extremamente fácil fornecer uma loja Redux ao componente `InboxScreen` numa estória! Pode ser usada uma versão simulada, que é fornecida através de um decorador:
 
 ```javascript
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { action } from "@storybook/addon-actions";
-import { Provider } from "react-redux";
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { Provider } from 'react-redux';
 
-import { PureInboxScreen } from "./InboxScreen";
-import { defaultTasks } from "./TaskList.stories";
+import { PureInboxScreen } from './InboxScreen';
+import { defaultTasks } from './TaskList.stories';
 
 // A super-simple mock of a redux store
 const store = {
   getState: () => {
     return {
-      tasks: defaultTasks
+      tasks: defaultTasks,
     };
   },
   subscribe: () => 0,
-  dispatch: action("dispatch")
+  dispatch: action('dispatch'),
 };
 
-storiesOf("InboxScreen", module)
+storiesOf('InboxScreen', module)
   .addDecorator(story => <Provider store={store}>{story()}</Provider>)
-  .add("default", () => <PureInboxScreen />)
-  .add("error", () => <PureInboxScreen error="Something" />);
+  .add('default', () => <PureInboxScreen />)
+  .add('error', () => <PureInboxScreen error="Something" />);
 ```
 
 Existem abordagens semelhantes de forma a fornecer contextos simulados para outras bibliotecas de dados tal como [Apollo](https://www.npmjs.com/package/apollo-storybook-decorator), [Relay](https://github.com/orta/react-storybooks-relay-container) assim como outras.

--- a/content/intro-to-storybook/react/pt/simple-component.md
+++ b/content/intro-to-storybook/react/pt/simple-component.md
@@ -1,7 +1,7 @@
 ---
-title: "Construção de um componente siples"
-tocTitle: "Componente simples"
-description: "Construção de um componente simples isolado"
+title: 'Construção de um componente siples'
+tocTitle: 'Componente simples'
+description: 'Construção de um componente simples isolado'
 commit: 403f19a
 ---
 
@@ -11,12 +11,12 @@ Iremos construir o interface de utilizador de acordo com a metodologia de [Desen
 
 ![Componente Task ao longo de três estados](/intro-to-storybook/task-states-learnstorybook.png)
 
-`Task` é o componente nuclear da nossa aplicação. Cada tarefa é apresentada de forma diferente dependendo do estado em que se encontra. 
-O que vai ser apresentado é uma caixa de confirmação, selecionada (ou não), alguma informação adicional acerca da tarefa e um botão "fixador", que permite a movimentação para cima e para baixo das tarefas ao longo da lista. 
+`Task` é o componente nuclear da nossa aplicação. Cada tarefa é apresentada de forma diferente dependendo do estado em que se encontra.
+O que vai ser apresentado é uma caixa de confirmação, selecionada (ou não), alguma informação adicional acerca da tarefa e um botão "fixador", que permite a movimentação para cima e para baixo das tarefas ao longo da lista.
 Para que seja possível implementar isto serão necessárias os seguintes adereços (props):
 
-* `title` - uma cadeia de caracteres que descreve a tarefa
-* `state` - qual a lista em que a tarefa se encontra e se está confirmada?
+- `title` - uma cadeia de caracteres que descreve a tarefa
+- `state` - qual a lista em que a tarefa se encontra e se está confirmada?
 
 Á medida que construimos a `Task`, é necessário definir os três estados que correspondem os três tipos de tarefa delineados acima.
 Em seguida usa-se o Storybook para construir este componente isolado, usando dados predefinidos. Irá "testar-se visualmente" a aparência do componente para cada estado á medida que prosseguimos.
@@ -41,6 +41,7 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
   );
 }
 ```
+
 O bloco de código acima, quando renderizado, não é nada mais nada menos que a estrutura HTML da `Task` na aplicação Todos.
 
 Em seguida irão ser criados os três testes ao estado da tarefa no ficheiro de estórias correspondente:
@@ -72,10 +73,10 @@ storiesOf('Task', module)
 
 Existem dois tipos de organização com Storybook. O componente em si e as estórias associadas. É preferível pensar em cada estória como uma permutação de um componente. Como tal podem existir tantas estórias, tantas as que forem necessárias.
 
-* **Component**
-  * Story
-  * Story
-  * Story
+- **Component**
+  - Story
+  - Story
+  - Story
 
 Ao ser invocada a função `storiesOf()`, está a registar-se o componente, e com isto o processo de arranque do Storybook. É adicionado um nome, nome esse que será usado na barra lateral da aplicação Storybook para identificar o componente.
 
@@ -120,7 +121,6 @@ Após esta alteração, ao ser reiniciado o servidor Storybook, deverá produzir
     type="video/mp4"
   />
 </video>
-
 
 ## Especificação de requisitos de dados
 

--- a/content/intro-to-storybook/react/pt/test.md
+++ b/content/intro-to-storybook/react/pt/test.md
@@ -1,7 +1,7 @@
 ---
-title: "Teste de componentes de interface de utilizador"
-tocTitle: "Testes"
-description: "Aprendizagem das formas de teste dos componentes interface utilizador"
+title: 'Teste de componentes de interface de utilizador'
+tocTitle: 'Testes'
+description: 'Aprendizagem das formas de teste dos componentes interface utilizador'
 commit: 78a45d1
 ---
 
@@ -60,13 +60,13 @@ yarn add storybook-chromatic
 O Chromatic é importado para o ficheiro `.storybook/config.js`.
 
 ```javascript
-import { configure } from "@storybook/react";
-import requireContext from "require-context.macro";
-import "storybook-chromatic";
+import { configure } from '@storybook/react';
+import requireContext from 'require-context.macro';
+import 'storybook-chromatic';
 
-import "../src/index.css";
+import '../src/index.css';
 
-const req = requireContext("../src/components", true, /\.stories\.js$/);
+const req = requireContext('../src/components', true, /\.stories\.js$/);
 
 function loadStories() {
   req.keys().forEach(filename => req(filename));

--- a/content/intro-to-storybook/react/pt/using-addons.md
+++ b/content/intro-to-storybook/react/pt/using-addons.md
@@ -1,8 +1,8 @@
 ---
-title: "Extras"
-tocTitle: "Extras"
-description: "Aprender a integrar e usar extras com recurso a um exemplo popular"
-commit: "dac373a"
+title: 'Extras'
+tocTitle: 'Extras'
+description: 'Aprender a integrar e usar extras com recurso a um exemplo popular'
+commit: 'dac373a'
 ---
 
 Storybook possui um sistema robusto de [extras](https://storybook.js.org/addons/introduction/) com o qual se pode aumentar a experiência de desenvolvimento para qualquer elemento da sua equipa. Se estiver a seguir este tutorial, pode ter reparado que já foram mencionados múltiplos extras e já terá implementado um no [capitulo de testes](/react/pt/test/).
@@ -32,9 +32,9 @@ yarn add @storybook/addon-knobs
 Registar o Knobs no ficheiro `.storybook/addons.js`.
 
 ```javascript
-import "@storybook/addon-actions/register";
-import "@storybook/addon-knobs/register";
-import "@storybook/addon-links/register";
+import '@storybook/addon-actions/register';
+import '@storybook/addon-knobs/register';
+import '@storybook/addon-links/register';
 ```
 
 <div class="aside">
@@ -52,16 +52,16 @@ Vamos usar o objecto knob no componente `Task`.
 Primeiro, importamos o decorador `withKnobs` e o tipo `object` de knob para o ficheiro `Task.stories.js`:
 
 ```javascript
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { action } from "@storybook/addon-actions";
-import { withKnobs, object } from "@storybook/addon-knobs/react";
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withKnobs, object } from '@storybook/addon-knobs/react';
 ```
 
 Em seguida, dentro das estórias do componente `Task`, iremos fornecer `withKnobs` como parâmetro da função `addDecorator()`:
 
 ```javascript
-storiesOf("Task", module)
+storiesOf('Task', module)
   .addDecorator(withKnobs)
   .add(/*...*/);
 ```
@@ -69,17 +69,13 @@ storiesOf("Task", module)
 Finalmente, integramos o tipo `object` do knob na estória "padrão":
 
 ```javascript
-storiesOf("Task", module)
+storiesOf('Task', module)
   .addDecorator(withKnobs)
-  .add("default", () => {
-    return <Task task={object("task", { ...task })} {...actions} />;
+  .add('default', () => {
+    return <Task task={object('task', { ...task })} {...actions} />;
   })
-  .add("pinned", () => (
-    <Task task={{ ...task, state: "TASK_PINNED" }} {...actions} />
-  ))
-  .add("archived", () => (
-    <Task task={{ ...task, state: "TASK_ARCHIVED" }} {...actions} />
-  ));
+  .add('pinned', () => <Task task={{ ...task, state: 'TASK_PINNED' }} {...actions} />)
+  .add('archived', () => <Task task={{ ...task, state: 'TASK_ARCHIVED' }} {...actions} />);
 ```
 
 Tal como se encontra documentado [aqui](https://github.com/storybooks/storybook/tree/master/addons/knobs#object), este tipo aceita uma "etiqueta" e um objeto padrão como parâmetros.
@@ -103,7 +99,7 @@ Devido a facilidade com que é possível testar inputs diferentes podemos descob
   value={title}
   readOnly={true}
   placeholder="Input title"
-  style={{ textOverflow: "ellipsis" }}
+  style={{ textOverflow: 'ellipsis' }}
 />
 ```
 
@@ -119,17 +115,11 @@ Vamos então adicionar uma estória para o caso da ocorrência de um texto grand
 ```javascript
 const longTitle = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not`;
 
-storiesOf("Task", module)
-  .add("default", () => <Task task={task} {...actions} />)
-  .add("pinned", () => (
-    <Task task={{ ...task, state: "TASK_PINNED" }} {...actions} />
-  ))
-  .add("archived", () => (
-    <Task task={{ ...task, state: "TASK_ARCHIVED" }} {...actions} />
-  ))
-  .add("long title", () => (
-    <Task task={{ ...task, title: longTitle }} {...actions} />
-  ));
+storiesOf('Task', module)
+  .add('default', () => <Task task={task} {...actions} />)
+  .add('pinned', () => <Task task={{ ...task, state: 'TASK_PINNED' }} {...actions} />)
+  .add('archived', () => <Task task={{ ...task, state: 'TASK_ARCHIVED' }} {...actions} />)
+  .add('long title', () => <Task task={{ ...task, title: longTitle }} {...actions} />);
 ```
 
 Agora que foi adicionada a estória, podemos reproduzir este caso extremo com relativa facilidade quando for necessário:

--- a/content/intro-to-storybook/react/zh-CN/composite-component.md
+++ b/content/intro-to-storybook/react/zh-CN/composite-component.md
@@ -1,11 +1,11 @@
 ---
-title: "组装复合组件"
-tocTitle: "合成组件"
-description: "使用更简单的组件 组装复合组件"
+title: '组装复合组件'
+tocTitle: '合成组件'
+description: '使用更简单的组件 组装复合组件'
 commit: '8db511e'
 ---
 
-上一章我们构建了第一个组件; 本章 我们学习 扩展构建TaskList的任务列表. 让我们将 组件组合 在一起,看看在引入更多复杂性时会发生什么.
+上一章我们构建了第一个组件; 本章 我们学习 扩展构建 TaskList 的任务列表. 让我们将 组件组合 在一起,看看在引入更多复杂性时会发生什么.
 
 ## 任务列表
 
@@ -13,7 +13,7 @@ Taskbox 通过将 固定任务 置于默认任务之上 来强调 固定任务. 
 
 ![default and pinned tasks](/intro-to-storybook/tasklist-states-1.png)
 
-`Task`可以异步发送数据,我们 **也**需要在没有连接的情况下 loading 渲染 *右图*. 此外,当没有任务时,需要 空状态 *左图*.
+`Task`可以异步发送数据,我们 **也**需要在没有连接的情况下 loading 渲染 _右图_. 此外,当没有任务时,需要 空状态 _左图_.
 
 ![empty and loading tasks](/intro-to-storybook/tasklist-states-2.png)
 
@@ -44,7 +44,9 @@ function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
 
   return (
     <div className="list-items">
-      {tasks.map(task => <Task key={task.id} task={task} {...events} />)}
+      {tasks.map(task => (
+        <Task key={task.id} task={task} {...events} />
+      ))}
     </div>
   );
 }
@@ -83,7 +85,7 @@ storiesOf('TaskList', module)
   .add('empty', () => <TaskList tasks={[]} {...actions} />);
 ```
 
-`addDecorator()`允许我们为每个任务的渲染添加一些"上下文". 在这种情况下,我们在列表周围添加 *填充-padding*,以便更容易进行 可视化验证.
+`addDecorator()`允许我们为每个任务的渲染添加一些"上下文". 在这种情况下,我们在列表周围添加 _填充-padding_,以便更容易进行 可视化验证.
 
 <div class="aside">
 <a href="https://storybook.js.org/addons/introduction/#1-decorators"><b>Decorators-装饰器</b></a> 是一种为 故事 提供任意包装的方法。 在这种情况下，我们使用装饰器来添加样式。 它们还可以用于包装故事在 <b>"providers" - 设置 React上下文 的库组件</b>.
@@ -91,7 +93,7 @@ storiesOf('TaskList', module)
 
 `task`提供一个`Task`的形状,这是通过我们创建和导出的`Task.stories.js`文件. 同样的,`actions`定义`Task`组件期望的操作 (模拟回调) ,其中`TaskList`也需要.
 
-现在查看 Storybook的新内容`TaskList`故事.
+现在查看 Storybook 的新内容`TaskList`故事.
 
 <video autoPlay muted playsInline loop>
   <source
@@ -156,7 +158,9 @@ function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
 
   return (
     <div className="list-items">
-      {tasksInOrder.map(task => <Task key={task.id} task={task} {...events} />)}
+      {tasksInOrder.map(task => (
+        <Task key={task.id} task={task} {...events} />
+      ))}
     </div>
   );
 }
@@ -164,7 +168,7 @@ function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
 export default TaskList;
 ```
 
-添加的标记会产生以下UI:
+添加的标记会产生以下 UI:
 
 <video autoPlay muted playsInline loop>
   <source
@@ -175,9 +179,9 @@ export default TaskList;
 
 请注意列表中 固定项 的位置. 我们希望固定项目在 列表顶部 呈现,以使其成为我们用户的优先事项.
 
-## 数据要求和props
+## 数据要求和 props
 
-随着组件的增长,输入要求也在增长. 要求定义`TaskList`的*props*. 因为`Task`是一个子组件,请确保提供 正确形状的数据 来呈现它. 为了节省时间和头痛,请重用您定义的早期`Task`的propTypes.
+随着组件的增长,输入要求也在增长. 要求定义`TaskList`的*props*. 因为`Task`是一个子组件,请确保提供 正确形状的数据 来呈现它. 为了节省时间和头痛,请重用您定义的早期`Task`的 propTypes.
 
 ```javascript
 import React from 'react';
@@ -204,19 +208,19 @@ export default TaskList;
 
 ## 自动化测试
 
-在上一章中,我们学习了如何使用 Storyshots快照测试 故事. `Task`测试没有太多的复杂性,已然够用了. 而`TaskList`增加了另一层复杂性,我们希望 以 自动测试 的方式验证 某些输入产生某些输出. 为此,我们将使用创建单 元测试[jest-笑话](https://facebook.github.io/jest/)再加上测试渲染器等[Enzyme](http://airbnb.io/enzyme/).
+在上一章中,我们学习了如何使用 Storyshots 快照测试 故事. `Task`测试没有太多的复杂性,已然够用了. 而`TaskList`增加了另一层复杂性,我们希望 以 自动测试 的方式验证 某些输入产生某些输出. 为此,我们将使用创建单 元测试[jest-笑话](https://facebook.github.io/jest/)再加上测试渲染器等[Enzyme](http://airbnb.io/enzyme/).
 
 ![Jest logo](/intro-to-storybook/logo-jest.png)
 
-### 用Jest进行单元测试
+### 用 Jest 进行单元测试
 
- Storybook故事 与 手动可视化测试 和 快照测试 (见上文) 相结合,可以避免 UI错误. 如果故事 涵盖了 各种各样的组件用例,并且我们使用的工具可以确保 人员检查故事的任何变化,那么错误的可能性就大大降低.
+Storybook 故事 与 手动可视化测试 和 快照测试 (见上文) 相结合,可以避免 UI 错误. 如果故事 涵盖了 各种各样的组件用例,并且我们使用的工具可以确保 人员检查故事的任何变化,那么错误的可能性就大大降低.
 
 然而,有时候魔鬼是在细节中. 需要一个明确有关这些细节的测试框架. 这让我们进行了单元测试.
 
-在我们的例子中,我们希望我们的`TaskList`,在传递 不固定tasks 之前,呈现所有固定tasks. 虽然我们有一个故事 (`withPinnedTasks`) 测试这个确切的场景; 但是如果组件停止对 这样的任务 进行排序，那么就人类看着来说，这可能是不明确的,*因为只看到表面与操作*, 这是一个bug. 它肯定不会尖叫 **"错误!"** 直怼眼睛.
+在我们的例子中,我们希望我们的`TaskList`,在传递 不固定 tasks 之前,呈现所有固定 tasks. 虽然我们有一个故事 (`withPinnedTasks`) 测试这个确切的场景; 但是如果组件停止对 这样的任务 进行排序，那么就人类看着来说，这可能是不明确的,_因为只看到表面与操作_, 这是一个 bug. 它肯定不会尖叫 **"错误!"** 直怼眼睛.
 
-因此,为了避免这个问题,我们可以使用Jest 将故事呈现给`DOM`,并运行一些`DOM`查询代码,来验证输出的显着特征.
+因此,为了避免这个问题,我们可以使用 Jest 将故事呈现给`DOM`,并运行一些`DOM`查询代码,来验证输出的显着特征.
 
 创建一个名为的测试文件`TaskList.test.js`. 在这里,我们将构建我们的测试,对输出进行断言.
 
@@ -243,4 +247,4 @@ it('renders pinned tasks at the start of the list', () => {
 
 请注意,我们已经能够重用`withPinnedTasks`故事 和 单元测试中的任务列表;通过这种方式,我们可以继续 以越来越多的方式 利用现有资源 (代表组件的有趣配置的示例) .
 
-另请注意,此测试非常脆弱. 随着项目的成熟,以及项目的确切实现,这都可能是`Task`的更改 - 可能使用 不同的类名或`textarea`而不是一个`input`- 测试将失败,需要更新. 这不一定是一个问题,但使用UI的 单元测试 要小心的指示. 它们不容易维护. 替代的是依靠视觉,快照和视觉回归 (参见[测试章节](/test/)) 的 Storybook测试.
+另请注意,此测试非常脆弱. 随着项目的成熟,以及项目的确切实现,这都可能是`Task`的更改 - 可能使用 不同的类名或`textarea`而不是一个`input`- 测试将失败,需要更新. 这不一定是一个问题,但使用 UI 的 单元测试 要小心的指示. 它们不容易维护. 替代的是依靠视觉,快照和视觉回归 (参见[测试章节](/test/)) 的 Storybook 测试.

--- a/content/intro-to-storybook/react/zh-CN/conclusion.md
+++ b/content/intro-to-storybook/react/zh-CN/conclusion.md
@@ -1,31 +1,31 @@
 ---
-title: "结论"
-tocTitle: "总结"
-description: "把所有的知识汇总以下，学习更多的 storybook 技巧"
+title: '结论'
+tocTitle: '总结'
+description: '把所有的知识汇总以下，学习更多的 storybook 技巧'
 ---
 
-恭喜! 您在Storybook中创建了第一个UI. 在此过程中,您学习了如何构建,组合,测试和部署UI组件. 如果您一直关注,您的 repo和部署的Storybook 应如下所示: 
+恭喜! 您在 Storybook 中创建了第一个 UI. 在此过程中,您学习了如何构建,组合,测试和部署 UI 组件. 如果您一直关注,您的 repo 和部署的 Storybook 应如下所示:
 
-[📕**GitHub回购: hichroma / learnstorybook-code**](https://github.com/chromaui/learnstorybook-code)
+[📕**GitHub 回购: hichroma / learnstorybook-code**](https://github.com/chromaui/learnstorybook-code)
 <br/>
 [🌎**部署 Storybook**](https://clever-banach-415c03.netlify.com/)
 
-Storybook是 React,Vue和Angular 的强大工具. 它拥有蓬勃发展的开发者社区和丰富的插件. 这篇介绍揭示了可能的表面. 我们相信,一旦您采用了Storybook,您将会对构建持久UI的效率印象深刻. 
+Storybook 是 React,Vue 和 Angular 的强大工具. 它拥有蓬勃发展的开发者社区和丰富的插件. 这篇介绍揭示了可能的表面. 我们相信,一旦您采用了 Storybook,您将会对构建持久 UI 的效率印象深刻.
 
 ## 学到更多
 
-想深入了解? 这是有用的资源. 
+想深入了解? 这是有用的资源.
 
--   [**官方 Storybook文档**](https://storybook.js.org/basics/introduction/)有API文档,社区链接和插件库. 
+- [**官方 Storybook 文档**](https://storybook.js.org/basics/introduction/)有 API 文档,社区链接和插件库.
 
--   [**令人愉快的 Storybook工作流程**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07) 重点介绍Squarespace,Major League Soccer,Discovery Network和 Apollo GraphQL 的高速团队使用的工作流程最佳实践. 
+- [**令人愉快的 Storybook 工作流程**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07) 重点介绍 Squarespace,Major League Soccer,Discovery Network 和 Apollo GraphQL 的高速团队使用的工作流程最佳实践.
 
--   [**视觉测试手册**](https://www.chromaticqa.com/book/visual-testing-handbook)深入探讨将 Storybook 用于可视化测试组件. 免费的31页电子书. 
+- [**视觉测试手册**](https://www.chromaticqa.com/book/visual-testing-handbook)深入探讨将 Storybook 用于可视化测试组件. 免费的 31 页电子书.
 
 ## 谁制作了 LearnStorybook.com?
 
 文本,代码和制作都是由[Chroma](http://blog.hichroma.com/). 该教程的灵感来自 Chroma 的流行[GraphQL + React 教程系列](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858).
 
-想要更多这样的教程和文章吗? 注册 Chroma 邮件列表. 
+想要更多这样的教程和文章吗? 注册 Chroma 邮件列表.
 
 <iframe style="height:400px;width:100%;max-width:800px;margin:30px auto;" src="https://upscri.be/bface0?as_embed"></iframe>

--- a/content/intro-to-storybook/react/zh-CN/contribute.md
+++ b/content/intro-to-storybook/react/zh-CN/contribute.md
@@ -1,7 +1,7 @@
 ---
-title: "帮忙帮忙"
-tocTitle: "帮助我们"
-description: "帮助 我们与世界分享 Storybook"
+title: '帮忙帮忙'
+tocTitle: '帮助我们'
+description: '帮助 我们与世界分享 Storybook'
 ---
 
 鼓励学习 Storybook 的贡献! 如果它像 语法或标点符号 那样小,请打开拉取请求. 如果这是一个更大的变化,[添加一个问题](https://github.com/chromaui/learnstorybook.com/issues)讨论.

--- a/content/intro-to-storybook/react/zh-CN/data.md
+++ b/content/intro-to-storybook/react/zh-CN/data.md
@@ -1,22 +1,21 @@
 ---
-title: "连线数据"
-tocTitle: "Data"
-description: "了解如何将数据连接到UI组件"
+title: '连线数据'
+tocTitle: 'Data'
+description: '了解如何将数据连接到UI组件'
 commit: 9c50472
 ---
 
-到目前为止,我们创建了孤立的无状态组件 - Storybook很棒,但作用不大,除非我们在应用程序中为他们提供一些数据. 
+到目前为止,我们创建了孤立的无状态组件 - Storybook 很棒,但作用不大,除非我们在应用程序中为他们提供一些数据.
 
-本教程不关注构建应用程序的细节,因此我们不会在此处深入研究这些细节. 但我们将花点时间研究一下 与容器组件 连接数据 的常见模式. 
+本教程不关注构建应用程序的细节,因此我们不会在此处深入研究这些细节. 但我们将花点时间研究一下 与容器组件 连接数据 的常见模式.
 
 ## 容器组件
 
-我们的`TaskList`目前编写的组件是"表现性的" (见[这篇博文](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0)) 因为它不会与 其自身实现之外 的任何内容交谈. 为了获取数据,我们需要一个"容器". 
+我们的`TaskList`目前编写的组件是"表现性的" (见[这篇博文](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0)) 因为它不会与 其自身实现之外 的任何内容交谈. 为了获取数据,我们需要一个"容器".
 
-这个例子使用[Redux](https://redux.js.org/),最流行的React库,用于存储数据,为我们的应用程序构建一个简单的数据模型. 但是,此处使用的模式同样适用于其他数据管理库[阿波罗](https://www.apollographql.com/client/)和[MobX](https://mobx.js.org/). 
+这个例子使用[Redux](https://redux.js.org/),最流行的 React 库,用于存储数据,为我们的应用程序构建一个简单的数据模型. 但是,此处使用的模式同样适用于其他数据管理库[阿波罗](https://www.apollographql.com/client/)和[MobX](https://mobx.js.org/).
 
-
-首先,我们将构建一个简单的Redux存储,它在一个`src/lib/redux.js`中定义改变任务状态的操作 (故意保持简单) : 
+首先,我们将构建一个简单的 Redux 存储,它在一个`src/lib/redux.js`中定义改变任务状态的操作 (故意保持简单) :
 
 ```javascript
 // 一个简单的 redux store/actions/reducer 实现。
@@ -38,12 +37,12 @@ function taskStateReducer(taskState) {
   return (state, action) => {
     return {
       ...state,
-      tasks: state.tasks.map(
-        task => (task.id === action.id ? { ...task, state: taskState } : task)
+      tasks: state.tasks.map(task =>
+        task.id === action.id ? { ...task, state: taskState } : task
       ),
     };
   };
-};
+}
 
 // reducer描述了 Store 中每个 action 如何改变内容
 
@@ -72,7 +71,7 @@ const defaultTasks = [
 export default createStore(reducer, { tasks: defaultTasks });
 ```
 
-然后我们将更新默认导出`TaskList`组件连接到Redux存储,并呈现我们感兴趣的任务: 
+然后我们将更新默认导出`TaskList`组件连接到 Redux 存储,并呈现我们感兴趣的任务:
 
 ```javascript
 import React from 'react';
@@ -108,10 +107,9 @@ export default connect(
 )(PureTaskList);
 ```
 
-在这个阶段,我们的 Storybook测试将停止工作,因为`TaskList`现在是一个容器,不再需要任何 props,而是连接到 Store 并设置`PureTaskList`包裹组件的props. 
+在这个阶段,我们的 Storybook 测试将停止工作,因为`TaskList`现在是一个容器,不再需要任何 props,而是连接到 Store 并设置`PureTaskList`包裹组件的 props.
 
-
-但是,我们可以通过简单地渲染`PureTaskList`来轻松解决这个问题 - 我们的 Storybook故事中的表现部分: 
+但是,我们可以通过简单地渲染`PureTaskList`来轻松解决这个问题 - 我们的 Storybook 故事中的表现部分:
 
 ```javascript
 import React from 'react';
@@ -149,7 +147,7 @@ storiesOf('TaskList', module)
   />
 </video>
 
-同样,我们需要使用`PureTaskList`在我们的Jest测试中: 
+同样,我们需要使用`PureTaskList`在我们的 Jest 测试中:
 
 ```js
 import React from 'react';

--- a/content/intro-to-storybook/react/zh-CN/deploy.md
+++ b/content/intro-to-storybook/react/zh-CN/deploy.md
@@ -1,7 +1,7 @@
 ---
-title: "发布 Storybook"
-tocTitle: "发布"
-description: "使用 GitHub 和 Netlify 发布 Storybook网站 "
+title: '发布 Storybook'
+tocTitle: '发布'
+description: '使用 GitHub 和 Netlify 发布 Storybook网站 '
 ---
 
 在本教程中,我们在开发机器上运行了 Storybook. 您可能还想与团队分享该 Storybook,尤其是非技术成员. 值得庆幸的是,在线部署 Storybook 很容易.

--- a/content/intro-to-storybook/react/zh-CN/get-started.md
+++ b/content/intro-to-storybook/react/zh-CN/get-started.md
@@ -1,7 +1,7 @@
 ---
-title: "开始吧"
-tocTitle: "从头开始"
-description: "在你的开发环境下, 设置 React Storybook "
+title: '开始吧'
+tocTitle: '从头开始'
+description: '在你的开发环境下, 设置 React Storybook '
 commit: ebe2ae2
 ---
 

--- a/content/intro-to-storybook/react/zh-CN/screen.md
+++ b/content/intro-to-storybook/react/zh-CN/screen.md
@@ -1,7 +1,7 @@
 ---
-title: "构建一个页面"
-tocTitle: "页面"
-description: "用组件构建一个页面"
+title: '构建一个页面'
+tocTitle: '页面'
+description: '用组件构建一个页面'
 commit: e56e345
 ---
 
@@ -14,11 +14,11 @@ commit: e56e345
 由于我们的应用程序非常简单,我们将构建的页面非常简单,只需简单地包装`TaskList`组件 (通过 Redux 提供自己的数据) 在某些布局中并拉出 redux 中顶层`error`的字段 (假设我们在连接到 服务器时遇到问题,我们将设置该字段) . 创建`InboxScreen.js`在你的`components`夹:
 
 ```javascript
-import React from "react";
-import PropTypes from "prop-types";
-import { connect } from "react-redux";
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
-import TaskList from "./TaskList";
+import TaskList from './TaskList';
 
 export function PureInboxScreen({ error }) {
   if (error) {
@@ -46,11 +46,11 @@ export function PureInboxScreen({ error }) {
 }
 
 PureInboxScreen.propTypes = {
-  error: PropTypes.string
+  error: PropTypes.string,
 };
 
 PureInboxScreen.defaultProps = {
-  error: null
+  error: null,
 };
 
 export default connect(({ error }) => ({ error }))(PureInboxScreen);
@@ -59,11 +59,11 @@ export default connect(({ error }) => ({ error }))(PureInboxScreen);
 我们也改变了`App`,用于渲染的组件`InboxScreen` (最终我们会使用路由器来选择正确的页面,但不要在此担心) :
 
 ```javascript
-import React, { Component } from "react";
-import { Provider } from "react-redux";
-import store from "./lib/redux";
+import React, { Component } from 'react';
+import { Provider } from 'react-redux';
+import store from './lib/redux';
 
-import InboxScreen from "./components/InboxScreen";
+import InboxScreen from './components/InboxScreen';
 
 class App extends Component {
   render() {
@@ -87,14 +87,14 @@ export default App;
 但是,对于`PureInboxScreen`我们有一个问题,因为虽然`PureInboxScreen`本身是表现性的,它的孩子,`TaskList`, 不是. 从某种意义上说`PureInboxScreen`被"容器"污染了. 所以,当我们设置我们的故事`InboxScreen.stories.js`:
 
 ```javascript
-import React from "react";
-import { storiesOf } from "@storybook/react";
+import React from 'react';
+import { storiesOf } from '@storybook/react';
 
-import { PureInboxScreen } from "./InboxScreen";
+import { PureInboxScreen } from './InboxScreen';
 
-storiesOf("InboxScreen", module)
-  .add("default", () => <PureInboxScreen />)
-  .add("error", () => <PureInboxScreen error="Something" />);
+storiesOf('InboxScreen', module)
+  .add('default', () => <PureInboxScreen />)
+  .add('error', () => <PureInboxScreen error="Something" />);
 ```
 
 我们看到了虽然如此`error`故事工作得很好,我们`default`故事有一个问题,因为`TaskList`没有要连接的 Redux Store . (在尝试测试时,您也会遇到类似的问题`PureInboxScreen`用单元测试) .
@@ -114,29 +114,29 @@ storiesOf("InboxScreen", module)
 好消息是 Redux Store 很容易提供给 一个`InboxScreen`故事! 我们可以使用 Redux Store 的模拟版本 提供给到装饰器中:
 
 ```javascript
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { action } from "@storybook/addon-actions";
-import { Provider } from "react-redux";
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { Provider } from 'react-redux';
 
-import { PureInboxScreen } from "./InboxScreen";
-import { defaultTasks } from "./TaskList.stories";
+import { PureInboxScreen } from './InboxScreen';
+import { defaultTasks } from './TaskList.stories';
 
 // A super-simple mock of a redux store
 const store = {
   getState: () => {
     return {
-      tasks: defaultTasks
+      tasks: defaultTasks,
     };
   },
   subscribe: () => 0,
-  dispatch: action("dispatch")
+  dispatch: action('dispatch'),
 };
 
-storiesOf("InboxScreen", module)
+storiesOf('InboxScreen', module)
   .addDecorator(story => <Provider store={store}>{story()}</Provider>)
-  .add("default", () => <PureInboxScreen />)
-  .add("error", () => <PureInboxScreen error="Something" />);
+  .add('default', () => <PureInboxScreen />)
+  .add('error', () => <PureInboxScreen error="Something" />);
 ```
 
 存在类似的方法来为其他数据库提供模拟的上下文,例如[阿波罗](https://www.npmjs.com/package/apollo-storybook-decorator),[Relay](https://github.com/orta/react-storybooks-relay-container)和别的.

--- a/content/intro-to-storybook/react/zh-CN/simple-component.md
+++ b/content/intro-to-storybook/react/zh-CN/simple-component.md
@@ -1,33 +1,33 @@
 ---
-title: "构建一个简单的组件"
-tocTitle: "简单 组件"
-description: "单独构建一个简单的组件"
+title: '构建一个简单的组件'
+tocTitle: '简单 组件'
+description: '单独构建一个简单的组件'
 commit: 403f19a
 ---
 
-我们将按照[组件驱动开发](https://blog.hichroma.com/component-driven-development-ce1109d56c8e) (CDD) 方法论来 构建我们的UI. 这是一个从"自下而上"开始构建UI的过程,从组件开始到整个页面结束. CDD 可帮助您在构建UI时,摆列您所面临的复杂程度. 
+我们将按照[组件驱动开发](https://blog.hichroma.com/component-driven-development-ce1109d56c8e) (CDD) 方法论来 构建我们的 UI. 这是一个从"自下而上"开始构建 UI 的过程,从组件开始到整个页面结束. CDD 可帮助您在构建 UI 时,摆列您所面临的复杂程度.
 
 ## 任务-Task
 
 ![Task component in three states](/intro-to-storybook/task-states-learnstorybook.png)
 
-`Task`是我们的应用程序的核心组件. 每个任务的显示略有不同,具体取决于它所处的`状态-state`. 我们显示一个选中 (或未选中) 复选框,一些有关任务的信息,以及一个"pin"按钮,允许我们在列表中上下移动任务. 为了把各个它们摆在一起,我们需要下面的 **props**: 
+`Task`是我们的应用程序的核心组件. 每个任务的显示略有不同,具体取决于它所处的`状态-state`. 我们显示一个选中 (或未选中) 复选框,一些有关任务的信息,以及一个"pin"按钮,允许我们在列表中上下移动任务. 为了把各个它们摆在一起,我们需要下面的 **props**:
 
--   `title` - 描述任务的字符串
+- `title` - 描述任务的字符串
 
--   `state` - 哪个列表是当前的任务,是否已检查?
+- `state` - 哪个列表是当前的任务,是否已检查?
 
-在我们开始构建`Task`时,我们首先编写 与 上面草图中不同类型的任务 相对应的测试状态. 然后我们使用 Storybook 模拟数据 隔离对应状态组件. 我们将"视觉测试"组件在每个状态下的外观. 
+在我们开始构建`Task`时,我们首先编写 与 上面草图中不同类型的任务 相对应的测试状态. 然后我们使用 Storybook 模拟数据 隔离对应状态组件. 我们将"视觉测试"组件在每个状态下的外观.
 
 这个过程类似于[测试驱动的开发(TDD)](https://en.wikipedia.org/wiki/Test-driven_development),我们可以称之为["Visual-虚拟 TDD"](https://blog.hichroma.com/visual-test-driven-development-aec1c98bed87)
 
 ## 获取设置
 
-首先,让我们创建任务组件 及 其附带的 *storybook-故事* 文件: 
+首先,让我们创建任务组件 及 其附带的 _storybook-故事_ 文件:
 
 `src/components/Task.js`和`src/components/Task.stories.js`
 
-我们将从基本实现开始,简单传入我们需要的`属性-props` 以及 您可以对任务执行的两个`on`操作 (在列表之间移动它) : 
+我们将从基本实现开始,简单传入我们需要的`属性-props` 以及 您可以对任务执行的两个`on`操作 (在列表之间移动它) :
 
 ```javascript
 import React from 'react';
@@ -41,10 +41,9 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
 }
 ```
 
-上面,我们基于 Todos应用程序现有HTML结构 为 `Task`提供简单的 markup . 
+上面,我们基于 Todos 应用程序现有 HTML 结构 为 `Task`提供简单的 markup .
 
-下面, 我们在 故事文件中 构建 Task的 三个测试状态: 
-
+下面, 我们在 故事文件中 构建 Task 的 三个测试状态:
 
 ```javascript
 import React from 'react';
@@ -71,28 +70,28 @@ storiesOf('Task', module)
   .add('archived', () => <Task task={{ ...task, state: 'TASK_ARCHIVED' }} {...actions} />);
 ```
 
-Storybook中有两个基本的组织级别. 
+Storybook 中有两个基本的组织级别.
 
-该组件 及 其 child 故事. 
+该组件 及 其 child 故事.
 
-将每个故事 视为组件的排列. 您可以根据需要为每个组件 创建 尽可能多的故事. 
+将每个故事 视为组件的排列. 您可以根据需要为每个组件 创建 尽可能多的故事.
 
--   **组件**
-    -   故事
-    -   故事
-    -   故事
+- **组件**
+  - 故事
+  - 故事
+  - 故事
 
-要开始 Storybook,我们先运`行 注册组件的`storiesOf()`函数. 我们为组件添加 *显示名称 -  Storybook应用程序侧栏上显示的名称*. 
+要开始 Storybook,我们先运`行 注册组件的`storiesOf()`函数. 我们为组件添加 _显示名称 - Storybook 应用程序侧栏上显示的名称_.
 
-`action()`允许我们创建一个回调, 当在Storybook UI的面板中 单击这个 **action** 时 回调触发. 因此,当我们构建一个pin按钮 时,我们将能够在 测试UI中 确定按钮单击 是否成功. 
+`action()`允许我们创建一个回调, 当在 Storybook UI 的面板中 单击这个 **action** 时 回调触发. 因此,当我们构建一个 pin 按钮 时,我们将能够在 测试 UI 中 确定按钮单击 是否成功.
 
-由于我们需要将 相同的一组操作 传递给 组件的所有排列,因此将它们捆绑到`actions`变量 并 使用React`{...actions}`的`porps`扩展以立即传递它们. `<Task {...actions}>`相当于`<Task onPinTask={actions.onPinTask} onArchiveTask={actions.onArchiveTask}>`. 
+由于我们需要将 相同的一组操作 传递给 组件的所有排列,因此将它们捆绑到`actions`变量 并 使用 React`{...actions}`的`porps`扩展以立即传递它们. `<Task {...actions}>`相当于`<Task onPinTask={actions.onPinTask} onArchiveTask={actions.onArchiveTask}>`.
 
-关于捆绑`actions`的另一个好处就是,你可以`export-暴露`它们,用于重用该组件的组件,我们稍后会看到. 
+关于捆绑`actions`的另一个好处就是,你可以`export-暴露`它们,用于重用该组件的组件,我们稍后会看到.
 
-为了定义我们的故事,我们用`add()`,一次一个为我们的每个测试状态生成一个故事. `add`第二个参数是一个函数,它返回一个给定状态的渲染元素 (即带有一组`props`的组件类)  - 就像一个React[无状态功能组件](https://reactjs.org/docs/components-and-props.html). 
+为了定义我们的故事,我们用`add()`,一次一个为我们的每个测试状态生成一个故事. `add`第二个参数是一个函数,它返回一个给定状态的渲染元素 (即带有一组`props`的组件类) - 就像一个 React[无状态功能组件](https://reactjs.org/docs/components-and-props.html).
 
-在创建故事时,我们使用基本任务 (`task`) 构建组件期望的 任务的形状. 这通常是 根据真实数据的模型建模的. 再次,正如我们所看到的,`export`这种形状将使我们能够在以后的故事中重复使用它. 
+在创建故事时,我们使用基本任务 (`task`) 构建组件期望的 任务的形状. 这通常是 根据真实数据的模型建模的. 再次,正如我们所看到的,`export`这种形状将使我们能够在以后的故事中重复使用它.
 
 <div class="aside">
 <a href="https://storybook.js.org/addons/introduction/#2-native-addons"><b>Actions</b></a> 帮助您在隔离构建UI组件时 验证交互. 通常，您无法访问应用程序上下文中的函数和状态。 使用 <code>action()</code> 将它们存入.
@@ -100,7 +99,7 @@ Storybook中有两个基本的组织级别.
 
 ## 配置
 
-我们还必须对 Storybook的配置设置 (`.storybook/config.js`) 做一个小改动,让它注意到我们的`.stories.js`文件并使用我们的CSS文件. 默认情况下, Storybook 会查找故事`/stories`目录; 本教程使用类似于`.test.js`的命名方案, 这个命令是 **CRA** 赞成的用于自动化测试的方案. 
+我们还必须对 Storybook 的配置设置 (`.storybook/config.js`) 做一个小改动,让它注意到我们的`.stories.js`文件并使用我们的 CSS 文件. 默认情况下, Storybook 会查找故事`/stories`目录; 本教程使用类似于`.test.js`的命名方案, 这个命令是 **CRA** 赞成的用于自动化测试的方案.
 
 ```javascript
 import { configure } from '@storybook/react';
@@ -115,7 +114,7 @@ function loadStories() {
 configure(loadStories, module);
 ```
 
-完成此操作后,重新启动 Storybook服务器 应该会产生 三个任务状态的测试用例: 
+完成此操作后,重新启动 Storybook 服务器 应该会产生 三个任务状态的测试用例:
 
 <video autoPlay muted playsInline controls >
   <source
@@ -126,9 +125,9 @@ configure(loadStories, module);
 
 ## 建立状态
 
-现在我们有 Storybook设置,导入的样式和构建的测试用例,我们可以快速开始实现组件的HTML,以匹配设计. 
+现在我们有 Storybook 设置,导入的样式和构建的测试用例,我们可以快速开始实现组件的 HTML,以匹配设计.
 
-该组件目前仍然是基本的. 首先编写实现设计的代码,不用过多细节: 
+该组件目前仍然是基本的. 首先编写实现设计的代码,不用过多细节:
 
 ```javascript
 import React from 'react';
@@ -161,7 +160,7 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
 }
 ```
 
-上面的附加 markup 与我们之前导入的CSS相结合,产生以下UI: 
+上面的附加 markup 与我们之前导入的 CSS 相结合,产生以下 UI:
 
 <video autoPlay muted playsInline loop>
   <source
@@ -172,7 +171,7 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
 
 ## 特别数据要求
 
-最好的做法是`propTypes`在React中 指定组件所需的 数据形状. 它不仅可以自我记录,还有助于及早发现问题. 
+最好的做法是`propTypes`在 React 中 指定组件所需的 数据形状. 它不仅可以自我记录,还有助于及早发现问题.
 
 ```javascript
 import React from 'react';
@@ -195,7 +194,7 @@ Task.propTypes = {
 export default Task;
 ```
 
-现在,如果任务组件被滥用,则会出现开发警告. 
+现在,如果任务组件被滥用,则会出现开发警告.
 
 <div class="aside">
 另一种实现方法是使用 类似TypeScript的JavaScript类型系统 来为组件属性 创建类型。
@@ -203,41 +202,41 @@ export default Task;
 
 ## 组件构建!
 
-我们现在已成功构建了一个组件,没用到服务器或运行整个前端应用程序. 下一步是以类似的方式逐个构建剩余的 Taskbox组件. 
+我们现在已成功构建了一个组件,没用到服务器或运行整个前端应用程序. 下一步是以类似的方式逐个构建剩余的 Taskbox 组件.
 
-如您所见,开始单独构建组件非常简单快捷. 我们可以期望生成更高质量的UI,减少错误和更多打磨,因为它可以挖掘并测试每个可能的状态. 
+如您所见,开始单独构建组件非常简单快捷. 我们可以期望生成更高质量的 UI,减少错误和更多打磨,因为它可以挖掘并测试每个可能的状态.
 
 ## 自动化测试
 
- Storybook 为我们提供了一种在施工期间,`可视化`测试我们的应用程序.在我们继续开发应用程序时,"故事"将有助于确保我们不会在视觉上打破我们的任务. 
- 但是,在这个阶段,这是一个完全手动的过程,有人必须努力点击每个测试状态,并确保它呈现良好且没有错误或警告. 
- 我们不能自动这样做吗?
+Storybook 为我们提供了一种在施工期间,`可视化`测试我们的应用程序.在我们继续开发应用程序时,"故事"将有助于确保我们不会在视觉上打破我们的任务.
+但是,在这个阶段,这是一个完全手动的过程,有人必须努力点击每个测试状态,并确保它呈现良好且没有错误或警告.
+我们不能自动这样做吗?
 
 ### 快照测试
 
-快照测试是指,记录 带一定输入的组件的"已知良好"输出,然后,将来 输出发生变化时标记组件 的做法. 
-这补充了 Storybook,因为快照 是查看 组件新版本 并 检查更改的快速方法. 
+快照测试是指,记录 带一定输入的组件的"已知良好"输出,然后,将来 输出发生变化时标记组件 的做法.
+这补充了 Storybook,因为快照 是查看 组件新版本 并 检查更改的快速方法.
 
 <div class="aside">
 确保您的组件呈现 <b>不变</b> 的数据，以便每次快照测试都不会失败。 注意日期或随机生成的值等内容。
 </div>
 
-需要[Storyshots 插件](https://github.com/storybooks/storybook/tree/master/addons/storyshots)为每个故事创建 快照测试. 
-通过添加开发依赖项来使用它: 
+需要[Storyshots 插件](https://github.com/storybooks/storybook/tree/master/addons/storyshots)为每个故事创建 快照测试.
+通过添加开发依赖项来使用它:
 
 ```bash
 yarn add --dev @storybook/addon-storyshots react-test-renderer
 ```
 
-然后创建一个`src/storybook.test.js`文件中包含以下内容: 
+然后创建一个`src/storybook.test.js`文件中包含以下内容:
 
 ```javascript
 import initStoryshots from '@storybook/addon-storyshots';
 initStoryshots();
 ```
 
-完成上述操作后,我们就可以运行了`yarn test`并看到以下输出: 
+完成上述操作后,我们就可以运行了`yarn test`并看到以下输出:
 
 ![Task test runner](/intro-to-storybook/task-testrunner.png)
 
-我们现在为每个`Task`故事进行快照测试. 如果我们改变了`Task`的实现,我们会提示您验证更改. 
+我们现在为每个`Task`故事进行快照测试. 如果我们改变了`Task`的实现,我们会提示您验证更改.

--- a/content/intro-to-storybook/react/zh-CN/test.md
+++ b/content/intro-to-storybook/react/zh-CN/test.md
@@ -1,7 +1,7 @@
 ---
-title: "测试 UI 组件"
-tocTitle: "测试"
-description: "了解测试UI组件的方法"
+title: '测试 UI 组件'
+tocTitle: '测试'
+description: '了解测试UI组件的方法'
 commit: 78a45d1
 ---
 
@@ -65,13 +65,13 @@ yarn add storybook-chromatic
 导入 Chromatic 到你的`.storybook/config.js`文件.
 
 ```javascript
-import { configure } from "@storybook/react";
-import requireContext from "require-context.macro";
-import "storybook-chromatic";
+import { configure } from '@storybook/react';
+import requireContext from 'require-context.macro';
+import 'storybook-chromatic';
 
-import "../src/index.css";
+import '../src/index.css';
 
-const req = requireContext("../src/components", true, /\.stories\.js$/);
+const req = requireContext('../src/components', true, /\.stories\.js$/);
 
 function loadStories() {
   req.keys().forEach(filename => req(filename));

--- a/content/intro-to-storybook/react/zh-TW/composite-component.md
+++ b/content/intro-to-storybook/react/zh-TW/composite-component.md
@@ -1,11 +1,11 @@
 ---
-title: "組裝複合元件"
-tocTitle: "合成元件"
-description: "使用更簡單的元件 組裝複合元件"
+title: '組裝複合元件'
+tocTitle: '合成元件'
+description: '使用更簡單的元件 組裝複合元件'
 commit: '8db511e'
 ---
 
-上一章我們構建了第一個元件; 本章 我們學習 擴充套件構建TaskList的任務列表. 讓我們將 元件組合 在一起,看看在引入更多複雜性時會發生什麼.
+上一章我們構建了第一個元件; 本章 我們學習 擴充套件構建 TaskList 的任務列表. 讓我們將 元件組合 在一起,看看在引入更多複雜性時會發生什麼.
 
 ## 任務列表
 
@@ -13,7 +13,7 @@ Taskbox 通過將 固定任務 置於預設任務之上 來強調 固定任務. 
 
 ![default and pinned tasks](/intro-to-storybook/tasklist-states-1.png)
 
-`Task`可以非同步傳送資料,我們 **也**需要在沒有連線的情況下 loading 渲染 *右圖*. 此外,當沒有任務時,需要 空狀態 *左圖*.
+`Task`可以非同步傳送資料,我們 **也**需要在沒有連線的情況下 loading 渲染 _右圖_. 此外,當沒有任務時,需要 空狀態 _左圖_.
 
 ![empty and loading tasks](/intro-to-storybook/tasklist-states-2.png)
 
@@ -44,7 +44,9 @@ function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
 
   return (
     <div className="list-items">
-      {tasks.map(task => <Task key={task.id} task={task} {...events} />)}
+      {tasks.map(task => (
+        <Task key={task.id} task={task} {...events} />
+      ))}
     </div>
   );
 }
@@ -83,7 +85,7 @@ storiesOf('TaskList', module)
   .add('empty', () => <TaskList tasks={[]} {...actions} />);
 ```
 
-`addDecorator()`允許我們為每個任務的渲染新增一些"上下文". 在這種情況下,我們在列表周圍新增 *填充-padding*,以便更容易進行 視覺化驗證.
+`addDecorator()`允許我們為每個任務的渲染新增一些"上下文". 在這種情況下,我們在列表周圍新增 _填充-padding_,以便更容易進行 視覺化驗證.
 
 <div class="aside">
 <a href="https://storybook.js.org/addons/introduction/#1-decorators"><b>Decorators-裝飾器</b></a> 是一種為 故事 提供任意包裝的方法。 在這種情況下，我們使用裝飾器來新增樣式。 它們還可以用於包裝故事在 <b>"providers" - 設定 React上下文 的庫元件</b>.
@@ -91,7 +93,7 @@ storiesOf('TaskList', module)
 
 `task`提供一個`Task`的形狀,這是通過我們建立和匯出的`Task.stories.js`檔案. 同樣的,`actions`定義`Task`元件期望的操作 (模擬回撥) ,其中`TaskList`也需要.
 
-現在檢視 Storybook的新內容`TaskList`故事.
+現在檢視 Storybook 的新內容`TaskList`故事.
 
 <video autoPlay muted playsInline loop>
   <source
@@ -156,7 +158,9 @@ function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
 
   return (
     <div className="list-items">
-      {tasksInOrder.map(task => <Task key={task.id} task={task} {...events} />)}
+      {tasksInOrder.map(task => (
+        <Task key={task.id} task={task} {...events} />
+      ))}
     </div>
   );
 }
@@ -164,7 +168,7 @@ function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
 export default TaskList;
 ```
 
-新增的標記會產生以下UI:
+新增的標記會產生以下 UI:
 
 <video autoPlay muted playsInline loop>
   <source
@@ -175,9 +179,9 @@ export default TaskList;
 
 請注意列表中 固定項 的位置. 我們希望固定專案在 列表頂部 呈現,以使其成為我們使用者的優先事項.
 
-## 資料要求和props
+## 資料要求和 props
 
-隨著元件的增長,輸入要求也在增長. 要求定義`TaskList`的*props*. 因為`Task`是一個子元件,請確保提供 正確形狀的資料 來呈現它. 為了節省時間和頭痛,請重用您定義的早期`Task`的propTypes.
+隨著元件的增長,輸入要求也在增長. 要求定義`TaskList`的*props*. 因為`Task`是一個子元件,請確保提供 正確形狀的資料 來呈現它. 為了節省時間和頭痛,請重用您定義的早期`Task`的 propTypes.
 
 ```javascript
 import React from 'react';
@@ -204,19 +208,19 @@ export default TaskList;
 
 ## 自動化測試
 
-在上一章中,我們學習瞭如何使用 Storyshots快照測試 故事. `Task`測試沒有太多的複雜性,已然夠用了. 而`TaskList`增加了另一層複雜性,我們希望 以 自動測試 的方式驗證 某些輸入產生某些輸出. 為此,我們將使用建立單 元測試[jest-笑話](https://facebook.github.io/jest/)再加上測試渲染器等[Enzyme](http://airbnb.io/enzyme/).
+在上一章中,我們學習瞭如何使用 Storyshots 快照測試 故事. `Task`測試沒有太多的複雜性,已然夠用了. 而`TaskList`增加了另一層複雜性,我們希望 以 自動測試 的方式驗證 某些輸入產生某些輸出. 為此,我們將使用建立單 元測試[jest-笑話](https://facebook.github.io/jest/)再加上測試渲染器等[Enzyme](http://airbnb.io/enzyme/).
 
 ![Jest logo](/intro-to-storybook/logo-jest.png)
 
-### 用Jest進行單元測試
+### 用 Jest 進行單元測試
 
- Storybook故事 與 手動視覺化測試 和 快照測試 (見上文) 相結合,可以避免 UI錯誤. 如果故事 涵蓋了 各種各樣的元件用例,並且我們使用的工具可以確保 人員檢查故事的任何變化,那麼錯誤的可能性就大大降低.
+Storybook 故事 與 手動視覺化測試 和 快照測試 (見上文) 相結合,可以避免 UI 錯誤. 如果故事 涵蓋了 各種各樣的元件用例,並且我們使用的工具可以確保 人員檢查故事的任何變化,那麼錯誤的可能性就大大降低.
 
 然而,有時候魔鬼是在細節中. 需要一個明確有關這些細節的測試框架. 這讓我們進行了單元測試.
 
-在我們的例子中,我們希望我們的`TaskList`,在傳遞 不固定tasks 之前,呈現所有固定tasks. 雖然我們有一個故事 (`withPinnedTasks`) 測試這個確切的場景; 但是如果元件停止對 這樣的任務 進行排序，那麼就人類看著來說，這可能是不明確的,*因為只看到表面與操作*, 這是一個bug. 它肯定不會尖叫 **"錯誤!"** 直懟眼睛.
+在我們的例子中,我們希望我們的`TaskList`,在傳遞 不固定 tasks 之前,呈現所有固定 tasks. 雖然我們有一個故事 (`withPinnedTasks`) 測試這個確切的場景; 但是如果元件停止對 這樣的任務 進行排序，那麼就人類看著來說，這可能是不明確的,_因為只看到表面與操作_, 這是一個 bug. 它肯定不會尖叫 **"錯誤!"** 直懟眼睛.
 
-因此,為了避免這個問題,我們可以使用Jest 將故事呈現給`DOM`,並執行一些`DOM`查詢程式碼,來驗證輸出的顯著特徵.
+因此,為了避免這個問題,我們可以使用 Jest 將故事呈現給`DOM`,並執行一些`DOM`查詢程式碼,來驗證輸出的顯著特徵.
 
 建立一個名為的測試檔案`TaskList.test.js`. 在這裡,我們將構建我們的測試,對輸出進行斷言.
 
@@ -243,4 +247,4 @@ it('renders pinned tasks at the start of the list', () => {
 
 請注意,我們已經能夠重用`withPinnedTasks`故事 和 單元測試中的任務列表;通過這種方式,我們可以繼續 以越來越多的方式 利用現有資源 (代表元件的有趣配置的示例) .
 
-另請注意,此測試非常脆弱. 隨著專案的成熟,以及專案的確切實現,這都可能是`Task`的更改 - 可能使用 不同的類名或`textarea`而不是一個`input`- 測試將失敗,需要更新. 這不一定是一個問題,但使用UI的 單元測試 要小心的指示. 它們不容易維護. 替代的是依靠視覺,快照和視覺迴歸 (參見[測試章節](/test/)) 的 Storybook測試. 
+另請注意,此測試非常脆弱. 隨著專案的成熟,以及專案的確切實現,這都可能是`Task`的更改 - 可能使用 不同的類名或`textarea`而不是一個`input`- 測試將失敗,需要更新. 這不一定是一個問題,但使用 UI 的 單元測試 要小心的指示. 它們不容易維護. 替代的是依靠視覺,快照和視覺迴歸 (參見[測試章節](/test/)) 的 Storybook 測試.

--- a/content/intro-to-storybook/react/zh-TW/conclusion.md
+++ b/content/intro-to-storybook/react/zh-TW/conclusion.md
@@ -1,26 +1,26 @@
 ---
-title: "結論"
-tocTitle: "總結"
-description: "把所有的知識彙總以下，學習更多的 storybook 技巧"
+title: '結論'
+tocTitle: '總結'
+description: '把所有的知識彙總以下，學習更多的 storybook 技巧'
 ---
 
-恭喜! 您在Storybook中建立了第一個UI. 在此過程中,您學習瞭如何構建,組合,測試和部署UI元件. 如果您一直關注,您的 repo和部署的Storybook 應如下所示:
+恭喜! 您在 Storybook 中建立了第一個 UI. 在此過程中,您學習瞭如何構建,組合,測試和部署 UI 元件. 如果您一直關注,您的 repo 和部署的 Storybook 應如下所示:
 
-[📕**GitHub回購: hichroma / learnstorybook-code**](https://github.com/chromaui/learnstorybook-code)
+[📕**GitHub 回購: hichroma / learnstorybook-code**](https://github.com/chromaui/learnstorybook-code)
 <br/>
 [🌎**部署 Storybook**](https://clever-banach-415c03.netlify.com/)
 
-Storybook是 React,Vue和Angular 的強大工具. 它擁有蓬勃發展的開發者社群和豐富的外掛. 這篇介紹揭示了可能的表面. 我們相信,一旦您採用了Storybook,您將會對構建持久UI的效率印象深刻.
+Storybook 是 React,Vue 和 Angular 的強大工具. 它擁有蓬勃發展的開發者社群和豐富的外掛. 這篇介紹揭示了可能的表面. 我們相信,一旦您採用了 Storybook,您將會對構建持久 UI 的效率印象深刻.
 
 ## 學到更多
 
 想深入瞭解? 這是有用的資源.
 
--   [**官方 Storybook文件**](https://storybook.js.org/basics/introduction/)有API文件,社群連結和外掛庫.
+- [**官方 Storybook 文件**](https://storybook.js.org/basics/introduction/)有 API 文件,社群連結和外掛庫.
 
--   [**令人愉快的 Storybook工作流程**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07) 重點介紹Squarespace,Major League Soccer,Discovery Network和 Apollo GraphQL 的高速團隊使用的工作流程最佳實踐.
+- [**令人愉快的 Storybook 工作流程**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07) 重點介紹 Squarespace,Major League Soccer,Discovery Network 和 Apollo GraphQL 的高速團隊使用的工作流程最佳實踐.
 
--   [**視覺測試手冊**](https://www.chromaticqa.com/book/visual-testing-handbook)深入探討將 Storybook 用於視覺化測試元件. 免費的31頁電子書.
+- [**視覺測試手冊**](https://www.chromaticqa.com/book/visual-testing-handbook)深入探討將 Storybook 用於視覺化測試元件. 免費的 31 頁電子書.
 
 ## 誰製作了 LearnStorybook.com?
 

--- a/content/intro-to-storybook/react/zh-TW/contribute.md
+++ b/content/intro-to-storybook/react/zh-TW/contribute.md
@@ -1,7 +1,7 @@
 ---
-title: "幫忙幫忙"
-tocTitle: "幫助我們"
-description: "幫助 我們與世界分享 Storybook "
+title: '幫忙幫忙'
+tocTitle: '幫助我們'
+description: '幫助 我們與世界分享 Storybook '
 ---
 
 鼓勵學習 Storybook 的貢獻! 如果它像 語法或標點符號 那樣小,請開啟拉取請求. 如果這是一個更大的變化,[新增一個問題](https://github.com/chromaui/learnstorybook.com/issues)討論.

--- a/content/intro-to-storybook/react/zh-TW/data.md
+++ b/content/intro-to-storybook/react/zh-TW/data.md
@@ -1,22 +1,21 @@
 ---
-title: "连线数据"
-tocTitle: "Data"
-description: "了解如何将数据连接到UI组件"
+title: '连线数据'
+tocTitle: 'Data'
+description: '了解如何将数据连接到UI组件'
 commit: 9c50472
 ---
 
-到目前为止,我们创建了孤立的无状态组件 - Storybook很棒,但作用不大,除非我们在应用程序中为他们提供一些数据. 
+到目前为止,我们创建了孤立的无状态组件 - Storybook 很棒,但作用不大,除非我们在应用程序中为他们提供一些数据.
 
-本教程不关注构建应用程序的细节,因此我们不会在此处深入研究这些细节. 但我们将花点时间研究一下 与容器组件 连接数据 的常见模式. 
+本教程不关注构建应用程序的细节,因此我们不会在此处深入研究这些细节. 但我们将花点时间研究一下 与容器组件 连接数据 的常见模式.
 
 ## 容器组件
 
-我们的`TaskList`目前编写的组件是"表现性的" (见[这篇博文](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0)) 因为它不会与 其自身实现之外 的任何内容交谈. 为了获取数据,我们需要一个"容器". 
+我们的`TaskList`目前编写的组件是"表现性的" (见[这篇博文](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0)) 因为它不会与 其自身实现之外 的任何内容交谈. 为了获取数据,我们需要一个"容器".
 
-这个例子使用[Redux](https://redux.js.org/),最流行的React库,用于存储数据,为我们的应用程序构建一个简单的数据模型. 但是,此处使用的模式同样适用于其他数据管理库[阿波罗](https://www.apollographql.com/client/)和[MobX](https://mobx.js.org/). 
+这个例子使用[Redux](https://redux.js.org/),最流行的 React 库,用于存储数据,为我们的应用程序构建一个简单的数据模型. 但是,此处使用的模式同样适用于其他数据管理库[阿波罗](https://www.apollographql.com/client/)和[MobX](https://mobx.js.org/).
 
-
-首先,我们将构建一个简单的Redux存储,它在一个`src/lib/redux.js`中定义改变任务状态的操作 (故意保持简单) : 
+首先,我们将构建一个简单的 Redux 存储,它在一个`src/lib/redux.js`中定义改变任务状态的操作 (故意保持简单) :
 
 ```javascript
 // 一个简单的 redux store/actions/reducer 实现。
@@ -38,12 +37,12 @@ function taskStateReducer(taskState) {
   return (state, action) => {
     return {
       ...state,
-      tasks: state.tasks.map(
-        task => (task.id === action.id ? { ...task, state: taskState } : task)
+      tasks: state.tasks.map(task =>
+        task.id === action.id ? { ...task, state: taskState } : task
       ),
     };
   };
-};
+}
 
 // reducer描述了 Store 中每个 action 如何改变内容
 
@@ -72,7 +71,7 @@ const defaultTasks = [
 export default createStore(reducer, { tasks: defaultTasks });
 ```
 
-然后我们将更新默认导出`TaskList`组件连接到Redux存储,并呈现我们感兴趣的任务: 
+然后我们将更新默认导出`TaskList`组件连接到 Redux 存储,并呈现我们感兴趣的任务:
 
 ```javascript
 import React from 'react';
@@ -108,10 +107,9 @@ export default connect(
 )(PureTaskList);
 ```
 
-在这个阶段,我们的 Storybook测试将停止工作,因为`TaskList`现在是一个容器,不再需要任何 props,而是连接到 Store 并设置`PureTaskList`包裹组件的props. 
+在这个阶段,我们的 Storybook 测试将停止工作,因为`TaskList`现在是一个容器,不再需要任何 props,而是连接到 Store 并设置`PureTaskList`包裹组件的 props.
 
-
-但是,我们可以通过简单地渲染`PureTaskList`来轻松解决这个问题 - 我们的 Storybook故事中的表现部分: 
+但是,我们可以通过简单地渲染`PureTaskList`来轻松解决这个问题 - 我们的 Storybook 故事中的表现部分:
 
 ```javascript
 import React from 'react';
@@ -149,7 +147,7 @@ storiesOf('TaskList', module)
   />
 </video>
 
-同样,我们需要使用`PureTaskList`在我们的Jest测试中: 
+同样,我们需要使用`PureTaskList`在我们的 Jest 测试中:
 
 ```js
 import React from 'react';

--- a/content/intro-to-storybook/react/zh-TW/deploy.md
+++ b/content/intro-to-storybook/react/zh-TW/deploy.md
@@ -1,7 +1,7 @@
 ---
-title: "部署 Storybook"
-tocTitle: "发布"
-description: "使用 GitHub 和 Netlify 发布 Storybook网站 "
+title: '部署 Storybook'
+tocTitle: '发布'
+description: '使用 GitHub 和 Netlify 发布 Storybook网站 '
 ---
 
 在本教程中,我们在开发机器上运行了 Storybook. 您可能还想与团队分享该 Storybook,尤其是非技术成员. 值得庆幸的是,在线部署 Storybook 很容易.

--- a/content/intro-to-storybook/react/zh-TW/get-started.md
+++ b/content/intro-to-storybook/react/zh-TW/get-started.md
@@ -1,7 +1,7 @@
 ---
-title: "開始吧"
-tocTitle: "從頭開始"
-description: "在你的開發環境下, 設定 React Storybook "
+title: '開始吧'
+tocTitle: '從頭開始'
+description: '在你的開發環境下, 設定 React Storybook '
 commit: ebe2ae2
 ---
 

--- a/content/intro-to-storybook/react/zh-TW/screen.md
+++ b/content/intro-to-storybook/react/zh-TW/screen.md
@@ -1,7 +1,7 @@
 ---
-title: "構建一個頁面"
-tocTitle: "頁面"
-description: "用元件構建一個頁面"
+title: '構建一個頁面'
+tocTitle: '頁面'
+description: '用元件構建一個頁面'
 commit: e56e345
 ---
 
@@ -14,11 +14,11 @@ commit: e56e345
 由於我們的應用程式非常簡單,我們將構建的頁面非常簡單,只需簡單地包裝`TaskList`元件 (通過 Redux 提供自己的資料) 在某些佈局中並拉出 redux 中頂層`error`的欄位 (假設我們在連線到 伺服器時遇到問題,我們將設定該欄位) . 建立`InboxScreen.js`在你的`components`夾:
 
 ```javascript
-import React from "react";
-import PropTypes from "prop-types";
-import { connect } from "react-redux";
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
-import TaskList from "./TaskList";
+import TaskList from './TaskList';
 
 export function PureInboxScreen({ error }) {
   if (error) {
@@ -46,11 +46,11 @@ export function PureInboxScreen({ error }) {
 }
 
 PureInboxScreen.propTypes = {
-  error: PropTypes.string
+  error: PropTypes.string,
 };
 
 PureInboxScreen.defaultProps = {
-  error: null
+  error: null,
 };
 
 export default connect(({ error }) => ({ error }))(PureInboxScreen);
@@ -59,11 +59,11 @@ export default connect(({ error }) => ({ error }))(PureInboxScreen);
 我們也改變了`App`,用於渲染的元件`InboxScreen` (最終我們會使用路由器來選擇正確的頁面,但不要在此擔心) :
 
 ```javascript
-import React, { Component } from "react";
-import { Provider } from "react-redux";
-import store from "./lib/redux";
+import React, { Component } from 'react';
+import { Provider } from 'react-redux';
+import store from './lib/redux';
 
-import InboxScreen from "./components/InboxScreen";
+import InboxScreen from './components/InboxScreen';
 
 class App extends Component {
   render() {
@@ -87,14 +87,14 @@ export default App;
 但是,對於`PureInboxScreen`我們有一個問題,因為雖然`PureInboxScreen`本身是表現性的,它的孩子,`TaskList`, 不是. 從某種意義上說`PureInboxScreen`被"容器"汙染了. 所以,當我們設定我們的故事`InboxScreen.stories.js`:
 
 ```javascript
-import React from "react";
-import { storiesOf } from "@storybook/react";
+import React from 'react';
+import { storiesOf } from '@storybook/react';
 
-import { PureInboxScreen } from "./InboxScreen";
+import { PureInboxScreen } from './InboxScreen';
 
-storiesOf("InboxScreen", module)
-  .add("default", () => <PureInboxScreen />)
-  .add("error", () => <PureInboxScreen error="Something" />);
+storiesOf('InboxScreen', module)
+  .add('default', () => <PureInboxScreen />)
+  .add('error', () => <PureInboxScreen error="Something" />);
 ```
 
 我們看到了雖然如此`error`故事工作得很好,我們`default`故事有一個問題,因為`TaskList`沒有要連線的 Redux Store . (在嘗試測試時,您也會遇到類似的問題`PureInboxScreen`用單元測試) .
@@ -114,29 +114,29 @@ storiesOf("InboxScreen", module)
 好訊息是 Redux Store 很容易提供給 一個`InboxScreen`故事! 我們可以使用 Redux Store 的模擬版本 提供給到裝飾器中:
 
 ```javascript
-import React from "react";
-import { storiesOf } from "@storybook/react";
-import { action } from "@storybook/addon-actions";
-import { Provider } from "react-redux";
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { Provider } from 'react-redux';
 
-import { PureInboxScreen } from "./InboxScreen";
-import { defaultTasks } from "./TaskList.stories";
+import { PureInboxScreen } from './InboxScreen';
+import { defaultTasks } from './TaskList.stories';
 
 // A super-simple mock of a redux store
 const store = {
   getState: () => {
     return {
-      tasks: defaultTasks
+      tasks: defaultTasks,
     };
   },
   subscribe: () => 0,
-  dispatch: action("dispatch")
+  dispatch: action('dispatch'),
 };
 
-storiesOf("InboxScreen", module)
+storiesOf('InboxScreen', module)
   .addDecorator(story => <Provider store={store}>{story()}</Provider>)
-  .add("default", () => <PureInboxScreen />)
-  .add("error", () => <PureInboxScreen error="Something" />);
+  .add('default', () => <PureInboxScreen />)
+  .add('error', () => <PureInboxScreen error="Something" />);
 ```
 
 存在類似的方法來為其他資料庫提供模擬的上下文,例如[阿波羅](https://www.npmjs.com/package/apollo-storybook-decorator),[Relay](https://github.com/orta/react-storybooks-relay-container)和別的.

--- a/content/intro-to-storybook/react/zh-TW/simple-component.md
+++ b/content/intro-to-storybook/react/zh-TW/simple-component.md
@@ -1,11 +1,11 @@
 ---
-title: "構建一個簡單的元件"
-tocTitle: "簡單 元件"
-description: "單獨構建一個簡單的元件"
+title: '構建一個簡單的元件'
+tocTitle: '簡單 元件'
+description: '單獨構建一個簡單的元件'
 commit: 403f19a
 ---
 
-我們將按照[元件驅動開發](https://blog.hichroma.com/component-driven-development-ce1109d56c8e) (CDD) 方法論來 構建我們的UI. 這是一個從"自下而上"開始構建UI的過程,從元件開始到整個頁面結束. CDD 可幫助您在構建UI時,擺列您所面臨的複雜程度.
+我們將按照[元件驅動開發](https://blog.hichroma.com/component-driven-development-ce1109d56c8e) (CDD) 方法論來 構建我們的 UI. 這是一個從"自下而上"開始構建 UI 的過程,從元件開始到整個頁面結束. CDD 可幫助您在構建 UI 時,擺列您所面臨的複雜程度.
 
 ## 任務-Task
 
@@ -13,9 +13,9 @@ commit: 403f19a
 
 `Task`是我們的應用程式的核心元件. 每個任務的顯示略有不同,具體取決於它所處的`狀態-state`. 我們顯示一個選中 (或未選中) 複選框,一些有關任務的資訊,以及一個"pin"按鈕,允許我們在列表中上下移動任務. 為了把各個它們擺在一起,我們需要下面的 **props**:
 
--   `title` - 描述任務的字串
+- `title` - 描述任務的字串
 
--   `state` - 哪個列表是當前的任務,是否已檢查?
+- `state` - 哪個列表是當前的任務,是否已檢查?
 
 在我們開始構建`Task`時,我們首先編寫 與 上面草圖中不同型別的任務 相對應的測試狀態. 然後我們使用 Storybook 模擬資料 隔離對應狀態元件. 我們將"視覺測試"元件在每個狀態下的外觀.
 
@@ -23,7 +23,7 @@ commit: 403f19a
 
 ## 獲取設定
 
-首先,讓我們建立任務元件 及 其附帶的 *storybook-故事* 檔案:
+首先,讓我們建立任務元件 及 其附帶的 _storybook-故事_ 檔案:
 
 `src/components/Task.js`和`src/components/Task.stories.js`
 
@@ -41,10 +41,9 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
 }
 ```
 
-上面,我們基於 Todos應用程式現有HTML結構 為 `Task`提供簡單的 markup .
+上面,我們基於 Todos 應用程式現有 HTML 結構 為 `Task`提供簡單的 markup .
 
-下面, 我們在 故事檔案中 構建 Task的 三個測試狀態:
-
+下面, 我們在 故事檔案中 構建 Task 的 三個測試狀態:
 
 ```javascript
 import React from 'react';
@@ -71,26 +70,26 @@ storiesOf('Task', module)
   .add('archived', () => <Task task={{ ...task, state: 'TASK_ARCHIVED' }} {...actions} />);
 ```
 
-Storybook中有兩個基本的組織級別.
+Storybook 中有兩個基本的組織級別.
 
 該元件 及 其 child 故事.
 
 將每個故事 視為元件的排列. 您可以根據需要為每個元件 建立 儘可能多的故事.
 
--   **元件**
-    -   故事
-    -   故事
-    -   故事
+- **元件**
+  - 故事
+  - 故事
+  - 故事
 
-要開始 Storybook,我們先運`行 註冊元件的`storiesOf()`函式. 我們為元件新增 *顯示名稱 -  Storybook應用程式側欄上顯示的名稱*.
+要開始 Storybook,我們先運`行 註冊元件的`storiesOf()`函式. 我們為元件新增 _顯示名稱 - Storybook 應用程式側欄上顯示的名稱_.
 
-`action()`允許我們建立一個回撥, 當在Storybook UI的面板中 單擊這個 **action** 時 回撥觸發. 因此,當我們構建一個pin按鈕 時,我們將能夠在 測試UI中 確定按鈕單擊 是否成功.
+`action()`允許我們建立一個回撥, 當在 Storybook UI 的面板中 單擊這個 **action** 時 回撥觸發. 因此,當我們構建一個 pin 按鈕 時,我們將能夠在 測試 UI 中 確定按鈕單擊 是否成功.
 
-由於我們需要將 相同的一組操作 傳遞給 元件的所有排列,因此將它們捆綁到`actions`變數 並 使用React`{...actions}`的`porps`擴充套件以立即傳遞它們. `<Task {...actions}>`相當於`<Task onPinTask={actions.onPinTask} onArchiveTask={actions.onArchiveTask}>`.
+由於我們需要將 相同的一組操作 傳遞給 元件的所有排列,因此將它們捆綁到`actions`變數 並 使用 React`{...actions}`的`porps`擴充套件以立即傳遞它們. `<Task {...actions}>`相當於`<Task onPinTask={actions.onPinTask} onArchiveTask={actions.onArchiveTask}>`.
 
 關於捆綁`actions`的另一個好處就是,你可以`export-暴露`它們,用於重用該元件的元件,我們稍後會看到.
 
-為了定義我們的故事,我們用`add()`,一次一個為我們的每個測試狀態生成一個故事. `add`第二個引數是一個函式,它返回一個給定狀態的渲染元素 (即帶有一組`props`的元件類)  - 就像一個React[無狀態功能元件](https://reactjs.org/docs/components-and-props.html).
+為了定義我們的故事,我們用`add()`,一次一個為我們的每個測試狀態生成一個故事. `add`第二個引數是一個函式,它返回一個給定狀態的渲染元素 (即帶有一組`props`的元件類) - 就像一個 React[無狀態功能元件](https://reactjs.org/docs/components-and-props.html).
 
 在建立故事時,我們使用基本任務 (`task`) 構建元件期望的 任務的形狀. 這通常是 根據真實資料的模型建模的. 再次,正如我們所看到的,`export`這種形狀將使我們能夠在以後的故事中重複使用它.
 
@@ -100,7 +99,7 @@ Storybook中有兩個基本的組織級別.
 
 ## 配置
 
-我們還必須對 Storybook的配置設定 (`.storybook/config.js`) 做一個小改動,讓它注意到我們的`.stories.js`檔案並使用我們的CSS檔案. 預設情況下, Storybook 會查詢故事`/stories`目錄; 本教程使用類似於`.test.js`的命名方案, 這個命令是 **CRA** 贊成的用於自動化測試的方案.
+我們還必須對 Storybook 的配置設定 (`.storybook/config.js`) 做一個小改動,讓它注意到我們的`.stories.js`檔案並使用我們的 CSS 檔案. 預設情況下, Storybook 會查詢故事`/stories`目錄; 本教程使用類似於`.test.js`的命名方案, 這個命令是 **CRA** 贊成的用於自動化測試的方案.
 
 ```javascript
 import { configure } from '@storybook/react';
@@ -115,7 +114,7 @@ function loadStories() {
 configure(loadStories, module);
 ```
 
-完成此操作後,重新啟動 Storybook伺服器 應該會產生 三個任務狀態的測試用例:
+完成此操作後,重新啟動 Storybook 伺服器 應該會產生 三個任務狀態的測試用例:
 
 <video autoPlay muted playsInline controls >
   <source
@@ -126,7 +125,7 @@ configure(loadStories, module);
 
 ## 建立狀態
 
-現在我們有 Storybook設定,匯入的樣式和構建的測試用例,我們可以快速開始實現元件的HTML,以匹配設計.
+現在我們有 Storybook 設定,匯入的樣式和構建的測試用例,我們可以快速開始實現元件的 HTML,以匹配設計.
 
 該元件目前仍然是基本的. 首先編寫實現設計的程式碼,不用過多細節:
 
@@ -161,7 +160,7 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
 }
 ```
 
-上面的附加 markup 與我們之前匯入的CSS相結合,產生以下UI:
+上面的附加 markup 與我們之前匯入的 CSS 相結合,產生以下 UI:
 
 <video autoPlay muted playsInline loop>
   <source
@@ -172,7 +171,7 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
 
 ## 特別資料要求
 
-最好的做法是`propTypes`在React中 指定元件所需的 資料形狀. 它不僅可以自我記錄,還有助於及早發現問題.
+最好的做法是`propTypes`在 React 中 指定元件所需的 資料形狀. 它不僅可以自我記錄,還有助於及早發現問題.
 
 ```javascript
 import React from 'react';
@@ -203,15 +202,15 @@ export default Task;
 
 ## 元件構建!
 
-我們現在已成功構建了一個元件,沒用到伺服器或執行整個前端應用程式. 下一步是以類似的方式逐個構建剩餘的 Taskbox元件.
+我們現在已成功構建了一個元件,沒用到伺服器或執行整個前端應用程式. 下一步是以類似的方式逐個構建剩餘的 Taskbox 元件.
 
-如您所見,開始單獨構建元件非常簡單快捷. 我們可以期望生成更高質量的UI,減少錯誤和更多打磨,因為它可以挖掘並測試每個可能的狀態.
+如您所見,開始單獨構建元件非常簡單快捷. 我們可以期望生成更高質量的 UI,減少錯誤和更多打磨,因為它可以挖掘並測試每個可能的狀態.
 
 ## 自動化測試
 
- Storybook 為我們提供了一種在施工期間,`視覺化`測試我們的應用程式.在我們繼續開發應用程式時,"故事"將有助於確保我們不會在視覺上打破我們的任務.
- 但是,在這個階段,這是一個完全手動的過程,有人必須努力點選每個測試狀態,並確保它呈現良好且沒有錯誤或警告.
- 我們不能自動這樣做嗎?
+Storybook 為我們提供了一種在施工期間,`視覺化`測試我們的應用程式.在我們繼續開發應用程式時,"故事"將有助於確保我們不會在視覺上打破我們的任務.
+但是,在這個階段,這是一個完全手動的過程,有人必須努力點選每個測試狀態,並確保它呈現良好且沒有錯誤或警告.
+我們不能自動這樣做嗎?
 
 ### 快照測試
 

--- a/content/intro-to-storybook/react/zh-TW/test.md
+++ b/content/intro-to-storybook/react/zh-TW/test.md
@@ -1,7 +1,7 @@
 ---
-title: "測試 UI 元件"
-tocTitle: "測試"
-description: "瞭解測試UI元件的方法"
+title: '測試 UI 元件'
+tocTitle: '測試'
+description: '瞭解測試UI元件的方法'
 commit: 78a45d1
 ---
 
@@ -65,13 +65,13 @@ yarn add storybook-chromatic
 匯入 Chromatic 到你的`.storybook/config.js`檔案.
 
 ```javascript
-import { configure } from "@storybook/react";
-import requireContext from "require-context.macro";
-import "storybook-chromatic";
+import { configure } from '@storybook/react';
+import requireContext from 'require-context.macro';
+import 'storybook-chromatic';
 
-import "../src/index.css";
+import '../src/index.css';
 
-const req = requireContext("../src/components", true, /\.stories\.js$/);
+const req = requireContext('../src/components', true, /\.stories\.js$/);
 
 function loadStories() {
   req.keys().forEach(filename => req(filename));

--- a/content/intro-to-storybook/vue/en/composite-component.md
+++ b/content/intro-to-storybook/vue/en/composite-component.md
@@ -1,7 +1,7 @@
 ---
-title: "Assemble a composite component"
-tocTitle: "Composite component"
-description: "Assemble a composite component out of simpler components"
+title: 'Assemble a composite component'
+tocTitle: 'Composite component'
+description: 'Assemble a composite component out of simpler components'
 commit: c72f06f
 ---
 
@@ -26,43 +26,48 @@ Start with a rough implementation of the `TaskList`. You’ll need to import the
 ```html
 <template>
   <div>
-    <div class="list-items" v-if="loading"> loading </div>
-    <div class="list-items" v-if="noTasks && !this.loading">empty </div>
+    <div class="list-items" v-if="loading">loading</div>
+    <div class="list-items" v-if="noTasks && !this.loading">empty</div>
     <div class="list-items" v-if="showTasks">
-      <task v-for="(task, index) in tasks" :key="index" :task="task"
-        @archiveTask="$emit('archiveTask', $event)" @pinTask="$emit('pinTask', $event)"/>
+      <task
+        v-for="(task, index) in tasks"
+        :key="index"
+        :task="task"
+        @archiveTask="$emit('archiveTask', $event)"
+        @pinTask="$emit('pinTask', $event)"
+      />
     </div>
   </div>
 </template>
 
 <script>
-import Task from "./Task";
-export default {
-  name: "task-list",
-  props: {
-    loading: {
-      type: Boolean,
-      default: false
+  import Task from './Task';
+  export default {
+    name: 'task-list',
+    props: {
+      loading: {
+        type: Boolean,
+        default: false,
+      },
+      tasks: {
+        type: Array,
+        default() {
+          return [];
+        },
+      },
     },
-    tasks: {
-      type: Array,
-      default() {
-        return [];
-      }
-    }
-  },
-  components: {
-    Task
-  },
-  computed: {
-    noTasks() {
-      return this.tasks.length === 0;
+    components: {
+      Task,
     },
-    showTasks() {
-      return !this.loading && !this.noTasks;
-    }
-  }
-};
+    computed: {
+      noTasks() {
+        return this.tasks.length === 0;
+      },
+      showTasks() {
+        return !this.loading && !this.noTasks;
+      },
+    },
+  };
 </script>
 ```
 
@@ -152,9 +157,7 @@ Our component is still rough but now we have an idea of the stories to work towa
     <div v-if="loading">
       <div class="loading-item" v-for="(n, index) in 5" :key="index">
         <span class="glow-checkbox" />
-        <span class="glow-text">
-          <span>Loading</span> <span>cool</span> <span>state</span>
-        </span>
+        <span class="glow-text"> <span>Loading</span> <span>cool</span> <span>state</span> </span>
       </div>
     </div>
     <div class="list-items" v-if="noTasks && !this.loading">
@@ -165,46 +168,51 @@ Our component is still rough but now we have an idea of the stories to work towa
       </div>
     </div>
     <div class="list-items" v-if="showTasks">
-      <task v-for="(task, index) in tasksInOrder" :key="index" :task="task"
-        @archiveTask="$emit('archiveTask', $event)" @pinTask="$emit('pinTask', $event)"/>
+      <task
+        v-for="(task, index) in tasksInOrder"
+        :key="index"
+        :task="task"
+        @archiveTask="$emit('archiveTask', $event)"
+        @pinTask="$emit('pinTask', $event)"
+      />
     </div>
   </div>
 </template>
 
 <script>
-import Task from "./Task";
-export default {
-  name: "task-list",
-  props: {
-    loading: {
-      type: Boolean,
-      default: false
+  import Task from './Task';
+  export default {
+    name: 'task-list',
+    props: {
+      loading: {
+        type: Boolean,
+        default: false,
+      },
+      tasks: {
+        type: Array,
+        default() {
+          return [];
+        },
+      },
     },
-    tasks: {
-      type: Array,
-      default() {
-        return [];
-      }
-    }
-  },
-  components: {
-    Task
-  },
-  computed: {
-    noTasks() {
-      return this.tasks.length === 0;
+    components: {
+      Task,
     },
-    showTasks() {
-      return !this.loading && !this.noTasks;
+    computed: {
+      noTasks() {
+        return this.tasks.length === 0;
+      },
+      showTasks() {
+        return !this.loading && !this.noTasks;
+      },
+      tasksInOrder() {
+        return [
+          ...this.tasks.filter(t => t.state === 'TASK_PINNED'),
+          ...this.tasks.filter(t => t.state !== 'TASK_PINNED'),
+        ];
+      },
     },
-    tasksInOrder() {
-      return [
-        ...this.tasks.filter(t => t.state === "TASK_PINNED"),
-        ...this.tasks.filter(t => t.state !== "TASK_PINNED")
-      ];
-    }
-  }
-};
+  };
 </script>
 ```
 

--- a/content/intro-to-storybook/vue/en/conclusion.md
+++ b/content/intro-to-storybook/vue/en/conclusion.md
@@ -1,6 +1,6 @@
 ---
-title: "Conclusion"
-description: "Put all your knowledge together and learn more Storybook techniques"
+title: 'Conclusion'
+description: 'Put all your knowledge together and learn more Storybook techniques'
 ---
 
 Congratulations! You created your first UI in Storybook. Along the way you learned how to build, compose, test, and deploy UI components. If you’ve been following, your repo and deployed Storybook should look like this:
@@ -15,11 +15,11 @@ Storybook is a powerful tool for React, Vue, and Angular. It has a thriving deve
 
 Want to dive deeper? Here are helpful resources.
 
-* [**Official Storybook documentation**](https://storybook.js.org/basics/introduction/) has API documentation, community links, and the addon gallery.
+- [**Official Storybook documentation**](https://storybook.js.org/basics/introduction/) has API documentation, community links, and the addon gallery.
 
-* [**The Delightful Storybook Workflow**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07) highlights workflow best practices used by high-velocity teams at Squarespace, Major League Soccer, Discovery Network, and Apollo GraphQL.
+- [**The Delightful Storybook Workflow**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07) highlights workflow best practices used by high-velocity teams at Squarespace, Major League Soccer, Discovery Network, and Apollo GraphQL.
 
-* [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) dives deep into using Storybook to visual test components. Free 31-page ebook.
+- [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) dives deep into using Storybook to visual test components. Free 31-page ebook.
 
 ## Who made LearnStorybook.com?
 

--- a/content/intro-to-storybook/vue/en/contribute.md
+++ b/content/intro-to-storybook/vue/en/contribute.md
@@ -1,6 +1,6 @@
 ---
-title: "Contribute"
-description: "Help share Storybook with the world"
+title: 'Contribute'
+description: 'Help share Storybook with the world'
 ---
 
 Contributions to Learn Storybook are encouraged! If it’s something small like grammar or punctuation, open up a pull request. If it’s a bigger change, [add an issue](https://github.com/chromaui/learnstorybook.com/issues) for discussion.

--- a/content/intro-to-storybook/vue/en/data.md
+++ b/content/intro-to-storybook/vue/en/data.md
@@ -1,7 +1,7 @@
 ---
-title: "Wire in data"
-tocTitle: "Data"
-description: "Learn how to wire in data to your UI component"
+title: 'Wire in data'
+tocTitle: 'Data'
+description: 'Learn how to wire in data to your UI component'
 commit: 28bc240
 ---
 
@@ -62,22 +62,22 @@ In our top-level app component (`src/App.vue`) we can wire the store into our co
 ```html
 <template>
   <div id="app">
-    <task-list/>
+    <task-list />
   </div>
 </template>
 
 <script>
-import store from "./store";
-import TaskList from "./components/TaskList.vue";
-import "../src/index.css";
+  import store from './store';
+  import TaskList from './components/TaskList.vue';
+  import '../src/index.css';
 
-export default {
-  name: "app",
-  store,
-  components: {
-    TaskList
-  }
-};
+  export default {
+    name: 'app',
+    store,
+    components: {
+      TaskList,
+    },
+  };
 </script>
 ```
 
@@ -102,26 +102,26 @@ In `src/components/TaskList.vue`:
 ```html
 <template>
   <div>
-    <pure-task-list :tasks="tasks" @archiveTask="archiveTask" @pinTask="pinTask"/>
+    <pure-task-list :tasks="tasks" @archiveTask="archiveTask" @pinTask="pinTask" />
   </div>
 </template>
 
 <script>
-import PureTaskList from "./PureTaskList";
-import { mapState, mapActions } from "vuex";
+  import PureTaskList from './PureTaskList';
+  import { mapState, mapActions } from 'vuex';
 
-export default {
-  name: "task-list",
-  components: {
-    PureTaskList
-  },
-  methods: {
-    ...mapActions(['archiveTask', 'pinTask'])
-  },
-  computed: {
-    ...mapState(["tasks"])
-  }
-};
+  export default {
+    name: 'task-list',
+    components: {
+      PureTaskList,
+    },
+    methods: {
+      ...mapActions(['archiveTask', 'pinTask']),
+    },
+    computed: {
+      ...mapState(['tasks']),
+    },
+  };
 </script>
 ```
 

--- a/content/intro-to-storybook/vue/en/deploy.md
+++ b/content/intro-to-storybook/vue/en/deploy.md
@@ -1,7 +1,7 @@
 ---
-title: "Deploy Storybook"
-tocTitle: "Deploy"
-description: "Deploy Storybook online with GitHub and Netlify"
+title: 'Deploy Storybook'
+tocTitle: 'Deploy'
+description: 'Deploy Storybook online with GitHub and Netlify'
 ---
 
 In this tutorial we ran Storybook on our development machine. You may also want to share that Storybook with the team, especially the non-technical members. Thankfully, it’s easy to deploy Storybook online.

--- a/content/intro-to-storybook/vue/en/get-started.md
+++ b/content/intro-to-storybook/vue/en/get-started.md
@@ -1,7 +1,7 @@
 ---
-title: "Storybook for Vue tutorial"
-tocTitle: "Get started"
-description: "Setup Vue Storybook in your development environment"
+title: 'Storybook for Vue tutorial'
+tocTitle: 'Get started'
+description: 'Setup Vue Storybook in your development environment'
 commit: d1c4858
 ---
 
@@ -51,7 +51,7 @@ Taskbox reuses design elements from the GraphQL and React Tutorial [example app]
 
 ```html
 <style>
-  @import "./index.css";
+  @import './index.css';
 </style>
 ```
 

--- a/content/intro-to-storybook/vue/en/screen.md
+++ b/content/intro-to-storybook/vue/en/screen.md
@@ -1,7 +1,7 @@
 ---
-title: "Construct a screen"
-tocTitle: "Screens"
-description: "Construct a screen out of components"
+title: 'Construct a screen'
+tocTitle: 'Screens'
+description: 'Construct a screen out of components'
 commit: b62db62
 ---
 
@@ -35,19 +35,19 @@ As our app is very simple, the screen we’ll build is pretty trivial, simply wr
 </template>
 
 <script>
-  import TaskList from "./TaskList.vue";
+  import TaskList from './TaskList.vue';
 
   export default {
-    name: "pure-inbox-screen",
+    name: 'pure-inbox-screen',
     props: {
       error: {
         type: Boolean,
-        default: false
-      }
+        default: false,
+      },
     },
     components: {
-      TaskList
-    }
+      TaskList,
+    },
   };
 </script>
 ```
@@ -62,17 +62,17 @@ Then, we can create a container, which again grabs the data for the `PureInboxSc
 </template>
 
 <script>
-  import PureInboxScreen from "./PureInboxScreen";
-  import { mapState } from "vuex";
+  import PureInboxScreen from './PureInboxScreen';
+  import { mapState } from 'vuex';
 
   export default {
-    name: "inbox-screen",
+    name: 'inbox-screen',
     components: {
-      PureInboxScreen
+      PureInboxScreen,
     },
     computed: {
-      ...mapState(["error"])
-    }
+      ...mapState(['error']),
+    },
   };
 </script>
 ```
@@ -87,16 +87,16 @@ We also change the `App` component to render the `InboxScreen` (eventually we wo
 </template>
 
 <script>
-  import store from "./store";
-  import InboxScreen from "./components/InboxScreen.vue";
-  import "../src/index.css";
+  import store from './store';
+  import InboxScreen from './components/InboxScreen.vue';
+  import '../src/index.css';
 
   export default {
-    name: "app",
+    name: 'app',
     store,
     components: {
-      InboxScreen
-    }
+      InboxScreen,
+    },
   };
 </script>
 ```
@@ -110,20 +110,20 @@ When placing the `TaskList` into Storybook, we were able to dodge this issue by 
 However, for the `PureInboxScreen` we have a problem because although the `PureInboxScreen` itself is presentational, its child, the `TaskList`, is not. In a sense the `PureInboxScreen` has been polluted by “container-ness”. So when we setup our stories in `src/components/PureInboxScreen.stories.js`:
 
 ```javascript
-import { storiesOf } from "@storybook/vue";
-import PureInboxScreen from "./PureInboxScreen";
+import { storiesOf } from '@storybook/vue';
+import PureInboxScreen from './PureInboxScreen';
 
-storiesOf("PureInboxScreen", module)
-  .add("default", () => {
+storiesOf('PureInboxScreen', module)
+  .add('default', () => {
     return {
       components: { PureInboxScreen },
-      template: `<pure-inbox-screen/>`
+      template: `<pure-inbox-screen/>`,
     };
   })
-  .add("error", () => {
+  .add('error', () => {
     return {
       components: { PureInboxScreen },
-      template: `<pure-inbox-screen :error="true"/>`
+      template: `<pure-inbox-screen :error="true"/>`,
     };
   });
 ```
@@ -145,41 +145,41 @@ As an aside, passing data down the hierarchy is a legitimate approach, especiall
 The good news is that it is easy to supply a Vuex store to the `PureInboxScreen` in a story! We can create a new store in our story file and pass it in as the context of the story:
 
 ```javascript
-import { action } from "@storybook/addon-actions";
-import { storiesOf } from "@storybook/vue";
-import Vue from "vue";
-import Vuex from "vuex";
+import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/vue';
+import Vue from 'vue';
+import Vuex from 'vuex';
 
-import { defaultTaskList } from "./PureTaskList.stories";
-import PureInboxScreen from "./PureInboxScreen.vue";
+import { defaultTaskList } from './PureTaskList.stories';
+import PureInboxScreen from './PureInboxScreen.vue';
 
 Vue.use(Vuex);
 export const store = new Vuex.Store({
   state: {
-    tasks: defaultTaskList
+    tasks: defaultTaskList,
   },
   actions: {
     pinTask(context, id) {
-      action("pinTask")(id);
+      action('pinTask')(id);
     },
     archiveTask(context, id) {
-      action("archiveTask")(id);
-    }
-  }
+      action('archiveTask')(id);
+    },
+  },
 });
 
-storiesOf("PureInboxScreen", module)
-  .add("default", () => {
+storiesOf('PureInboxScreen', module)
+  .add('default', () => {
     return {
       components: { PureInboxScreen },
       template: `<pure-inbox-screen/>`,
-      store
+      store,
     };
   })
-  .add("error", () => {
+  .add('error', () => {
     return {
       components: { PureInboxScreen },
-      template: `<pure-inbox-screen :error="true"/>`
+      template: `<pure-inbox-screen :error="true"/>`,
     };
   });
 ```

--- a/content/intro-to-storybook/vue/en/simple-component.md
+++ b/content/intro-to-storybook/vue/en/simple-component.md
@@ -1,7 +1,7 @@
 ---
-title: "Build a simple component"
-tocTitle: "Simple component"
-description: "Build a simple component in isolation"
+title: 'Build a simple component'
+tocTitle: 'Simple component'
+description: 'Build a simple component in isolation'
 commit: b2274bd
 ---
 
@@ -13,8 +13,8 @@ We’ll build our UI following a [Component-Driven Development](https://blog.hic
 
 `Task` is the core component in our app. Each task displays slightly differently depending on exactly what state it’s in. We display a checked (or unchecked) checkbox, some information about the task, and a “pin” button, allowing us to move tasks up and down the list. Putting this together, we’ll need these props:
 
-* `title` – a string describing the task
-* `state` - which list is the task currently in and is it checked off?
+- `title` – a string describing the task
+- `state` - which list is the task currently in and is it checked off?
 
 As we start to build `Task`, we first write our test states that correspond to the different types of tasks sketch above. Then we use Storybook to build the component in isolation using mocked data. We’ll “visual test” the component’s appearance given each state as we go.
 
@@ -30,19 +30,19 @@ We’ll begin with a basic implementation of the `Task`, simply taking in the at
 <template>
   <div class="list-item">
     <input type="text" :readonly="true" :value="this.task.title" />
-  </div>  
+  </div>
 </template>
 
 <script>
-export default {
-  name: "task",
-  props: {
-    task: {
-      type: Object,
-      required: true
-    }
-  }
-};
+  export default {
+    name: 'task',
+    props: {
+      task: {
+        type: Object,
+        required: true,
+      },
+    },
+  };
 </script>
 ```
 
@@ -97,10 +97,10 @@ storiesOf('Task', module)
 
 There are two basic levels of organization in Storybook: the component and its child stories. Think of each story as a permutation of a component. You can have as many stories per component as you need.
 
-* **Component**
-  * Story
-  * Story
-  * Story
+- **Component**
+  - Story
+  - Story
+  - Story
 
 To initiate Storybook we first call the `storiesOf()` function to register the component. We add a display name for the component –the name that appears on the sidebar in the Storybook app.
 
@@ -154,43 +154,38 @@ The component is still basic at the moment. First write the code that achieves t
 <template>
   <div :class="taskClass">
     <label class="checkbox">
-      <input
-        type="checkbox"
-        :checked="isChecked"
-        :disabled="true"
-        name="checked"
-      />
-      <span class="checkbox-custom" @click="$emit('archiveTask', task.id)"/>
+      <input type="checkbox" :checked="isChecked" :disabled="true" name="checked" />
+      <span class="checkbox-custom" @click="$emit('archiveTask', task.id)" />
     </label>
     <div class="title">
       <input type="text" :readonly="true" :value="this.task.title" placeholder="Input title" />
     </div>
     <div class="actions">
       <a @click="$emit('pinTask', task.id)" v-if="!isChecked">
-        <span class="icon-star"/>
+        <span class="icon-star" />
       </a>
     </div>
-  </div>  
+  </div>
 </template>
 
 <script>
-export default {
-  name: "task",
-  props: {
-    task: {
-      type: Object,
-      required: true
-    }
-  },
-  computed: {
-    taskClass() {
-      return `list-item ${this.task.state}`;
+  export default {
+    name: 'task',
+    props: {
+      task: {
+        type: Object,
+        required: true,
+      },
     },
-    isChecked() {
-      return this.task.state === "TASK_ARCHIVED";
-    }
-  }
-};
+    computed: {
+      taskClass() {
+        return `list-item ${this.task.state}`;
+      },
+      isChecked() {
+        return this.task.state === 'TASK_ARCHIVED';
+      },
+    },
+  };
 </script>
 ```
 

--- a/content/intro-to-storybook/vue/en/test.md
+++ b/content/intro-to-storybook/vue/en/test.md
@@ -1,7 +1,7 @@
 ---
-title: "Test UI components"
-tocTitle: "Testing"
-description: "Learn the ways to test UI components"
+title: 'Test UI components'
+tocTitle: 'Testing'
+description: 'Learn the ways to test UI components'
 commit: 8bf107e
 ---
 
@@ -65,12 +65,12 @@ yarn add --dev storybook-chromatic
 Import Chromatic in your `.storybook/config.js` file.
 
 ```javascript
-import { configure } from "@storybook/vue";
-import "storybook-chromatic";
+import { configure } from '@storybook/vue';
+import 'storybook-chromatic';
 
-import "../src/index.css";
+import '../src/index.css';
 
-const req = require.context("../src", true, /.stories.js$/);
+const req = require.context('../src', true, /.stories.js$/);
 function loadStories() {
   req.keys().forEach(filename => req(filename));
 }

--- a/content/intro-to-storybook/vue/pt/composite-component.md
+++ b/content/intro-to-storybook/vue/pt/composite-component.md
@@ -1,7 +1,7 @@
 ---
-title: "Construção de um componente composto"
-tocTitle: "Componente composto"
-description: "Construção de um componente composto a partir de componentes simples"
+title: 'Construção de um componente composto'
+tocTitle: 'Componente composto'
+description: 'Construção de um componente composto a partir de componentes simples'
 ---
 
 No capitulo anterior, construímos o nosso primeiro componente, neste capitulo iremos estender o que foi dito até agora, para que possamos construir a nossa TaskList, ou seja uma lista de Tasks. Vamos combinar componentes e ver o que irá acontecer quando é adicionada alguma complexidade.
@@ -20,7 +20,7 @@ Visto que os dados para a `Task` podem ser enviados de forma assíncrona, **irá
 
 ## Preparação
 
-Um componente composto não é em nada diferente do componente básico contido dentro deste. Comece por criar um componente `TaskList` e o ficheiro estória que o acompanha em: 
+Um componente composto não é em nada diferente do componente básico contido dentro deste. Comece por criar um componente `TaskList` e o ficheiro estória que o acompanha em:
 `src/components/TaskList.vue` e `src/components/TaskList.stories.js` respetivamente.
 
 Comece por uma implementação em bruto da `TaskList`. Será necessário importar o componente `Task` criado anteriormente e injetar os atributos e as respetivas ações como inputs.
@@ -28,43 +28,48 @@ Comece por uma implementação em bruto da `TaskList`. Será necessário importa
 ```html
 <template>
   <div>
-    <div class="list-items" v-if="loading"> loading </div>
-    <div class="list-items" v-if="noTasks && !this.loading">empty </div>
+    <div class="list-items" v-if="loading">loading</div>
+    <div class="list-items" v-if="noTasks && !this.loading">empty</div>
     <div class="list-items" v-if="showTasks">
-      <task v-for="(task, index) in tasks" :key="index" :task="task"
-        @archiveTask="$emit('archiveTask', $event)" @pinTask="$emit('pinTask', $event)"/>
+      <task
+        v-for="(task, index) in tasks"
+        :key="index"
+        :task="task"
+        @archiveTask="$emit('archiveTask', $event)"
+        @pinTask="$emit('pinTask', $event)"
+      />
     </div>
   </div>
 </template>
 
 <script>
-import Task from "./Task";
-export default {
-  name: "task-list",
-  props: {
-    loading: {
-      type: Boolean,
-      default: false
+  import Task from './Task';
+  export default {
+    name: 'task-list',
+    props: {
+      loading: {
+        type: Boolean,
+        default: false,
+      },
+      tasks: {
+        type: Array,
+        default() {
+          return [];
+        },
+      },
     },
-    tasks: {
-      type: Array,
-      default() {
-        return [];
-      }
-    }
-  },
-  components: {
-    Task
-  },
-  computed: {
-    noTasks() {
-      return this.tasks.length === 0;
+    components: {
+      Task,
     },
-    showTasks() {
-      return !this.loading && !this.noTasks;
-    }
-  }
-};
+    computed: {
+      noTasks() {
+        return this.tasks.length === 0;
+      },
+      showTasks() {
+        return !this.loading && !this.noTasks;
+      },
+    },
+  };
 </script>
 ```
 
@@ -134,7 +139,7 @@ A função `addDecorator()` permite que seja adicionado algum "contexto" á rend
 </div>
 
 Com a importação da `task` para este ficheiro, está a ser adicionada a forma que uma `Task` assume, isto a partir do ficheiro `Task.stories.js` criado anteriormente.
-Como tal também os `methods` que irão definir quais as ações (através de uma callback simulada) que o componente `Task` se encontra á espera. 
+Como tal também os `methods` que irão definir quais as ações (através de uma callback simulada) que o componente `Task` se encontra á espera.
 
 Estes também necessários á `TaskList`.
 
@@ -157,9 +162,7 @@ O componente ainda se encontra num estado bruto, mas já temos uma ideia de quai
     <div v-if="loading">
       <div class="loading-item" v-for="(n, index) in 5" :key="index">
         <span class="glow-checkbox" />
-        <span class="glow-text">
-          <span>Loading</span> <span>cool</span> <span>state</span>
-        </span>
+        <span class="glow-text"> <span>Loading</span> <span>cool</span> <span>state</span> </span>
       </div>
     </div>
     <div class="list-items" v-if="noTasks && !this.loading">
@@ -170,46 +173,51 @@ O componente ainda se encontra num estado bruto, mas já temos uma ideia de quai
       </div>
     </div>
     <div class="list-items" v-if="showTasks">
-      <task v-for="(task, index) in tasksInOrder" :key="index" :task="task"
-        @archiveTask="$emit('archiveTask', $event)" @pinTask="$emit('pinTask', $event)"/>
+      <task
+        v-for="(task, index) in tasksInOrder"
+        :key="index"
+        :task="task"
+        @archiveTask="$emit('archiveTask', $event)"
+        @pinTask="$emit('pinTask', $event)"
+      />
     </div>
   </div>
 </template>
 
 <script>
-import Task from "./Task";
-export default {
-  name: "task-list",
-  props: {
-    loading: {
-      type: Boolean,
-      default: false
+  import Task from './Task';
+  export default {
+    name: 'task-list',
+    props: {
+      loading: {
+        type: Boolean,
+        default: false,
+      },
+      tasks: {
+        type: Array,
+        default() {
+          return [];
+        },
+      },
     },
-    tasks: {
-      type: Array,
-      default() {
-        return [];
-      }
-    }
-  },
-  components: {
-    Task
-  },
-  computed: {
-    noTasks() {
-      return this.tasks.length === 0;
+    components: {
+      Task,
     },
-    showTasks() {
-      return !this.loading && !this.noTasks;
+    computed: {
+      noTasks() {
+        return this.tasks.length === 0;
+      },
+      showTasks() {
+        return !this.loading && !this.noTasks;
+      },
+      tasksInOrder() {
+        return [
+          ...this.tasks.filter(t => t.state === 'TASK_PINNED'),
+          ...this.tasks.filter(t => t.state !== 'TASK_PINNED'),
+        ];
+      },
     },
-    tasksInOrder() {
-      return [
-        ...this.tasks.filter(t => t.state === "TASK_PINNED"),
-        ...this.tasks.filter(t => t.state !== "TASK_PINNED")
-      ];
-    }
-  }
-};
+  };
 </script>
 ```
 
@@ -232,11 +240,11 @@ No capítulo anterior, aprendeu-se a usar o Storyshots para implementar estória
 
 ## Testes unitários com Jest
 
-As estórias criadas com o Storybook em conjunção com os testes visuais manuais e testes de snapshot (tal como mencionado acima) irão prevenir em larga escala problemas futuros no interface de utilizador. Se as estórias definidas abrangerem uma ampla variedade de casos do componente e forem usadas ferramentas que garantam verificações por parte humana, irá resultar num decréscimo de erros. 
+As estórias criadas com o Storybook em conjunção com os testes visuais manuais e testes de snapshot (tal como mencionado acima) irão prevenir em larga escala problemas futuros no interface de utilizador. Se as estórias definidas abrangerem uma ampla variedade de casos do componente e forem usadas ferramentas que garantam verificações por parte humana, irá resultar num decréscimo de erros.
 
-No entanto, por vezes o diabo encontra-se nos detalhes. É necessária uma framework de testes explicita acerca deste tipo de detalhes. O que nos leva aos testes unitários. 
+No entanto, por vezes o diabo encontra-se nos detalhes. É necessária uma framework de testes explicita acerca deste tipo de detalhes. O que nos leva aos testes unitários.
 
-Neste caso pretende-se que o nosso `TaskList` faça a renderização de quaisquer tarefas que foram confirmadas **antes** das não confirmadas que são fornecidas ao adereço (prop) `tasks`. 
+Neste caso pretende-se que o nosso `TaskList` faça a renderização de quaisquer tarefas que foram confirmadas **antes** das não confirmadas que são fornecidas ao adereço (prop) `tasks`.
 Apesar de existir uma estória (`withPinnedTasks`) que testa este cenário em particular; este poderá levar a alguma ambiguidade da parte humana, ou seja se o componente **parar** de ordenar as tarefas desta forma, logo existe um problema. Mas ao olho destreinado não irá gritar **"Erro!"**.
 
 De forma a evitar este problema em concreto, podemos usar o Jest, de forma que este renderize a estória na DOM e efetue pesquisas de forma a verificar o output.
@@ -262,6 +270,6 @@ it('renders pinned tasks at the start of the list', () => {
 
 ![Execução de testes da TaskList](/intro-to-storybook/tasklist-testrunner.png)
 
-Podemos verificar que foi possível reutilizar a lista de tarefas `withPinnedTasks` quer na estória, quer no teste unitário. Desta forma podemos continuar a aproveitar um recurso existente (os exemplos que representam configurações de um componente) de cada vez mais formas. 
+Podemos verificar que foi possível reutilizar a lista de tarefas `withPinnedTasks` quer na estória, quer no teste unitário. Desta forma podemos continuar a aproveitar um recurso existente (os exemplos que representam configurações de um componente) de cada vez mais formas.
 
 Mas também que este teste é algo frágil. É possível que á medida que o projeto amadurece, a implementação concreta do componente `Task` seja alterada --isto quer pelo uso de uma classe com um nome diferente, por exemplo-- com isto, este teste específico irá falhar e será necessária uma atualização. Isto não é necessariamente um problema, mas um indicador para ser cuidadoso no uso liberal de testes unitários para o interface de utilizador. Visto que não são de fácil manutenção. Ao invés deste tipo de testes, é preferível depender de testes visuais, snapshot ou de regressão visual (ver [capitulo de testes](/vue/pt/test/)) sempre que for possível.

--- a/content/intro-to-storybook/vue/pt/conclusion.md
+++ b/content/intro-to-storybook/vue/pt/conclusion.md
@@ -1,6 +1,6 @@
 ---
-title: "Conclusão"
-description: "Fusão de todo o conhecimento adquirido e aprendizagem de técnicas extra de Storybook"
+title: 'Conclusão'
+description: 'Fusão de todo o conhecimento adquirido e aprendizagem de técnicas extra de Storybook'
 ---
 
 Parabéns! Acabaste de criar o teu primeiro interface de utilizador com Storybook. Durante esta jornada aprendeste como construir, compor, testar e implementar componentes de interface de utilizador.
@@ -10,20 +10,19 @@ Se estiveste a seguir o tutorial, o repositório e o Storybook implementado irá
 <br/>
 [🌎 **Storybook implementado**](https://clever-banach-415c03.netlify.com/)
 
-O Storybook é uma ferramenta bastante poderosa para React, Vue, Angular. 
+O Storybook é uma ferramenta bastante poderosa para React, Vue, Angular.
 É composta por uma comunidade de desenvolvimento próspera e um número grande de extras. Esta introdução somente arranha a superfície das potencialidades existentes. Estamos confiantes que depois da adoção do Storybook, irá ficar impressionado com o quanto é produtivo a construção de interfaces de utilizador duradouros.
 
 ## Saber mais
 
 Pretende saber mais? Aqui ficam alguns recursos que irão ajudar.
 
-* [**Documentação Oficial Storybook**](https://storybook.js.org/basics/introduction/) contem a documentação da API, links da comunidade e a galeria de extras.
+- [**Documentação Oficial Storybook**](https://storybook.js.org/basics/introduction/) contem a documentação da API, links da comunidade e a galeria de extras.
 
-* [**Manual de testes visuais**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07) 
-enumera as boas práticas de fluxo de trabalho, usadas por equipas que operam a alta velocidade, tal como por exemplo a SquareSpace, a Major League Soccer, a Discovery Network e Apollo GraphQL.
+- [**Manual de testes visuais**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07)
+  enumera as boas práticas de fluxo de trabalho, usadas por equipas que operam a alta velocidade, tal como por exemplo a SquareSpace, a Major League Soccer, a Discovery Network e Apollo GraphQL.
 
-* [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) aprofunda o uso de Storybook para testes visuais. Livro eletrónico livre de 31 páginas.
-
+- [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) aprofunda o uso de Storybook para testes visuais. Livro eletrónico livre de 31 páginas.
 
 ## Quem fez LearnStorybook.com?
 

--- a/content/intro-to-storybook/vue/pt/contribute.md
+++ b/content/intro-to-storybook/vue/pt/contribute.md
@@ -1,6 +1,6 @@
 ---
-title: "Contribuições"
-description: "Ajudem na partilha do Storybook com o mundo"
+title: 'Contribuições'
+description: 'Ajudem na partilha do Storybook com o mundo'
 ---
 
 # Contribuições

--- a/content/intro-to-storybook/vue/pt/data.md
+++ b/content/intro-to-storybook/vue/pt/data.md
@@ -1,7 +1,7 @@
 ---
-title: "Ligação de dados"
-tocTitle: "Dados"
-description: "Aprendizagem da metodologia de ligação de dados ao componente interface utilizador"
+title: 'Ligação de dados'
+tocTitle: 'Dados'
+description: 'Aprendizagem da metodologia de ligação de dados ao componente interface utilizador'
 ---
 
 Até agora foram criados componentes sem estado e isolados, o que é fantástico para Storybook, mas em última análise não são úteis até que for fornecido algum tipo de dados da aplicação
@@ -63,22 +63,22 @@ Em seguida o componente de topo (`src/App.vue`) vai ser atualizado de forma que 
 ```html
 <template>
   <div id="app">
-    <task-list/>
+    <task-list />
   </div>
 </template>
 
 <script>
-import store from "./store";
-import TaskList from "./components/TaskList.vue";
-import "../src/index.css";
+  import store from './store';
+  import TaskList from './components/TaskList.vue';
+  import '../src/index.css';
 
-export default {
-  name: "app",
-  store,
-  components: {
-    TaskList
-  }
-};
+  export default {
+    name: 'app',
+    store,
+    components: {
+      TaskList,
+    },
+  };
 </script>
 ```
 
@@ -98,36 +98,36 @@ export default {
   ...
 }
 ```
+
 No ficheiro `src/components/TaskList.vue`:
 
 ```html
 <template>
   <div>
-    <pure-task-list :tasks="tasks" @archiveTask="archiveTask" @pinTask="pinTask"/>
+    <pure-task-list :tasks="tasks" @archiveTask="archiveTask" @pinTask="pinTask" />
   </div>
 </template>
 
 <script>
-import PureTaskList from "./PureTaskList";
-import { mapState, mapActions } from "vuex";
+  import PureTaskList from './PureTaskList';
+  import { mapState, mapActions } from 'vuex';
 
-export default {
-  name: "task-list",
-  components: {
-    PureTaskList
-  },
-  methods: {
-    ...mapActions(['archiveTask', 'pinTask'])
-  },
-  computed: {
-    ...mapState(["tasks"])
-  }
-};
+  export default {
+    name: 'task-list',
+    components: {
+      PureTaskList,
+    },
+    methods: {
+      ...mapActions(['archiveTask', 'pinTask']),
+    },
+    computed: {
+      ...mapState(['tasks']),
+    },
+  };
 </script>
 ```
 
 A razão porque irá ser mantida a versão de apresentação do `TaskList` em separado, é porque é mais fácil para testar e isolar. Visto que não depende da existência de uma loja, logo torna-se mais fácil de lidar do ponto de vista de testes. Irá ser renomeado `src/components/TaskList.stories.js` para `src/components/PureTaskList.stories.js` e com isto garantir que as nossas estórias usam a versão de apresentação:
-
 
 ```javascript
 import { storiesOf } from '@storybook/vue';
@@ -194,7 +194,6 @@ storiesOf('PureTaskList', module)
 </video>
 
 Similarmente, será usado o `PureTaskList` nos testes com Jest:
-
 
 ```js
 import Vue from 'vue';

--- a/content/intro-to-storybook/vue/pt/deploy.md
+++ b/content/intro-to-storybook/vue/pt/deploy.md
@@ -1,7 +1,7 @@
 ---
-title: "Implementar Storybook"
-tocTitle: "Implementação"
-descrição: "Implemntação online do Storybook com GitHub e Netlify"
+title: 'Implementar Storybook'
+tocTitle: 'Implementação'
+descrição: 'Implemntação online do Storybook com GitHub e Netlify'
 ---
 
 Neste tutorial o Storybook foi executado na máquina local. Poderá ser necessária a partilha com o resto da equipa, em particular com membros considerados não técnicos. Felizmente, é bastante fácil implementar o Storybook online.

--- a/content/intro-to-storybook/vue/pt/get-started.md
+++ b/content/intro-to-storybook/vue/pt/get-started.md
@@ -1,7 +1,7 @@
 ---
-title: "Storybook para o Vue tutorial"
-tocTitle: "Introdução"
-description: "Configuração do Vue Storybook no ambiente de desenvolvimento"
+title: 'Storybook para o Vue tutorial'
+tocTitle: 'Introdução'
+description: 'Configuração do Vue Storybook no ambiente de desenvolvimento'
 ---
 
 Storybook funciona em paralelo à aplicação em modo de desenvolvimento.
@@ -57,7 +57,7 @@ O CSS compilado encontra-se disponível [aqui](https://github.com/chromaui/learn
 
 ```html
 <style>
-  @import "./index.css";
+  @import './index.css';
 </style>
 ```
 

--- a/content/intro-to-storybook/vue/pt/screen.md
+++ b/content/intro-to-storybook/vue/pt/screen.md
@@ -1,7 +1,7 @@
 ---
-title: "Construção de um ecrã"
-tocTitle: "Ecrãs"
-description: "Construção de um ecrã a partir de componentes"
+title: 'Construção de um ecrã'
+tocTitle: 'Ecrãs'
+description: 'Construção de um ecrã a partir de componentes'
 ---
 
 Tem sido focada a construção de interfaces de utilizador da base para o topo.
@@ -35,19 +35,19 @@ Visto que a aplicação é deveras simples, o ecrã a ser construído é bastant
 </template>
 
 <script>
-  import TaskList from "./TaskList.vue";
+  import TaskList from './TaskList.vue';
 
   export default {
-    name: "pure-inbox-screen",
+    name: 'pure-inbox-screen',
     props: {
       error: {
         type: Boolean,
-        default: false
-      }
+        default: false,
+      },
     },
     components: {
-      TaskList
-    }
+      TaskList,
+    },
   };
 </script>
 ```
@@ -62,17 +62,17 @@ Em seguida, podemos criar um contentor, que mais uma vez obtém os dados vindos 
 </template>
 
 <script>
-  import PureInboxScreen from "./PureInboxScreen";
-  import { mapState } from "vuex";
+  import PureInboxScreen from './PureInboxScreen';
+  import { mapState } from 'vuex';
 
   export default {
-    name: "inbox-screen",
+    name: 'inbox-screen',
     components: {
-      PureInboxScreen
+      PureInboxScreen,
     },
     computed: {
-      ...mapState(["error"])
-    }
+      ...mapState(['error']),
+    },
   };
 </script>
 ```
@@ -87,16 +87,16 @@ Vai ser necessário alterar o componente `App` de forma a ser possível renderiz
 </template>
 
 <script>
-  import store from "./store";
-  import InboxScreen from "./components/InboxScreen.vue";
-  import "../src/index.css";
+  import store from './store';
+  import InboxScreen from './components/InboxScreen.vue';
+  import '../src/index.css';
 
   export default {
-    name: "app",
+    name: 'app',
     store,
     components: {
-      InboxScreen
-    }
+      InboxScreen,
+    },
   };
 </script>
 ```
@@ -111,20 +111,20 @@ Irá ser feito algo similar para o `PureInboxScreen` no Storybook também.
 No entanto para o `PureInboxScreen` existe um problema, isto porque apesar deste ser de apresentação, o seu "filho", ou seja a `TaskList` não o é. De certa forma o `PureInboxScreen` foi poluído pelo "container-ness". Com isto as estórias no ficheiro `src/components/PureInboxScreen.stories.js` terão que ser definidas da seguinte forma:
 
 ```javascript
-import { storiesOf } from "@storybook/vue";
-import PureInboxScreen from "./PureInboxScreen";
+import { storiesOf } from '@storybook/vue';
+import PureInboxScreen from './PureInboxScreen';
 
-storiesOf("PureInboxScreen", module)
-  .add("default", () => {
+storiesOf('PureInboxScreen', module)
+  .add('default', () => {
     return {
       components: { PureInboxScreen },
-      template: `<pure-inbox-screen/>`
+      template: `<pure-inbox-screen/>`,
     };
   })
-  .add("error", () => {
+  .add('error', () => {
     return {
       components: { PureInboxScreen },
-      template: `<pure-inbox-screen :error="true"/>`
+      template: `<pure-inbox-screen :error="true"/>`,
     };
   });
 ```
@@ -146,41 +146,41 @@ No entanto, algum programador **irá querer** renderizar contentores num nível 
 As boas noticias é que é extremamente fácil fornecer uma loja Vuex ao componente `PureInboxScreen` numa estória! Pode ser criada uma nova loja no ficheiro de estória e esta ser fornecida como contexto da estória:
 
 ```javascript
-import { action } from "@storybook/addon-actions";
-import { storiesOf } from "@storybook/vue";
-import Vue from "vue";
-import Vuex from "vuex";
+import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/vue';
+import Vue from 'vue';
+import Vuex from 'vuex';
 
-import { defaultTaskList } from "./PureTaskList.stories";
-import PureInboxScreen from "./PureInboxScreen.vue";
+import { defaultTaskList } from './PureTaskList.stories';
+import PureInboxScreen from './PureInboxScreen.vue';
 
 Vue.use(Vuex);
 export const store = new Vuex.Store({
   state: {
-    tasks: defaultTaskList
+    tasks: defaultTaskList,
   },
   actions: {
     pinTask(context, id) {
-      action("pinTask")(id);
+      action('pinTask')(id);
     },
     archiveTask(context, id) {
-      action("archiveTask")(id);
-    }
-  }
+      action('archiveTask')(id);
+    },
+  },
 });
 
-storiesOf("PureInboxScreen", module)
-  .add("default", () => {
+storiesOf('PureInboxScreen', module)
+  .add('default', () => {
     return {
       components: { PureInboxScreen },
       template: `<pure-inbox-screen/>`,
-      store
+      store,
     };
   })
-  .add("error", () => {
+  .add('error', () => {
     return {
       components: { PureInboxScreen },
-      template: `<pure-inbox-screen :error="true"/>`
+      template: `<pure-inbox-screen :error="true"/>`,
     };
   });
 ```

--- a/content/intro-to-storybook/vue/pt/simple-component.md
+++ b/content/intro-to-storybook/vue/pt/simple-component.md
@@ -1,7 +1,7 @@
 ---
-title: "Construção de um componente siples"
-tocTitle: "Componente simples"
-description: "Construção de um componente simples isolado"
+title: 'Construção de um componente siples'
+tocTitle: 'Componente simples'
+description: 'Construção de um componente simples isolado'
 ---
 
 Iremos construir o interface de utilizador de acordo com a metodologia de [Desenvolvimento orientada a componentes](https://blog.hichroma.com/component-driven-development-ce1109d56c8e), ou nativamente por (CDD, Component-Driven Development). É um processo que cria interfaces de utilizador a partir da base para o topo, iniciando com componentes e terminando com ecrãs. O DOC (CDD nativamente) ajuda no escalonamento da complexidade á qual o programador é sujeito á medida que constrói o interface de utilizador.
@@ -10,12 +10,12 @@ Iremos construir o interface de utilizador de acordo com a metodologia de [Desen
 
 ![Componente Task ao longo de três estados](/intro-to-storybook/task-states-learnstorybook.png)
 
-`Task` é o componente nuclear da nossa aplicação. Cada tarefa é apresentada de forma diferente dependendo do estado em que se encontra. 
-O que vai ser apresentado é uma caixa de confirmação, selecionada (ou não), alguma informação adicional acerca da tarefa e um botão "fixador", que permite a movimentação para cima e para baixo das tarefas ao longo da lista. 
+`Task` é o componente nuclear da nossa aplicação. Cada tarefa é apresentada de forma diferente dependendo do estado em que se encontra.
+O que vai ser apresentado é uma caixa de confirmação, selecionada (ou não), alguma informação adicional acerca da tarefa e um botão "fixador", que permite a movimentação para cima e para baixo das tarefas ao longo da lista.
 Para que seja possível implementar isto serão necessárias os seguintes adereços (props):
 
-* `title` - uma cadeia de caracteres que descreve a tarefa
-* `state` - qual a lista em que a tarefa se encontra e se está confirmada?
+- `title` - uma cadeia de caracteres que descreve a tarefa
+- `state` - qual a lista em que a tarefa se encontra e se está confirmada?
 
 Á medida que construimos a `Task`, é necessário definir os três estados que correspondem os três tipos de tarefa delineados acima.
 Em seguida usa-se o Storybook para construir este componente isolado, usando dados predefinidos. Irá "testar-se visualmente" a aparência do componente para cada estado á medida que prosseguimos.
@@ -33,19 +33,19 @@ Iremos iniciar por uma implementação básica da `Task`, que recebe os atributo
 <template>
   <div class="list-item">
     <input type="text" :readonly="true" :value="this.task.title" />
-  </div>  
+  </div>
 </template>
 
 <script>
-export default {
-  name: "task",
-  props: {
-    task: {
-      type: Object,
-      required: true
-    }
-  }
-};
+  export default {
+    name: 'task',
+    props: {
+      task: {
+        type: Object,
+        required: true,
+      },
+    },
+  };
 </script>
 ```
 
@@ -100,10 +100,10 @@ storiesOf('Task', module)
 
 Existem dois tipos de organização com Storybook. O componente em si e as estórias associadas. É preferível pensar em cada estória como uma permutação de um componente. Como tal podem existir tantas estórias, tantas as que forem necessárias.
 
-* **Component**
-  * Story
-  * Story
-  * Story
+- **Component**
+  - Story
+  - Story
+  - Story
 
 Ao ser invocada a função `storiesOf()`, está a registar-se o componente, e com isto o processo de arranque do Storybook. É adicionado um nome, nome esse que será usado na barra lateral da aplicação Storybook para identificar o componente.
 
@@ -158,43 +158,38 @@ O componente neste momento ainda é bastante básico. Primeiro irá ser definido
 <template>
   <div :class="taskClass">
     <label class="checkbox">
-      <input
-        type="checkbox"
-        :checked="isChecked"
-        :disabled="true"
-        name="checked"
-      />
-      <span class="checkbox-custom" @click="$emit('archiveTask', task.id)"/>
+      <input type="checkbox" :checked="isChecked" :disabled="true" name="checked" />
+      <span class="checkbox-custom" @click="$emit('archiveTask', task.id)" />
     </label>
     <div class="title">
       <input type="text" :readonly="true" :value="this.task.title" placeholder="Input title" />
     </div>
     <div class="actions">
       <a @click="$emit('pinTask', task.id)" v-if="!isChecked">
-        <span class="icon-star"/>
+        <span class="icon-star" />
       </a>
     </div>
-  </div>  
+  </div>
 </template>
 
 <script>
-export default {
-  name: "task",
-  props: {
-    task: {
-      type: Object,
-      required: true
-    }
-  },
-  computed: {
-    taskClass() {
-      return `list-item ${this.task.state}`;
+  export default {
+    name: 'task',
+    props: {
+      task: {
+        type: Object,
+        required: true,
+      },
     },
-    isChecked() {
-      return this.task.state === "TASK_ARCHIVED";
-    }
-  }
-};
+    computed: {
+      taskClass() {
+        return `list-item ${this.task.state}`;
+      },
+      isChecked() {
+        return this.task.state === 'TASK_ARCHIVED';
+      },
+    },
+  };
 </script>
 ```
 

--- a/content/intro-to-storybook/vue/pt/test.md
+++ b/content/intro-to-storybook/vue/pt/test.md
@@ -1,7 +1,7 @@
 ---
-title: "Teste de componentes de interface de utilizador"
-tocTitle: "Testes"
-description: "Aprendizagem das formas de teste dos componentes interface utilizador"
+title: 'Teste de componentes de interface de utilizador'
+tocTitle: 'Testes'
+description: 'Aprendizagem das formas de teste dos componentes interface utilizador'
 ---
 
 Qualquer tutorial de Storybook não estaria completo sem serem mencionados os testes. Estes são essenciais na criação de interfaces de utilizador de alta qualidade. Nos sistemas modulares, ajustes minúsculos poderão levar a regressões gigantescas. Até agora foram descritos três tipos de testes:
@@ -66,12 +66,12 @@ yarn add storybook-chromatic
 O Chromatic é importado no ficheiro `.storybook/config.js`.
 
 ```javascript
-import { configure } from "@storybook/vue";
-import "storybook-chromatic";
+import { configure } from '@storybook/vue';
+import 'storybook-chromatic';
 
-import "../src/index.css";
+import '../src/index.css';
 
-const req = require.context("../src", true, /.stories.js$/);
+const req = require.context('../src', true, /.stories.js$/);
 function loadStories() {
   req.keys().forEach(filename => req(filename));
 }

--- a/content/visual-testing-handbook/index.md
+++ b/content/visual-testing-handbook/index.md
@@ -1,34 +1,28 @@
 ---
-title: "Visual Testing Handbook"
-description: "✍️Coming soon: Visual testing is a pragmatic yet precise way to check UI appearance."
-heroDescription: "✍️Coming soon: Visual testing is a pragmatic yet precise way to verify the look of UI components. It’s practiced by companies like Slack, Lonely Planet, and Walmart. This five chapter handbook gives you an overview of visual testing in Storybook."
-overview: "What is visual testing? Visual tests validate the appearance of rendered UI by capturing an image of it in a consistent browser environment. That image is compared to previous images (baselines) to detect visual changes. UIs are more complex, multi-state, and personalized than ever. Visual testing helps you ensure that your app looks and feels right every release."
+title: 'Visual Testing Handbook'
+description: '✍️Coming soon: Visual testing is a pragmatic yet precise way to check UI appearance.'
+heroDescription: '✍️Coming soon: Visual testing is a pragmatic yet precise way to verify the look of UI components. It’s practiced by companies like Slack, Lonely Planet, and Walmart. This five chapter handbook gives you an overview of visual testing in Storybook.'
+overview: 'What is visual testing? Visual tests validate the appearance of rendered UI by capturing an image of it in a consistent browser environment. That image is compared to previous images (baselines) to detect visual changes. UIs are more complex, multi-state, and personalized than ever. Visual testing helps you ensure that your app looks and feels right every release.'
 order: 3
-themeColor: "#129F00"
-codeGithubUrl: "https://github.com/chromaui/learnstorybook-code"
+themeColor: '#129F00'
+codeGithubUrl: 'https://github.com/chromaui/learnstorybook-code'
 heroAnimationName: null
 toc:
-  [
-    "introduction",
-    "component-explorers",
-    "visual-test-driven-development",
-    "tutorial",
-    "automate",
-  ]
-coverImagePath: "/guide-cover/visual-testing.svg"
-thumbImagePath: "/guide-thumb/visual-testing.svg"
-contributorCount: "+2"
+  ['introduction', 'component-explorers', 'visual-test-driven-development', 'tutorial', 'automate']
+coverImagePath: '/guide-cover/visual-testing.svg'
+thumbImagePath: '/guide-thumb/visual-testing.svg'
+contributorCount: '+2'
 authors:
   [
     {
-      src: "https://avatars2.githubusercontent.com/u/263385",
-      name: "Dominic Nguyen",
-      detail: "Storybook design",
+      src: 'https://avatars2.githubusercontent.com/u/263385',
+      name: 'Dominic Nguyen',
+      detail: 'Storybook design',
     },
     {
-      src: "https://avatars2.githubusercontent.com/u/132554",
-      name: "Tom Coleman",
-      detail: "Storybook core",
+      src: 'https://avatars2.githubusercontent.com/u/132554',
+      name: 'Tom Coleman',
+      detail: 'Storybook core',
     },
   ]
 contributors: []

--- a/content/visual-testing-handbook/react/en/automate.md
+++ b/content/visual-testing-handbook/react/en/automate.md
@@ -1,7 +1,7 @@
 ---
-title: "Automate visual testing"
-tocTitle: "Automate"
-description: "Learn how to automate visual testing to conquer UI bugs"
+title: 'Automate visual testing'
+tocTitle: 'Automate'
+description: 'Learn how to automate visual testing to conquer UI bugs'
 ---
 
 Writing in progress.

--- a/content/visual-testing-handbook/react/en/component-explorers.md
+++ b/content/visual-testing-handbook/react/en/component-explorers.md
@@ -1,7 +1,7 @@
 ---
-title: "Component explorers"
-tocTitle: "Component explorers"
-description: "Your new favorite tool for UI development"
+title: 'Component explorers'
+tocTitle: 'Component explorers'
+description: 'Your new favorite tool for UI development'
 ---
 
 Writing in progress.

--- a/content/visual-testing-handbook/react/en/introduction.md
+++ b/content/visual-testing-handbook/react/en/introduction.md
@@ -1,7 +1,7 @@
 ---
-title: "Introduction to visual testing"
-tocTitle: "Introduction"
-description: "The pragmatic way to test user interfaces"
+title: 'Introduction to visual testing'
+tocTitle: 'Introduction'
+description: 'The pragmatic way to test user interfaces'
 ---
 
 **Writing in progress.** This handbook gives you an overview of visual testing in Storybook. After reading you’ll understand why to visual test components, what tools are needed, and how visual testing fits into your development process. You’ll also get a tutorial on creating an example component using visual testing techniques.

--- a/content/visual-testing-handbook/react/en/tutorial.md
+++ b/content/visual-testing-handbook/react/en/tutorial.md
@@ -1,6 +1,6 @@
 ---
-title: "Tutorial"
-description: "Put all the concepts together in code"
+title: 'Tutorial'
+description: 'Put all the concepts together in code'
 ---
 
 Writing in progress.

--- a/content/visual-testing-handbook/react/en/visual-test-driven-development.md
+++ b/content/visual-testing-handbook/react/en/visual-test-driven-development.md
@@ -1,6 +1,6 @@
 ---
-title: "Visual test-driven development"
-description: "A clear workflow for building components"
+title: 'Visual test-driven development'
+description: 'A clear workflow for building components'
 ---
 
 Writing in progress.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,17 @@
     "storybook": "start-storybook -s ./static -p 6006",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.md": [
+      "prettier --write",
+      "git add"
+    ]
+  },
   "devDependencies": {
     "@babel/core": "^7.4.5",
     "@storybook/addon-a11y": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.7.0",
+    "husky": "^3.0.8",
+    "lint-staged": "^9.4.2",
     "prettier": "^1.17.1",
     "prettier-eslint": "^8.8.2",
     "prettier-eslint-cli": "^4.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,9 +1050,30 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@nodelib/fs.scandir@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
+  integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.3"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
+  integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
+
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
+  integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.3"
+    fastq "^1.6.0"
 
 "@pieh/friendly-errors-webpack-plugin@1.7.0-chalk-2":
   version "1.7.0-chalk-2"
@@ -1072,6 +1093,13 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
+
+"@samverschueren/stream-to-observable@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
+  integrity sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==
+  dependencies:
+    any-observable "^0.3.0"
 
 "@stefanprobst/lokijs@^1.5.6-b":
   version "1.5.6-b"
@@ -1570,6 +1598,11 @@
   version "7.0.58"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.58.tgz#ae852120137f40a29731a559e48003bd2d5d19f7"
 
+"@types/normalize-package-data@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
+  integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
 "@types/prop-types@*":
   version "15.7.1"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
@@ -1961,6 +1994,14 @@ after@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
 
+aggregate-error@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
+  integrity sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==
+  dependencies:
+    clean-stack "^2.0.0"
+    indent-string "^4.0.0"
+
 "airbnb-js-shims@^1 || ^2":
   version "2.2.0"
   resolved "https://registry.npmjs.org/airbnb-js-shims/-/airbnb-js-shims-2.2.0.tgz#46e1d9d9516f704ef736de76a3b6d484df9a96d8"
@@ -2067,6 +2108,11 @@ ansi-styles@^3.1.0, ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+any-observable@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
+  integrity sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==
+
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
@@ -2168,6 +2214,11 @@ array-union@^1.0.1:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
   dependencies:
     array-uniq "^1.0.1"
+
+array-union@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
+  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
 array-uniq@^1.0.1, array-uniq@^1.0.2:
   version "1.0.3"
@@ -2924,6 +2975,13 @@ braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
+braces@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  dependencies:
+    fill-range "^7.0.1"
+
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
@@ -3245,7 +3303,7 @@ ccount@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.4.tgz#9cf2de494ca84060a2a8d2854edd6dfb0445f386"
 
-chalk@1.1.3, chalk@^1.1.3:
+chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -3395,6 +3453,11 @@ clean-css@4.2.x:
   dependencies:
     source-map "~0.6.0"
 
+clean-stack@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
+  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
+
 cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
@@ -3403,7 +3466,7 @@ cli-boxes@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.0.tgz#538ecae8f9c6ca508e3c3c95b453fe93cb4c168d"
 
-cli-cursor@^2.1.0:
+cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   dependencies:
@@ -3421,6 +3484,14 @@ cli-table3@0.5.1, cli-table3@^0.5.1:
     string-width "^2.1.1"
   optionalDependencies:
     colors "^1.1.2"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  integrity sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cli-truncate@^1.1.0:
   version "1.1.0"
@@ -3568,6 +3639,11 @@ commander@^2.11.0:
 commander@^2.19.0, commander@^2.9.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+
+commander@^2.20.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commander@~2.19.0:
   version "2.19.0"
@@ -3806,7 +3882,7 @@ cosmiconfig@^4.0.0:
     parse-json "^4.0.0"
     require-from-string "^2.0.1"
 
-cosmiconfig@^5.0.0, cosmiconfig@^5.2.0:
+cosmiconfig@^5.0.0, cosmiconfig@^5.2.0, cosmiconfig@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
   dependencies:
@@ -3893,6 +3969,15 @@ cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+cross-spawn@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
+  integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 crypt@~0.0.1:
   version "0.0.2"
@@ -4173,6 +4258,11 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+date-fns@^1.27.2:
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
+  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -4214,6 +4304,11 @@ decompress-response@^3.2.0, decompress-response@^3.3.0:
   resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
   dependencies:
     mimic-response "^1.0.0"
+
+dedent@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
+  integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
 deep-equal@^1.0.1:
   version "1.0.1"
@@ -4312,6 +4407,20 @@ del@^4.1.1:
     p-map "^2.0.0"
     pify "^4.0.1"
     rimraf "^2.6.3"
+
+del@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-5.1.0.tgz#d9487c94e367410e6eff2925ee58c0c84a75b3a7"
+  integrity sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==
+  dependencies:
+    globby "^10.0.1"
+    graceful-fs "^4.2.2"
+    is-glob "^4.0.1"
+    is-path-cwd "^2.2.0"
+    is-path-inside "^3.0.1"
+    p-map "^3.0.0"
+    rimraf "^3.0.0"
+    slash "^3.0.0"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -4425,6 +4534,13 @@ dir-glob@2.0.0:
   dependencies:
     arrify "^1.0.1"
     path-type "^3.0.0"
+
+dir-glob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+  dependencies:
+    path-type "^4.0.0"
 
 dlv@^1.1.0:
   version "1.1.1"
@@ -4610,6 +4726,11 @@ electron-to-chromium@^1.3.122, electron-to-chromium@^1.3.137:
 electron-to-chromium@^1.3.133, electron-to-chromium@^1.3.47:
   version "1.3.137"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz#ba7c88024984c038a5c5c434529aabcea7b42944"
+
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
+  integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
 
 element-resize-detector@^1.1.15:
   version "1.1.15"
@@ -5196,6 +5317,21 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-2.1.0.tgz#e5d3ecd837d2a60ec50f3da78fd39767747bbe99"
+  integrity sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^3.0.0"
+    onetime "^5.1.0"
+    p-finally "^2.0.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
 exenv@^1.2.0, exenv@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
@@ -5343,6 +5479,17 @@ fast-glob@^2.0.2, fast-glob@^2.2.2:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
+fast-glob@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.1.0.tgz#77375a7e3e6f6fc9b18f061cddd28b8d1eec75ae"
+  integrity sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -5354,6 +5501,13 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4:
 fastparse@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
+
+fastq@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.6.0.tgz#4ec8a38f4ac25f21492673adb7eae9cfef47d1c2"
+  integrity sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==
+  dependencies:
+    reusify "^1.0.0"
 
 fault@^1.0.2:
   version "1.0.3"
@@ -5424,6 +5578,14 @@ figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
 
+figures@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+  integrity sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    object-assign "^4.1.0"
+
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -5485,6 +5647,13 @@ fill-range@^4.0.0:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
+
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
 
 finalhandler@~1.1.2:
   version "1.1.2"
@@ -6084,6 +6253,11 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
+get-own-enumerable-property-symbols@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.1.tgz#6f7764f88ea11e0b514bd9bd860a132259992ca4"
+  integrity sha512-09/VS4iek66Dh2bctjRkowueRJbY1JDGR1L/zRxO1Qk8Uxs6PnqaNSqalpizPT+CDjre3hnEsuzvhgomz9qYrA==
+
 get-port@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
@@ -6092,6 +6266,11 @@ get-stdin@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
 
+get-stdin@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-7.0.0.tgz#8d5de98f15171a125c5e516643c7a6d0ea8a96f6"
+  integrity sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==
+
 get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
@@ -6099,6 +6278,13 @@ get-stream@3.0.0, get-stream@^3.0.0:
 get-stream@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+  dependencies:
+    pump "^3.0.0"
+
+get-stream@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
+  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
   dependencies:
     pump "^3.0.0"
 
@@ -6124,6 +6310,13 @@ glob-parent@^3.1.0:
   dependencies:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
+
+glob-parent@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
+  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
+  dependencies:
+    is-glob "^4.0.1"
 
 glob-to-regexp@^0.3.0:
   version "0.3.0"
@@ -6235,6 +6428,20 @@ globby@8.0.2:
     pify "^3.0.0"
     slash "^1.0.0"
 
+globby@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-10.0.1.tgz#4782c34cb75dd683351335c5829cc3420e606b22"
+  integrity sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.0.3"
+    glob "^7.1.3"
+    ignore "^5.1.1"
+    merge2 "^1.2.3"
+    slash "^3.0.0"
+
 globby@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
@@ -6327,6 +6534,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
 graceful-fs@^4.1.15, graceful-fs@^4.1.9:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
+
+graceful-fs@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
+  integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
 
 graphql-compose@^6.3.2:
   version "6.3.2"
@@ -6809,6 +7021,23 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
+husky@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-3.0.8.tgz#8de3fed26ce9b43034ef51013c4ad368b6b74ea8"
+  integrity sha512-HFOsgcyrX3qe/rBuqyTt+P4Gxn5P0seJmr215LAZ/vnwK3jWB3r0ck7swbzGRUbufCf9w/lgHPVbF/YXQALgfQ==
+  dependencies:
+    chalk "^2.4.2"
+    cosmiconfig "^5.2.1"
+    execa "^1.0.0"
+    get-stdin "^7.0.0"
+    is-ci "^2.0.0"
+    opencollective-postinstall "^2.0.2"
+    pkg-dir "^4.2.0"
+    please-upgrade-node "^3.2.0"
+    read-pkg "^5.1.1"
+    run-node "^1.0.0"
+    slash "^3.0.0"
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -6861,6 +7090,11 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
 
+ignore@^5.1.1:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
+  integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
+
 immer@1.10.0:
   version "1.10.0"
   resolved "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
@@ -6910,9 +7144,14 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
-indent-string@^3.1.0, indent-string@^3.2.0:
+indent-string@^3.0.0, indent-string@^3.1.0, indent-string@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
+
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
 indexes-of@^1.0.1:
   version "1.0.1"
@@ -7264,6 +7503,13 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
+is-glob@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
 is-hexadecimal@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz#6e084bbc92061fbb0971ec58b6ce6d404e24da69"
@@ -7295,13 +7541,25 @@ is-number@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
 
-is-obj@^1.0.0:
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
 is-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+
+is-observable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-1.1.0.tgz#b3e986c8f44de950867cab5403f5a3465005975e"
+  integrity sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==
+  dependencies:
+    symbol-observable "^1.1.0"
 
 is-odd@^2.0.0:
   version "2.0.0"
@@ -7316,6 +7574,11 @@ is-path-cwd@^1.0.0:
 is-path-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.1.0.tgz#2e0c7e463ff5b7a0eb60852d851a6809347a124c"
+
+is-path-cwd@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
+  integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
 
 is-path-in-cwd@^1.0.0:
   version "1.0.1"
@@ -7340,6 +7603,11 @@ is-path-inside@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-2.1.0.tgz#7c9810587d659a40d27bcdb4d5616eab059494b2"
   dependencies:
     path-is-inside "^1.0.2"
+
+is-path-inside@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz#f5220fc82a3e233757291dddc9c5877f2a1f3017"
+  integrity sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
 
 is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
@@ -7370,6 +7638,11 @@ is-regex@^1.0.4:
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:
     has "^1.0.1"
+
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+  integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
 is-relative-url@^2.0.0:
   version "2.0.0"
@@ -7402,6 +7675,11 @@ is-root@2.0.0:
 is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
 is-svg@^3.0.0:
   version "3.0.0"
@@ -7807,6 +8085,75 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lines-and-columns@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
+  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+
+lint-staged@^9.4.2:
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-9.4.2.tgz#14cb577a9512f520691f8b5aefce6a8f7ead6c04"
+  integrity sha512-OFyGokJSWTn2M6vngnlLXjaHhi8n83VIZZ5/1Z26SULRUWgR3ITWpAEQC9Pnm3MC/EpCxlwts/mQWDHNji2+zA==
+  dependencies:
+    chalk "^2.4.2"
+    commander "^2.20.0"
+    cosmiconfig "^5.2.1"
+    debug "^4.1.1"
+    dedent "^0.7.0"
+    del "^5.0.0"
+    execa "^2.0.3"
+    listr "^0.14.3"
+    log-symbols "^3.0.0"
+    micromatch "^4.0.2"
+    normalize-path "^3.0.0"
+    please-upgrade-node "^3.1.1"
+    string-argv "^0.3.0"
+    stringify-object "^3.3.0"
+
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+  integrity sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=
+
+listr-update-renderer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz#4ea8368548a7b8aecb7e06d8c95cb45ae2ede6a2"
+  integrity sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^2.3.0"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz#f1132167535ea4c1261102b9f28dac7cba1e03db"
+  integrity sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==
+  dependencies:
+    chalk "^2.4.1"
+    cli-cursor "^2.1.0"
+    date-fns "^1.27.2"
+    figures "^2.0.0"
+
+listr@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.14.3.tgz#2fea909604e434be464c50bddba0d496928fa586"
+  integrity sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==
+  dependencies:
+    "@samverschueren/stream-to-observable" "^0.3.0"
+    is-observable "^1.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.5.0"
+    listr-verbose-renderer "^0.5.0"
+    p-map "^2.0.0"
+    rxjs "^6.3.3"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -7954,6 +8301,29 @@ lodash@^4.11.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5:
 lodash@^4.13.1, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  integrity sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=
+  dependencies:
+    chalk "^1.0.0"
+
+log-symbols@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
+  integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
+  dependencies:
+    chalk "^2.4.2"
+
+log-update@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-2.3.0.tgz#88328fd7d1ce7938b29283746f0b1bc126b24708"
+  integrity sha1-iDKP19HOeTiykoN0bwsbwSayRwg=
+  dependencies:
+    ansi-escapes "^3.0.0"
+    cli-cursor "^2.0.0"
+    wrap-ansi "^3.0.1"
 
 log-update@^3.0.0:
   version "3.2.0"
@@ -8248,9 +8618,19 @@ merge-stream@^1.0.1:
   dependencies:
     readable-stream "^2.0.1"
 
+merge-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
 merge2@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
+
+merge2@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
+  integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
 
 messageformat-parser@^1.1.0:
   version "1.1.0"
@@ -8292,6 +8672,14 @@ micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
+micromatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -8331,7 +8719,7 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
-mimic-fn@^2.0.0:
+mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
 
@@ -8682,6 +9070,16 @@ normalize-package-data@^2.3.2:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
+normalize-package-data@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
+  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
+  dependencies:
+    hosted-git-info "^2.1.4"
+    resolve "^1.10.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
 normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
@@ -8733,6 +9131,13 @@ npm-run-path@^2.0.0:
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
   dependencies:
     path-key "^2.0.0"
+
+npm-run-path@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-3.1.0.tgz#7f91be317f6a466efed3c9f2980ad8a4ee8b0fa5"
+  integrity sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==
+  dependencies:
+    path-key "^3.0.0"
 
 npmlog@^4.0.2, npmlog@^4.1.2:
   version "4.1.2"
@@ -8892,11 +9297,23 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+onetime@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
+  integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
+  dependencies:
+    mimic-fn "^2.1.0"
+
 open@^6.1.0:
   version "6.3.0"
   resolved "https://registry.npmjs.org/open/-/open-6.3.0.tgz#60d0b845ee38fae0631f5d739a21bd40e3d2a527"
   dependencies:
     is-wsl "^1.1.0"
+
+opencollective-postinstall@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
+  integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
 
 opentracing@^0.14.3:
   version "0.14.3"
@@ -9007,6 +9424,11 @@ p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
+p-finally@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-2.0.1.tgz#bd6fcaa9c559a096b680806f4d657b3f0f240561"
+  integrity sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==
+
 p-is-promise@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
@@ -9052,6 +9474,13 @@ p-map@^1.1.1:
 p-map@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
+
+p-map@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-3.0.0.tgz#d704d9af8a2ba684e2600d9a215983d4141a979d"
+  integrity sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==
+  dependencies:
+    aggregate-error "^3.0.0"
 
 p-timeout@^1.1.1, p-timeout@^1.2.0:
   version "1.2.1"
@@ -9154,6 +9583,16 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
+parse-json@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.0.0.tgz#73e5114c986d143efa3712d4ea24db9a4266f60f"
+  integrity sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+    lines-and-columns "^1.1.6"
+
 parse-latin@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/parse-latin/-/parse-latin-4.1.0.tgz#f560d46cab1cf04d632815443485a8b3b31e31a7"
@@ -9228,6 +9667,11 @@ path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
+path-key@^3.0.0, path-key@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.0.tgz#99a10d870a803bdd5ee6f0470e58dfcd2f9a54d3"
+  integrity sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==
+
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
@@ -9260,6 +9704,11 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
 pbkdf2@^3.0.3:
   version "3.0.14"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.14.tgz#a35e13c64799b06ce15320f459c230e68e73bade"
@@ -9277,6 +9726,11 @@ performance-now@^2.1.0:
 physical-cpu-count@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/physical-cpu-count/-/physical-cpu-count-2.0.0.tgz#18de2f97e4bf7a9551ad7511942b5496f7aba660"
+
+picomatch@^2.0.5:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
+  integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
 
 pify@^2.0.0:
   version "2.3.0"
@@ -9318,7 +9772,7 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
-pkg-dir@^4.1.0:
+pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   dependencies:
@@ -9329,6 +9783,13 @@ pkg-up@2.0.0:
   resolved "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
   dependencies:
     find-up "^2.1.0"
+
+please-upgrade-node@^3.1.1, please-upgrade-node@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
+  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
+  dependencies:
+    semver-compare "^1.0.0"
 
 pluralize@^7.0.0:
   version "7.0.0"
@@ -10450,6 +10911,16 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
+read-pkg@^5.1.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
+  integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
+  dependencies:
+    "@types/normalize-package-data" "^2.4.0"
+    normalize-package-data "^2.5.0"
+    parse-json "^5.0.0"
+    type-fest "^0.6.0"
+
 read@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
@@ -10927,6 +11398,11 @@ retext-english@^3.0.0:
     parse-english "^4.0.0"
     unherit "^1.0.4"
 
+reusify@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rgb-regex@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/rgb-regex/-/rgb-regex-1.0.1.tgz#c0e0d6882df0e23be254a475e8edd41915feaeb1"
@@ -10947,6 +11423,13 @@ rimraf@^2.2.8, rimraf@^2.5.0, rimraf@^2.5.4, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
+rimraf@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.0.tgz#614176d4b3010b75e5c390eb0ee96f6dc0cebb9b"
+  integrity sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.1.tgz#0f4584295c53a3628af7e6d79aca21ce57d1c6e7"
@@ -10959,6 +11442,16 @@ run-async@^2.2.0:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
     is-promise "^2.1.0"
+
+run-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
+  integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
+
+run-parallel@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
+  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
@@ -10981,6 +11474,13 @@ rxjs@^5.3.0:
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.8.tgz#b2b0809a57614ad6254c03d7446dea0d83ca3791"
   dependencies:
     symbol-observable "1.0.1"
+
+rxjs@^6.3.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"
+  integrity sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==
+  dependencies:
+    tslib "^1.9.0"
 
 rxjs@^6.4.0:
   version "6.5.2"
@@ -11078,6 +11578,11 @@ selfsigned@^1.10.4:
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.4.tgz#cdd7eccfca4ed7635d47a08bf2d5d3074092e2cd"
   dependencies:
     node-forge "0.7.5"
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
 semver-diff@^2.0.0:
   version "2.1.0"
@@ -11230,9 +11735,21 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shell-quote@1.6.1:
   version "1.6.1"
@@ -11302,6 +11819,16 @@ sitemap@^1.12.0:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slice-ansi@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+  integrity sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
 
 slice-ansi@1.0.0, slice-ansi@^1.0.0:
   version "1.0.0"
@@ -11656,6 +12183,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
 
+string-argv@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
+  integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
+
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
@@ -11749,6 +12281,15 @@ stringify-entities@^1.0.1:
     is-alphanumerical "^1.0.0"
     is-hexadecimal "^1.0.0"
 
+stringify-object@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
+  integrity sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==
+  dependencies:
+    get-own-enumerable-property-symbols "^3.0.0"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
+
 strip-ansi@3.0.1, strip-ansi@^3, strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -11788,6 +12329,11 @@ strip-color@^0.1.0:
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+
+strip-final-newline@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
 strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -11896,7 +12442,7 @@ symbol-observable@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
 
-symbol-observable@^1.0.4, symbol-observable@^1.2.0:
+symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
@@ -12098,6 +12644,13 @@ to-regex-range@^2.1.0:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
 
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
+
 to-regex@^3.0.1, to-regex@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
@@ -12206,6 +12759,11 @@ type-check@~0.3.2:
 type-fest@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
+
+type-fest@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
+  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
@@ -12936,6 +13494,13 @@ which@^1.3.1:
   dependencies:
     isexe "^2.0.0"
 
+which@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.1.tgz#f1cf94d07a8e571b6ff006aeb91d0300c47ef0a4"
+  integrity sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==
+  dependencies:
+    isexe "^2.0.0"
+
 wide-align@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
@@ -12978,6 +13543,14 @@ wrap-ansi@^2.0.0:
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
+
+wrap-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz#288a04d87eda5c286e060dfe8f135ce8d007f8ba"
+  integrity sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
 
 wrap-ansi@^5.0.0:
   version "5.1.0"


### PR DESCRIPTION
This PR implements #162, and adds a precommit hook via [lint-staged](https://github.com/okonet/lint-staged/) and [husky](https://github.com/typicode/husky). For the time being, I have only added an entry to lint-staged to format markdown (md) files. As well, all the md files have been formatted using the prettier settings that I copied from Storybook's settings.

Built everything locally and it looks good. I just did a smoke test navigating to some pages.

![learnstorybook.com screeshot](https://user-images.githubusercontent.com/833231/66687352-5fc81e00-ec50-11e9-8058-a0828819b2b3.png)

Also, Skeletor approves of this PR.

![Skeletor approves](https://media.giphy.com/media/aWRWTF27ilPzy/giphy.gif)
