### PR TITLE
Fix Spanish translation and update example code

### DIFF
--- a/content/intro-to-storybook/react/es/composite-component.md
+++ b/content/intro-to-storybook/react/es/composite-component.md
@@ -13,7 +13,7 @@ Taskbox enfatiza las tareas ancladas colocándolas por encima de las tareas pred
 
 ![default and pinned tasks](/intro-to-storybook/tasklist-states-1.png)
 
-Dado que los datos de `Tareas` pueden enviarse asincrónicamente, **también** necesitamos un estado de cargando para renderizar en ausencia de alguna conexión. Además, también se requiere un estado vacío para cuando no hay tareas.
+Dado que los datos de `Task` pueden enviarse asincrónicamente, **también** necesitamos un estado de cargando para renderizar en ausencia de alguna conexión. Además, también se requiere un estado vacío para cuando no hay tareas.
 
 ![empty and loading tasks](/intro-to-storybook/tasklist-states-2.png)
 
@@ -21,9 +21,11 @@ Dado que los datos de `Tareas` pueden enviarse asincrónicamente, **también** n
 
 Un componente compuesto no es muy diferente de los componentes básicos que contiene. Crea un componente `TaskList` y un archivo de historia que lo acompañe: `src/components/TaskList.js` y `src/components/TaskList.stories.js`.
 
-Comienza con una implementación aproximada de la `TaskList`. Necesitarás importar el componente `Tareas` del capítulo anterior y pasarle los atributos y acciones como entrada.
+Comienza con una implementación aproximada de la `TaskList`. Necesitarás importar el componente `Task` del capítulo anterior y pasarle los atributos y acciones como entrada.
 
 ```javascript
+// src/components/TaskList.js
+
 import React from 'react';
 
 import Task from './Task';
@@ -55,28 +57,26 @@ export default TaskList;
 A continuación, crea los estados de prueba de `Tasklist` en el archivo de historia.
 
 ```javascript
+// src/components/TaskList.stories.js
+
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import TaskList from './TaskList';
-import { createTask, actions } from './Task.stories';
+import { task, actions } from './Task.stories';
 
 export const defaultTasks = [
-  createTask({ state: 'TASK_INBOX' }),
-  createTask({ state: 'TASK_INBOX' }),
-  createTask({ state: 'TASK_INBOX' }),
-  createTask({ state: 'TASK_INBOX' }),
-  createTask({ state: 'TASK_INBOX' }),
-  createTask({ state: 'TASK_INBOX' }),
+  { ...task, id: '1', title: 'Task 1' },
+  { ...task, id: '2', title: 'Task 2' },
+  { ...task, id: '3', title: 'Task 3' },
+  { ...task, id: '4', title: 'Task 4' },
+  { ...task, id: '5', title: 'Task 5' },
+  { ...task, id: '6', title: 'Task 6' },
 ];
 
 export const withPinnedTasks = [
-  createTask({ title: 'Task 1', state: 'TASK_INBOX' }),
-  createTask({ title: 'Task 2', state: 'TASK_INBOX' }),
-  createTask({ title: 'Task 3', state: 'TASK_INBOX' }),
-  createTask({ title: 'Task 4', state: 'TASK_INBOX' }),
-  createTask({ title: 'Task 5', state: 'TASK_INBOX' }),
-  createTask({ title: 'Task 6 (pinned)', state: 'TASK_PINNED' }),
+  ...defaultTasks.slice(0, 5),
+  { id: '6', title: 'Task 6 (pinned)', state: 'TASK_PINNED' },
 ];
 
 storiesOf('TaskList', module)
@@ -90,12 +90,12 @@ storiesOf('TaskList', module)
 `addDecorator()` nos permite añadir algún "contexto" al renderizado de cada tarea. En este caso añadimos relleno alrededor de la lista para que sea más fácil de verificar visualmente.
 
 <div class="aside">
-Los <a href="https://storybook.js.org/addons/introduction/#1-decorators"><b>Decoradores</b></a> son una forma de proporcionar envoltorios arbitrarios a las historias. En este caso estamos usando un decorador para añadir estilo. También se pueden utilizar para envolver historias en "proveedores", es decir, componentes de la librebría que establecen el contexto de React.
+Los <a href="https://storybook.js.org/addons/introduction/#1-decorators"><b>Decoradores</b></a> son una forma de proporcionar envoltorios arbitrarios a las historias. En este caso estamos usando un decorador para añadir estilo. También se pueden utilizar para envolver historias en "proveedores", es decir, componentes de la librería que establecen el contexto de React.
 </div>
 
-`createTask()` es una función de ayuda que genera la forma de una Tarea que creamos y exportamos desde el archivo `Task.stories.js`. De manera similar, las `acciones` exportadas de `Task.stories.js` definieron las acciones (comunmente llamadas mockeadas) que espera un componente `Task`, el cual también necesita la `TaskList`.
+`task` provee la forma de un `Task` que creamos y exportamos desde el archivo `Task.stories.js`. De manera similar, `actions` define las acciones (llamadas simuladas)  que espera un componente `Task`, el cual también necesita la `TaskList`.
 
