### PR TITLE
Add link for Angular Spanish guide

### DIFF
--- a/content/intro-to-storybook/react/es/get-started.md
+++ b/content/intro-to-storybook/react/es/get-started.md
@@ -5,7 +5,7 @@ description: "Configurar React Storybook en tu entorno de desarrollo"
 commit: ebe2ae2
 ---
 
-Storybook se ejecuta junto con tu aplicación en modo desarrollo. Te ayuda a crear componentes de UI aislados de la lógica y el contexto de tu aplicación. Esta edición de Aprende Storybook es para React; otras ediciones para Vue y Angular vendrán pronto.
+Storybook se ejecuta junto con tu aplicación en modo desarrollo. Te ayuda a crear componentes de UI aislados de la lógica y el contexto de tu aplicación. Esta edición de Aprende Storybook es para React; existe una edición para [Angular](/angular/es/get-started) y para Vue vendrá pronto.
 
 ![Storybook and your app](/intro-to-storybook/storybook-relationship.jpg)
 


### PR DESCRIPTION
The current Spanish guide for React doesn't contain the link for the Angular guide in the "Get started section". I added the link in this PR.