### PR TITLE
Fix for issue #192

### DIFF
--- a/src/components/screens/GuideScreen/Hero.js
+++ b/src/components/screens/GuideScreen/Hero.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { Button, styles } from '@storybook/design-system';
-import { rgba } from 'polished';
 import GatsbyLink from '../../basics/GatsbyLink';
 import Stat from '../../basics/Stat';
 import * as animations from '../../../styles/animations';
@@ -107,17 +106,6 @@ const LanguagesLabel = styled.span`
 `;
 const LanguageLinkStyles = `
   && {
-    color: ${styles.color.lightest};
-    &:hover {
-      color: ${rgba(styles.color.lightest, 0.5)};
-    }
-    &:visited{
-      color: ${styles.color.lightest};
-    }
-    &:active {
-      color: ${rgba(styles.color.lightest, 1)};
-    }
-   
     &:not(:last-child):after{
       content:', ';
       white-space: pre;
@@ -202,7 +190,7 @@ const Hero = ({
           <Languages>
             <LanguagesLabel>Languages: </LanguagesLabel>
             {languages.map(language => (
-              <LanguagesLink key={`lang_link_${language.name}`} to={language.tutorial}>
+              <LanguagesLink inverse key={`lang_link_${language.name}`} to={language.tutorial}>
                 {language.name}
               </LanguagesLink>
             ))}

--- a/src/components/screens/GuideScreen/Hero.js
+++ b/src/components/screens/GuideScreen/Hero.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { Button, styles } from '@storybook/design-system';
+import { rgba } from 'polished';
 import GatsbyLink from '../../basics/GatsbyLink';
 import Stat from '../../basics/Stat';
-import getLanguageName from '../../../lib/getLanguageName';
 import * as animations from '../../../styles/animations';
 
 const { breakpoint, color, pageMargins, spacing, typography } = styles;
@@ -105,6 +105,29 @@ const Languages = styled.div`
 const LanguagesLabel = styled.span`
   font-weight: ${typography.weight.bold};
 `;