-Ahora revise Storybook para ver las nuevas historias de la lista de tareas.
+Ahora hay que revisar Storybook para ver las nuevas historias de `TaskList`.
 
 <video autoPlay muted playsInline loop>
   <source
@@ -109,6 +109,8 @@ Ahora revise Storybook para ver las nuevas historias de la lista de tareas.
 Nuestro componente sigue siendo muy rudimentario, pero ahora tenemos una idea de las historias en las que trabajaremos. Podrías estar pensando que el envoltorio de `.list-items` es demasiado simplista. Tienes razón, en la mayoría de los casos no crearíamos un nuevo componente sólo para añadir un envoltorio. Pero la **complejidad real** del componente `TaskList` se revela en los casos extremos `withPinnedTasks`, `loading`, y `empty`.
 
 ```javascript
+// src/components/TaskList.js
+
 import React from 'react';
 
 import Task from './Task';
@@ -181,11 +183,15 @@ Observa la posición del elemento anclado en la lista. Queremos que el elemento 
 
 ## Requisitos de data y props
 
-A medida que el componente crece, también lo hacen los parámetros de entrada requeridos de `TaskList`. Define las props requeridas de `TaskList`. Debido a que `Task` es un componente hijo, asegúrate de proporcionar los datos en la forma correcta para renderizarlo. Para ahorrar tiempo y dolores de cabeza, reutiliza los propTypes que definiste en `Tareas` anteriormente.
+A medida que el componente crece, también lo hacen los parámetros de entrada requeridos de `TaskList`. Define las props requeridas de `TaskList`. Debido a que `Task` es un componente hijo, asegúrate de proporcionar los datos en la forma correcta para renderizarlo. Para ahorrar tiempo y dolores de cabeza, reutiliza los propTypes que definiste en `Task` anteriormente.
 
 ```javascript
+// src/components/TaskList.js
+
 import React from 'react';
 import PropTypes from 'prop-types';
+
+import Task from './Task';
 
 function TaskList() {
   ...
@@ -222,9 +228,11 @@ En nuestro caso, queremos que nuestra `TaskList` muestre cualquier tarea anclada
 
 Por lo tanto, para evitar este problema, podemos usar Jest para renderizar la historia en el DOM y ejecutar algún código de consulta del DOM para verificar las características salientes del resultado.
 
-Crea un archivo de prueba llamado `Task.test.js`. Aquí vamos a construir nuestras pruebas que hacen afirmaciones acerca del resultado.
+Crea un archivo de prueba llamado `src/components/TaskList.test.js`. Aquí vamos a construir nuestras pruebas que hacen afirmaciones acerca del resultado.
 
 ```javascript
+// src/components/TaskList.test.js
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TaskList from './TaskList';
@@ -235,7 +243,7 @@ it('renders pinned tasks at the start of the list', () => {
   const events = { onPinTask: jest.fn(), onArchiveTask: jest.fn() };
   ReactDOM.render(<TaskList tasks={withPinnedTasks} {...events} />, div);
 
-  // Esperamos que la tarea titulada "Tarea 6 (anclada)" se ejecute primero, no al final.
+  // Esperamos que la tarea titulada "Task 6 (pinned)" se ejecute primero, no al final.
   const lastTaskInput = div.querySelector('.list-item:nth-child(1) input[value="Task 6 (pinned)"]');
   expect(lastTaskInput).not.toBe(null);
 
@@ -247,4 +255,4 @@ it('renders pinned tasks at the start of the list', () => {
 
 Nota que hemos sido capaces de reutilizar la lista de tareas `withPinnedTasks` tanto en la prueba de la historia como en el test unitario; de esta manera podemos continuar aprovechando un recurso existente (los ejemplos que representan configuraciones interesantes de un componente) de más y más maneras.
 
-Note también que esta prueba es bastante frágil. Es posible que a medida que el proyecto madure y que la implementación exacta de la `Tarea` cambie --quizás usando un nombre de clase diferente o un "área de texto" en lugar de un "input" en el etiquetado-- la prueba falle y necesite ser actualizada. Esto no es necesariamente un problema, sino más bien una indicación de que hay que ser bastante cuidadoso usando pruebas unitarias para la UI. No son fáciles de mantener. En su lugar, confía en las pruebas visuales, de instantáneas y de regresión visual (mira el [capitulo sobre las pruebas](/test/)) siempre que te sea posible.
+Nota también que esta prueba es bastante frágil. Es posible que a medida que el proyecto madure y que la implementación exacta de `Task` cambie --quizás usando un nombre de clase diferente o un `textarea` en lugar de un `input`-- la prueba falle y necesite ser actualizada. Esto no es necesariamente un problema, sino más bien una indicación de que hay que ser bastante cuidadoso usando pruebas unitarias para la UI. No son fáciles de mantener. En su lugar, confía en las pruebas visuales, de instantáneas y de regresión visual (mira el [capitulo sobre las pruebas](/test/)) siempre que te sea posible.


### PR DESCRIPTION
- Fix Spanish translation and update example code to be equal that English version for "Composite component" chapter.
- Add the correct name of the components, we are using the English name in the code so it doesn't need to be translated.