+const LanguageLinkStyles = `
+  && {
+    color: ${styles.color.lightest};
+    &:hover {
+      color: ${rgba(styles.color.lightest, 0.5)};
+    }
+    &:visited{
+      color: ${styles.color.lightest};
+    }
+    &:active {
+      color: ${rgba(styles.color.lightest, 1)};
+    }
+   
+    &:not(:last-child):after{
+      content:', ';
+      white-space: pre;
+    }
+  }
+ 
+`;
+const LanguagesLink = styled(GatsbyLink)`
+  ${LanguageLinkStyles}
+`;
 
 const StatWrapper = styled.div`
   margin-top: 32px;
@@ -161,44 +184,44 @@ const Hero = ({
   themeColor,
   title,
   ...rest
-}) => {
-  const languageList = languages.map(language => getLanguageName(language)).join(', ');
+}) => (
+  <HeroWrapper themeColor={themeColor} {...rest}>
+    <HeroContent>
+      <Pitch>
+        <PitchTitle>{title}</PitchTitle>
 
-  return (
-    <HeroWrapper themeColor={themeColor} {...rest}>
-      <HeroContent>
-        <Pitch>
-          <PitchTitle>{title}</PitchTitle>
+        {description && <PitchDescription>{description}</PitchDescription>}
 
-          {description && <PitchDescription>{description}</PitchDescription>}
+        {ctaHref && (
+          <GatsbyLink to={ctaHref}>
+            <GetStartedButton>Get started</GetStartedButton>
+          </GatsbyLink>
+        )}
 
-          {ctaHref && (
-            <GatsbyLink to={ctaHref}>
-              <GetStartedButton>Get started</GetStartedButton>
-            </GatsbyLink>
-          )}
+        {languages.length > 0 && (
+          <Languages>
+            <LanguagesLabel>Languages: </LanguagesLabel>
+            {languages.map(language => (
+              <LanguagesLink key={`lang_link_${language.name}`} to={language.tutorial}>
+                {language.name}
+              </LanguagesLink>
+            ))}
+          </Languages>
+        )}
+        <StatWrapper>
+          {contributorCount && <Stat value={contributorCount} label="Contributors" />}
+          {chapterCount && <Stat value={chapterCount} label="Chapters" />}
+        </StatWrapper>
+      </Pitch>
 
-          {languageList.length > 0 && (
-            <Languages>
-              <LanguagesLabel>Languages: </LanguagesLabel>
-              {languageList}
-            </Languages>
-          )}
-          <StatWrapper>
-            {contributorCount && <Stat value={contributorCount} label="Contributors" />}
-            {chapterCount && <Stat value={chapterCount} label="Chapters" />}
-          </StatWrapper>
-        </Pitch>
-
-        <Figure>
-          {imagePath && (
-            <GuideImage alt={title} heroAnimationName={heroAnimationName} src={imagePath} />
-          )}
-        </Figure>
-      </HeroContent>
-    </HeroWrapper>
-  );
-};
+      <Figure>
+        {imagePath && (
+          <GuideImage alt={title} heroAnimationName={heroAnimationName} src={imagePath} />
+        )}
+      </Figure>
+    </HeroContent>
+  </HeroWrapper>
+);
 
 Hero.propTypes = {
   contributorCount: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -207,7 +230,12 @@ Hero.propTypes = {
   description: PropTypes.string,
   heroAnimationName: PropTypes.string,
   imagePath: PropTypes.string,
-  languages: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+  languages: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string,
+      tutorial: PropTypes.string,
+    })
+  ).isRequired,
   themeColor: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
 };

--- a/src/components/screens/GuideScreen/Hero.stories.js
+++ b/src/components/screens/GuideScreen/Hero.stories.js
@@ -2,18 +2,140 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import Hero from './Hero';
 
+// list of possible available languages used for stories
+const storyLanguages = [
+  {
+    name: 'English',
+    tutorial: '/intro-to-storybook/react/en/get-started/',
+  },
+  {
+    name: 'Español',
+    tutorial: '/intro-to-storybook/react/es/get-started/',
+  },
+  {
+    name: 'Português',
+    tutorial: '/intro-to-storybook/react/pt/get-started/',
+  },
+  {
+    name: '简体中文',
+    tutorial: '/intro-to-storybook/react/zh-CN/get-started/',
+  },
+  {
+    name: '繁體中文',
+    tutorial: '/intro-to-storybook/react/zh-TW/get-started/',
+  },
+  {
+    name: 'Nederlandse',
+    tutorial: '/intro-to-storybook/react/nl/get-started/',
+  },
+  {
+    name: 'Deutsche',
+    tutorial: '/intro-to-storybook/react/de/get-started/',
+  },
+  {
+    name: 'Polskie',
+    tutorial: '/intro-to-storybook/react/pl/get-started/',
+  },
+  {
+    name: '한국어',
+    tutorial: '/intro-to-storybook/react/kr/get-started/',
+  },
+  {
+    name: '日本語',
+    tutorial: '/intro-to-storybook/react/jp/get-started/',
+  },
+  {
+    name: 'South African',
+    tutorial: '/intro-to-storybook/react/za/get-started/',
+  },
+  {
+    name: 'Svenska',
+    tutorial: '/intro-to-storybook/react/se/get-started/',
+  },
+  {
+    name: 'Français',
+    tutorial: '/intro-to-storybook/react/fr/get-started/',
+  },
+  {
+    name: 'Slovensko',
+    tutorial: '/intro-to-storybook/react/si/get-started/',
+  },
+  {
+    name: 'български',
+    tutorial: '/intro-to-storybook/react/bg/get-started/',
+  },
+  {
+    name: 'Ungherese',
+    tutorial: '/intro-to-storybook/react/hu/get-started/',
+  },
+  {
+    name: 'Italiano',
+    tutorial: '/intro-to-storybook/react/it/get-started/',
+  },
+  {
+    name: 'Türk',
+    tutorial: '/intro-to-storybook/react/tr/get-started/',
+  },
+  {
+    name: 'ישראלי',
+    tutorial: '/intro-to-storybook/react/il/get-started/',
+  },
+  {
+    name: 'Ελληνικά',
+    tutorial: '/intro-to-storybook/react/gr/get-started/',
+  },
+  {
+    name: 'русский',
+    tutorial: '/intro-to-storybook/react/ru/get-started/',
+  },
+];
+//
+// list of baseline language for the first 3 stories
+const defaultLanguages = storyLanguages.slice(0, 5);
+//
+
 const props = {
   ctaHref: '/get-started',
   description:
     "Visual testing is a pragmatic yet precise way to verify the look of UI components. It's practiced by companies like Slack, Lonely Planet and Walmart. This 31-page handbook gives you an overview of visual testing in React.",
   imagePath: '/guide-cover/intro.svg',
-  languages: ['en', 'es', 'zh-CN', 'zh-TW', 'pt'],
   themeColor: '#6F2CAC',
   title: 'Visual Testing Handbook',
 };
 
 storiesOf('Screens|GuideScreen/Hero', module)
   .addParameters({ component: Hero })
-  .add('default', () => <Hero {...props} />)
-  .add('with contributor count', () => <Hero {...props} contributorCount="34+" />)
-  .add('with chapter count', () => <Hero {...props} contributorCount="34+" chapterCount={9} />);
+  .add('default', () => <Hero {...props} languages={defaultLanguages} />)
+  .add('with contributor count', () => (
+    <Hero {...props} contributorCount="34+" languages={defaultLanguages} />
+  ))
+  .add('with chapter count', () => (
+    <Hero {...props} contributorCount="34+" chapterCount={9} languages={defaultLanguages} />
+  ))
+  .add('with only one language', () => (
+    <Hero
+      {...props}
+      contributorCount="34+"
+      chapterCount={9}
+      languages={storyLanguages.slice(0, 1)}
+    />
+  ))
+  .add('with +5 languages', () => (
+    <Hero
+      {...props}
+      contributorCount="34+"
+      chapterCount={9}
+      languages={storyLanguages.slice(0, 7)}
+    />
+  ))
+  .add('with +10 languages', () => (
+    <Hero
+      {...props}
+      contributorCount="34+"
+      chapterCount={9}
+      languages={storyLanguages.slice(0, 12)}
+    />
+  ))
+  .add('with +20 languages', () => (
+    <Hero {...props} contributorCount="34+" chapterCount={9} languages={storyLanguages} />
+  ));

--- a/src/components/screens/GuideScreen/index.js
+++ b/src/components/screens/GuideScreen/index.js
@@ -12,6 +12,7 @@ import Hero from './Hero';
 import TableOfContents from './TableOfContents';
 import { guideFormatting } from '../../../styles/formatting';
 import tocEntries from '../../../lib/tocEntries';
+import getLanguageName from '../../../lib/getLanguageName';
 
 const { breakpoint, color, pageMargins, typography } = styles;
 
@@ -73,7 +74,7 @@ const getTranslationLanguages = translationPages =>
     new Set()
   );
 
-const Guide = ({ data }) => {
+const Guide = ({ data, pageContext }) => {
   const {
     currentPage: {
       html,
@@ -96,9 +97,15 @@ const Guide = ({ data }) => {
     site: { siteMetadata },
     translationPages,
   } = data;
+  const { slug } = pageContext;
   const entries = toc && toc.length > 0 ? tocEntries(toc, pages) : [];
-  const languages = Array.from(getTranslationLanguages(translationPages));
-
+  const languages = Array.from(getTranslationLanguages(translationPages)).map(language => ({
+    name: getLanguageName(language),
+    tutorial:
+      slug === '/intro-to-storybook/'
+        ? `${slug}react/${language}/get-started/`
+        : `${slug}react/${language}/introduction/`,
+  }));
   return (
     <>
       <Helmet>
@@ -202,8 +209,22 @@ Guide.propTypes = {
         title: PropTypes.string.isRequired,
       }).isRequired,
     }).isRequired,
-    translationPages: PropTypes.arrayOf(PropTypes.any).isRequired,
+    translationPages: PropTypes.shape({
+      edges: PropTypes.arrayOf(
+        PropTypes.shape({
+          node: PropTypes.shape({
+            fields: PropTypes.shape({
+              language: PropTypes.string,
+              slug: PropTypes.string,
+            }),
+          }),
+        })
+      ),
+    }),
   }).isRequired,
+  pageContext: PropTypes.shape({
+    slug: PropTypes.string.isRequired,
+  }),
 };
 
 export default Guide;

--- a/src/components/screens/GuideScreen/index.js
+++ b/src/components/screens/GuideScreen/index.js
@@ -223,7 +223,7 @@ Guide.propTypes = {
     }),
   }).isRequired,
   pageContext: PropTypes.shape({
-    slug: PropTypes.string.isRequired,
+    slug: PropTypes.string,
   }),
 };
 

--- a/src/components/screens/GuideScreen/index.js
+++ b/src/components/screens/GuideScreen/index.js
@@ -223,8 +223,8 @@ Guide.propTypes = {
     }),
   }).isRequired,
   pageContext: PropTypes.shape({
-    slug: PropTypes.string,
-  }),
+    slug: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 export default Guide;

--- a/src/components/screens/GuideScreen/index.stories.js
+++ b/src/components/screens/GuideScreen/index.stories.js
@@ -91,6 +91,9 @@ const props = {
       ],
     },
   },
+  pageContext: {
+    slug: '/intro-to-storybook/',
+  },
 };
 
 storiesOf('Screens|GuideScreen/index', module)


### PR DESCRIPTION
This PR addresses issue #192 . 

Below is a list of the changes made to fix the issue:

- In `src/components/screens/GuideScreen/index.js`:
  - Moved `getLanguageName` function call from the `Hero` component to this component.
  - Modified the `languages` array from a array of strings, to be a array of objects that contain the language and the translation path. The  name is obtained from calling the `getlanguageName` function and the path of the translation is constructed by retrieving the `slug` from gatsby's special prop `pageContext`. As per present implementation it will default to the react tutorial.
  - Updated the PropTypes for `translationPages`, to prevent warnings and reflect the current graphql result.
- In `src/components/screens/GuideScreen/index.stories.js`:
  - Added `pageContext` to the props object, per implementation above. So that the stories don't break.
- In `src/components/screens/GuideScreen/Hero.js`:
  - Removed `getLanguageName ` function call as it makes more sense to use it in the `src/components/screens/GuideScreen/index.js` component. making this component even more simple.
  - Styled the links.
- `src/components/screens/GuideScreen/Hero.stories.js`
   - A array containing possible languages and tutorial translations was created. And some extra stories aswell to check how the component would react and display the information. 


Feel free to provide feedback