### PR TITLE
Docs: added using addons section to vue tutorial and minor tweaks

### DIFF
--- a/content/intro-to-storybook/react/en/using-addons.md
+++ b/content/intro-to-storybook/react/en/using-addons.md
@@ -94,7 +94,7 @@ storiesOf('Task', module)
 
 Now a new "Knobs" tab should show up next to the "Action Logger" tab in the bottom pane.
 
-As documented [here](https://github.com/storybooks/storybook/tree/master/addons/knobs#object), the `object` knob type accepts a label and a default object as paramters. The label is constant and shows up to the left of a text field in your addons panel. The object you've passed will be represented as an editable JSON blob. As long as you submit valid JSON, your component will adjust based upon the data being passed to the object!
+As documented [here](https://github.com/storybooks/storybook/tree/master/addons/knobs#object), the `object` knob type accepts a label and a default object as parameters. The label is constant and shows up to the left of a text field in your addons panel. The object you've passed will be represented as an editable JSON blob. As long as you submit valid JSON, your component will adjust based upon the data being passed to the object!
 
 ## Addons Evolve Your Storybook's Scope
 

--- a/content/intro-to-storybook/vue/en/data.md
+++ b/content/intro-to-storybook/vue/en/data.md
@@ -69,7 +69,6 @@ In our top-level app component (`src/App.vue`) we can wire the store into our co
 <script>
   import store from './store';
   import TaskList from './components/TaskList.vue';
-  import '../src/index.css';
 
   export default {
     name: 'app',
@@ -79,6 +78,9 @@ In our top-level app component (`src/App.vue`) we can wire the store into our co
     },
   };
 </script>
+<style>
+  @import "./index.css";
+</style>
 ```
 
 Then we'll update our `TaskList` to read data out of the store. First let's move our existing presentational version to the file `src/components/PureTaskList.vue` (renaming the component to `pure-task-list`), and wrap it with a container.
@@ -209,3 +211,4 @@ it('renders pinned tasks at the start of the list', () => {
   expect(lastTaskInput).not.toBe(null);
 });
 ```
+<div class="aside">Should your snapshot tests fail at this stage, you must update the existing snapshots by running the test script with the flag -u. Or create a new script to address this issue.</div>

--- a/content/intro-to-storybook/vue/en/deploy.md
+++ b/content/intro-to-storybook/vue/en/deploy.md
@@ -24,7 +24,7 @@ To deploy Storybook we first need to export it as a static web app. This functio
 }
 ```
 
-Now when you run Storybook via `npm run build-storybook`, it will output a static Storybook in the `storybook-static` directory.
+Now when you run Storybook via `yarn build-storybook`, it will output a static Storybook in the `storybook-static` directory.
 
 ## Continuous deploy
 

--- a/content/intro-to-storybook/vue/en/get-started.md
+++ b/content/intro-to-storybook/vue/en/get-started.md
@@ -29,7 +29,7 @@ We can quickly check that the various environments of our application are workin
 yarn test:unit
 
 # Start the component explorer on port 6006:
-yarn run storybook
+yarn storybook
 
 # Run the frontend app proper on port 8080:
 yarn serve
@@ -47,7 +47,7 @@ Depending on what part of the app you’re working on, you may want to run one o
 
 ## Reuse CSS
 
-Taskbox reuses design elements from the GraphQL and React Tutorial [example app](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858), so we won’t need to write CSS in this tutorial. We’ll simply compile the LESS to a single CSS file and include it in our app. Copy and paste [this compiled CSS](https://github.com/chromaui/learnstorybook-code/blob/master/src/index.css) into `src/index.css` and then import the CSS into the app by editing the `<style>` tag in `src/App.vue` so it looks like:
+Taskbox reuses design elements from the GraphQL and React Tutorial [example app](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858), so we won’t need to write CSS in this tutorial. Copy and paste [this compiled CSS](https://github.com/chromaui/learnstorybook-code/blob/master/src/index.css) into `src/index.css` and then import the CSS into the app by editing the `<style>` tag in `src/App.vue` so it looks like:
 
 ```html
 <style>

--- a/content/intro-to-storybook/vue/en/screen.md
+++ b/content/intro-to-storybook/vue/en/screen.md
@@ -89,8 +89,6 @@ We also change the `App` component to render the `InboxScreen` (eventually we wo
 <script>
   import store from './store';
   import InboxScreen from './components/InboxScreen.vue';
-  import '../src/index.css';
-
   export default {
     name: 'app',
     store,
@@ -99,6 +97,9 @@ We also change the `App` component to render the `InboxScreen` (eventually we wo
     },
   };
 </script>
+<style>
+  @import "./index.css";
+</style>
 ```
 
 However, where things get interesting is in rendering the story in Storybook.

--- a/content/intro-to-storybook/vue/en/using-addons.md
+++ b/content/intro-to-storybook/vue/en/using-addons.md
@@ -115,7 +115,7 @@ storiesOf("Task", module)
 
 Now a new "Knobs" tab should show up next to the "Action Logger" tab in the bottom pane.
 
-As documented [here](https://github.com/storybooks/storybook/tree/master/addons/knobs#object), the `object` knob type accepts a label and a default object as paramters. The label is constant and shows up to the left of a text field in your addons panel. The object you've passed will be represented as an editable JSON blob. As long as you submit valid JSON, your component will adjust based upon the data being passed to the object!
+As documented [here](https://github.com/storybooks/storybook/tree/master/addons/knobs#object), the `object` knob type accepts a label and a default object as parameters. The label is constant and shows up to the left of a text field in your addons panel. The object you've passed will be represented as an editable JSON blob. As long as you submit valid JSON, your component will adjust based upon the data being passed to the object!
 
 ## Addons Evolve Your Storybook's Scope
 

--- a/content/intro-to-storybook/vue/en/using-addons.md
+++ b/content/intro-to-storybook/vue/en/using-addons.md
@@ -1,0 +1,213 @@
+---
+title: 'Addons'
+tocTitle: 'Addons'
+description: 'Learn how to integrate and use addons using a popular example'
+---
+
+Storybook boasts a robust system of [addons](https://storybook.js.org/addons/introduction/) with which you can enhance the developer experience for
+everybody in your team. If you've been following along with this tutorial linearly, we have referenced multiple addons so far, and you will have already implemented one in the [Testing chapter](/react/en/test/).
+
+<div class="aside">
+<strong>Looking for a list of potential addons?</strong>
+<br/>
+😍 You can see the list of officially-supported and strongly-supported community addons <a href="https://storybook.js.org/addons/addon-gallery/">here</a>.
+</div>
+
+We could write forever about configuring and using addons for all of your particular use-cases. For now, let's work towards integrating one of the most popular addons within Storybook's ecosystem: [knobs](https://github.com/storybooks/storybook/tree/master/addons/knobs).
+
+## Setting Up Knobs
+
+Knobs is an amazing resource for designers and developers to experiment and play with components in a controlled environment without the need to code! You essentially provide dynamically defined fields with which a user manipulates the props being passed to the components in your stories. Here's what we're going to implement...
+
+<video autoPlay muted playsInline loop>
+  <source
+    src="/intro-to-storybook/addon-knobs-demo.mp4"
+    type="video/mp4"
+  />
+</video>
+
+### Installation
+
+First, we will need to install all the necessary dependencies.
+
+```bash
+yarn add @storybook/addon-knobs
+```
+
+Register Knobs in your `.storybook/addons.js` file.
+
+```javascript
+// .storybook/addons.js
+
+import '@storybook/addon-actions/register';
+import '@storybook/addon-knobs/register';
+import '@storybook/addon-links/register';
+```
+
+<div class="aside">
+<strong>📝 Addon registration order matters!</strong>
+<br/>
+The order you list these addons will dictate the order in which they appear as tabs on your addon panel (for those that appear there).
+</div>
+
+That's it! Time to use it in a story.
+
+### Usage
+
+Let's use the object knob type in the `Task` component.
+
+First, import the `withKnobs` decorator and the `object` knob type to `Task.stories.js`:
+
+```javascript
+// src/components/Task.stories.js
+
+import { storiesOf } from "@storybook/vue";
+import { action } from "@storybook/addon-actions";
+import { withKnobs, object } from "@storybook/addon-knobs";
+```
+
+Next, within the stories of `Task`, pass `withKnobs` as a parameter to the `addDecorator()` function:
+
+```javascript
+// src/components/Task.stories.js
+
+storiesOf('Task', module)
+  .addDecorator(withKnobs)
+  .add(/*...*/);
+```
+
+Lastly, integrate the `object` knob type within the "default" story:
+
+```javascript
+// src/components/Task.stories.js
+storiesOf("Task", module)
+  .addDecorator(withKnobs)
+  .add("default", () => {
+    return {
+      components: { Task },
+      template: `<task :task="task" @archiveTask="onArchiveTask" @pinTask="onPinTask"/>`,
+      props: {
+        task: {
+          type: Object,
+          default: object("task", { ...task })
+        }
+      },
+      methods
+    };
+  })
+  .add("pinned", () => {
+    return {
+      components: { Task },
+      template: `<task :task="task" @archiveTask="onArchiveTask" @pinTask="onPinTask"/>`,
+      data: () => ({ task: { ...task, state: "TASK_PINNED" } }),
+      methods
+    };
+  })
+  .add("archived", () => {
+    return {
+      components: { Task },
+      template: `<task :task="task" @archiveTask="onArchiveTask" @pinTask="onPinTask"/>`,
+      data: () => ({ task: { ...task, state: "TASK_ARCHIVED" } }),
+      methods
+    };
+  });
+```
+
+Now a new "Knobs" tab should show up next to the "Action Logger" tab in the bottom pane.
+
+As documented [here](https://github.com/storybooks/storybook/tree/master/addons/knobs#object), the `object` knob type accepts a label and a default object as paramters. The label is constant and shows up to the left of a text field in your addons panel. The object you've passed will be represented as an editable JSON blob. As long as you submit valid JSON, your component will adjust based upon the data being passed to the object!
+
+## Addons Evolve Your Storybook's Scope
+
+Not only does your Storybook instance serve as a wonderful [CDD environment](https://blog.hichroma.com/component-driven-development-ce1109d56c8e), but now we're providing an interactive source of documentation. PropTypes are great, but a designer or somebody completely new to a component's code will be able to figure out its behavior very quickly via Storybook with the knobs addon implemented.
+
+## Using Knobs To Find Edge-Cases
+
+Additionally, with easy access to editing passed data to a component, QA Engineers or preventative UI Engineers can now push a component to the limit! As an example, what happens to `Task` if our list item has a _MASSIVE_ string?
+
+![Oh no! The far right content is cut-off!](/intro-to-storybook/addon-knobs-demo-edge-case.png) 😥
+
+Thanks to quickly being able to try different inputs to a component we can find and fix such problems with relative ease! Let's fix the issue with overflowing by adding a style to `Task.vue`:
+
+```html
+<!--src/components/Task.vue>-->
+
+<!-- This is the input for our task title. 
+     In practice we would probably update the styles for this element but for this tutorial, 
+     let's fix the problem with an inline style:-->
+ <input
+    type="text"
+    :readonly="true"
+    :value="this.task.title"
+    placeholder="Input title"
+    style="text-overflow: ellipsis;"
+  />
+```
+
+![That's better.](/intro-to-storybook/addon-knobs-demo-edge-case-resolved.png) 👍
+
+## Adding A New Story To Avoid Regressions
+
+Of course we can always reproduce this problem by entering the same input into the knobs, but it's better to write a fixed story for this input. This will increase your regression testing and clearly outline the limits of the component(s) to the rest of your team.
+
+Let's add a story for the long text case in Task.stories.js:
+
+```javascript
+// src/components/Task.stories.js
+
+const longTitle = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not`;
+
+storiesOf("Task", module)
+  .addDecorator(withKnobs)
+  .add("default", () => {
+    return {
+      components: { Task },
+      template: `<task :task="task" @archiveTask="onArchiveTask" @pinTask="onPinTask"/>`,
+      props: {
+        task: {
+          type: Object,
+          default: object("task", { ...task })
+        }
+      },
+      methods
+    };
+  })
+  .add("pinned", () => {
+    return {
+      components: { Task },
+      template: `<task :task="task" @archiveTask="onArchiveTask" @pinTask="onPinTask"/>`,
+      data: () => ({ task: { ...task, state: "TASK_PINNED" } }),
+      methods
+    };
+  })
+  .add("archived", () => {
+    return {
+      components: { Task },
+      template: `<task :task="task" @archiveTask="onArchiveTask" @pinTask="onPinTask"/>`,
+      data: () => ({ task: { ...task, state: "TASK_ARCHIVED" } }),
+      methods
+    };
+  })
+  .add("longTitle", () => {
+    return {
+      components: { Task },
+      template: `<task :task="task" @archiveTask="onArchiveTask" @pinTask="onPinTask"/>`,
+      data: () => ({ task: { ...task, title: longTitle } }),
+      methods
+    };
+  });
+```
+
+Now we've added the story, we can reproduce this edge-case with ease whenever we want to work on it:
+
+![Here it is in Storybook.](/intro-to-storybook/addon-knobs-demo-edge-case-in-storybook.png)
+
+If we are using [visual regression testing](/react/en/test/), we will also be informed if we ever break our ellipsizing solution. Such obscure edge-cases are always liable to be forgotten!
+
+### Merge Changes
+
+Don't forget to merge your changes with git!
+
+## Sharing Addons With The Team
+
+Knobs is a great way to get non-developers playing with your components and stories. However, it can be difficult for them to run the storybook on their local machine. That's why deploying your storybook to an online location can be really helpful. In the next chapter we'll do just that!

--- a/content/intro-to-storybook/vue/pt/data.md
+++ b/content/intro-to-storybook/vue/pt/data.md
@@ -70,7 +70,6 @@ Em seguida o componente de topo (`src/App.vue`) vai ser atualizado de forma que 
 <script>
   import store from './store';
   import TaskList from './components/TaskList.vue';
-  import '../src/index.css';
 
   export default {
     name: 'app',
@@ -80,6 +79,9 @@ Em seguida o componente de topo (`src/App.vue`) vai ser atualizado de forma que 
     },
   };
 </script>
+<style>
+  @import "./index.css";
+</style>
 ```
 
 Em seguida é atualizado o componente `Tasklist`, de forma que este receba os dados oriundos da loja.
@@ -211,3 +213,4 @@ it('renders pinned tasks at the start of the list', () => {
   expect(lastTaskInput).not.toBe(null);
 });
 ```
+<div class="aside">Se os testes snapshot falharem, deverá ter que atualizar os snapshots existentes, executando o comando de testes de novo com a flag -u. Ou criar um novo script para lidar esta situação.</div>

--- a/content/intro-to-storybook/vue/pt/deploy.md
+++ b/content/intro-to-storybook/vue/pt/deploy.md
@@ -25,7 +25,7 @@ Para implementar o Storybook será necessário ser exportado como uma aplicaçã
 }
 ```
 
-E pode agora construir-se o Storybook via `npm run build-storybook`, o que irá popular a pasta `storybook-static` com esta versão.
+E pode agora construir-se o Storybook via `yarn build-storybook`, o que irá popular a pasta `storybook-static` com esta versão.
 
 ## Implementação contínua
 

--- a/content/intro-to-storybook/vue/pt/get-started.md
+++ b/content/intro-to-storybook/vue/pt/get-started.md
@@ -33,7 +33,7 @@ Podemos rapidamente verificar que os vários ecossistemas da nossa aplicação e
 yarn test:unit
 
 # Start the component explorer on port 6006:
-yarn run storybook
+yarn storybook
 
 # Run the frontend app proper on port 8080:
 yarn serve
@@ -45,10 +45,12 @@ yarn serve
 
 Sendo estes os seguintes: testes automáticos (Jest), desenvolvimento de componentes (Storybook) e a aplicação em si.
 
-![3 modalidades](/intro-to-storybook/app-three-modalities.png)
+![3 modalidades](/intro-to-storybook/app-three-modalities-vue.png)
 
 Dependendo de qual parte da aplicação que estamos a trabalhar, podemos querer executar um ou mais simultâneamente.
 Visto que neste caso, o foco é a criação de um componente de interface de utilizador simples, iremos cingir-nos somente á execução de Storybook.
+
+## Reutilizar CSS
 
 A Taskbox reutiliza elementos de design do tutorial de React e GraphQL
 [Tutorial React e GraphQL](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858), como tal não será necessária a criação de CSS neste tutorial.

--- a/content/intro-to-storybook/vue/pt/screen.md
+++ b/content/intro-to-storybook/vue/pt/screen.md
@@ -89,8 +89,6 @@ Vai ser necessário alterar o componente `App` de forma a ser possível renderiz
 <script>
   import store from './store';
   import InboxScreen from './components/InboxScreen.vue';
-  import '../src/index.css';
-
   export default {
     name: 'app',
     store,
@@ -99,6 +97,9 @@ Vai ser necessário alterar o componente `App` de forma a ser possível renderiz
     },
   };
 </script>
+<style>
+  @import "./index.css";
+</style>
 ```
 
 No entanto as coisas irão tornar-se interessantes ao renderizar-se a estória no Storybook.

--- a/content/intro-to-storybook/vue/pt/using-addons.md
+++ b/content/intro-to-storybook/vue/pt/using-addons.md
@@ -1,0 +1,207 @@
+---
+title: 'Extras'
+tocTitle: 'Extras'
+description: 'Aprender a integrar e usar extras com recurso a um exemplo popular'
+commit: 'dac373a'
+---
+
+Storybook possui um sistema robusto de [extras](https://storybook.js.org/addons/introduction/) com o qual se pode aumentar a experiência de desenvolvimento para qualquer elemento da sua equipa. Se estiver a seguir este tutorial, pode ter reparado que já foram mencionados múltiplos extras e já terá implementado um no [capitulo de testes](/react/pt/test/).
+
+<div class="aside">
+    <strong>Á procura de uma lista de extras?</strong>
+    <br/>
+    😍 A lista de extras oficiais e da comunidade pode ser consultada <a href="https://storybook.js.org/addons/addon-gallery/">aqui</a>.
+</div>
+
+Poderíamos ficar aqui eternamente a discutir como configurar e usar os extras para todos os casos. Por enquanto, vamos focar-nos em integrar um dos extras mais populares no ecossistema Storybook: [knobs](https://github.com/storybooks/storybook/tree/master/addons/knobs).
+
+## Configuração do extra Knobs
+
+Knobs é um recurso fantástico quer para designers quer para programadores, para fazerem experiências com componentes num ambiente controlado sem ser necessário qualquer tipo de código! Essencialmente, são fornecidos dados com os quais um qualquer utilizador irá manipular e fornecer aos componentes que se encontram definidos nas estórias. Isto é o que iremos implementar....
+
+<video autoPlay muted playsInline loop>
+  <source
+    src="/intro-to-storybook/addon-knobs-demo.mp4"
+    type="video/mp4"
+  />
+</video>
+
+## Instalação
+
+Primeiro irá ser necessário instalar todas as dependências necessárias.
+
+```bash
+yarn add @storybook/addon-knobs
+```
+
+Registar o Knobs no ficheiro `.storybook/addons.js`.
+
+```javascript
+import '@storybook/addon-actions/register';
+import '@storybook/addon-knobs/register';
+import '@storybook/addon-links/register';
+```
+
+<div class="aside">
+    <strong>📝A ordem em que se registam os extras tem muita importância!</strong>
+    <br/>
+    A ordem em que são listados os extras irá ditar a ordem em que aparecem como tabs no painel de extras( para os que irão aparecer).
+</div>
+
+E já está! É tempo de usar o extra numa estória.
+
+### Utilização
+
+Vamos usar o objecto knob no componente `Task`.
+
+Primeiro, importamos o decorador `withKnobs` e o tipo `object` de knob para o ficheiro `Task.stories.js`:
+
+```javascript
+import { storiesOf } from "@storybook/vue";
+import { action } from "@storybook/addon-actions";
+import { withKnobs, object } from "@storybook/addon-knobs";
+```
+
+Em seguida, dentro das estórias do componente `Task`, iremos fornecer `withKnobs` como parâmetro da função `addDecorator()`:
+
+```javascript
+storiesOf('Task', module)
+  .addDecorator(withKnobs)
+  .add(/*...*/);
+```
+
+Finalmente, integramos o tipo `object` do knob na estória "padrão":
+
+```javascript
+storiesOf("Task", module)
+  .addDecorator(withKnobs)
+  .add("default", () => {
+    return {
+      components: { Task },
+      template: `<task :task="task" @archiveTask="onArchiveTask" @pinTask="onPinTask"/>`,
+      props: {
+        task: {
+          type: Object,
+          default: object("task", { ...task })
+        }
+      },
+      methods
+    };
+  })
+  .add("pinned", () => {
+    return {
+      components: { Task },
+      template: `<task :task="task" @archiveTask="onArchiveTask" @pinTask="onPinTask"/>`,
+      data: () => ({ task: { ...task, state: "TASK_PINNED" } }),
+      methods
+    };
+  })
+  .add("archived", () => {
+    return {
+      components: { Task },
+      template: `<task :task="task" @archiveTask="onArchiveTask" @pinTask="onPinTask"/>`,
+      data: () => ({ task: { ...task, state: "TASK_ARCHIVED" } }),
+      methods
+    };
+  });
+```
+
+Tal como se encontra documentado [aqui](https://github.com/storybooks/storybook/tree/master/addons/knobs#object), este tipo aceita uma "etiqueta" e um objeto padrão como parâmetros.
+A etiqueta é constante e irá aparecer no painel de extras á esquerda do campo de texto. O objeto fornecido será representado como um blob JSON que pode ser editado. Desde que seja submetido JSON válido, o componente irá ajustar-se com base na informação fornecida ao objeto!
+
+## Os extras aumentam a esfera de ação do teu Storybook
+
+Não somente a tua instância Storybook serve como um [ambiente CDD](https://blog.hichroma.com/component-driven-development-ce1109d56c8e) fantástico, mas agora estamos também a fornecer uma forma de documentação interativa. Os PropTypes são fantásticos, mas quer um designer quer uma outra pessoa qualquer nova que é apresentada ao código do componente irá ser capaz de entender qual é o seu comportamento rapidamente graças ao Storybook e a este extra.
+
+## Utilização de Knobs para afinar os casos extremos
+
+Adicionalmente com a facilidade de edição de dados fornecidos ao componente, engenheiros QA ou Engenheiros UI, podem levar o componente ao extremo! Como exemplo o que irá acontecer ao nosso componente se contém uma cadeia de caracteres _GIGANTESCA_ ? 
+
+![OHH não! O conteúdo á direita aparece corto!](/intro-to-storybook/addon-knobs-demo-edge-case.png) 😥
+
+Devido a facilidade com que é possível testar inputs diferentes podemos descobrir e resolver estes problemas com facilidade! Vamos então resolver o nosso problema, através da adição de um elemento de estilo ao `Task.vue`:
+
+```html
+<!--src/components/Task.vue>-->
+
+<!-- This is the input for our task title. 
+     In practice we would probably update the styles for this element but for this tutorial, 
+     let's fix the problem with an inline style:-->
+ <input
+    type="text"
+    :readonly="true"
+    :value="this.task.title"
+    placeholder="Input title"
+    style="text-overflow: ellipsis;"
+  />
+```
+
+![Assim sim.](/intro-to-storybook/addon-knobs-demo-edge-case-resolved.png) 👍
+
+## Criação de uma nova estória para evitar regressões
+
+Claro que podemos sempre reproduzir este problema através da introdução do mesmo input no objeto knob, mas é melhor escrever uma estória adicional para este input.
+Isto irá expandir os testes de regressão e delinear com maior facilidade quais são os limites do componente(s) aos restantes elementos da equipa.
+
+Vamos então adicionar uma estória para o caso da ocorrência de um texto grande no ficheiro Task.stories.js
+
+```javascript
+// src/components/Task.stories.js
+
+const longTitle = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not`;
+
+storiesOf("Task", module)
+  .addDecorator(withKnobs)
+  .add("default", () => {
+    return {
+      components: { Task },
+      template: `<task :task="task" @archiveTask="onArchiveTask" @pinTask="onPinTask"/>`,
+      props: {
+        task: {
+          type: Object,
+          default: object("task", { ...task })
+        }
+      },
+      methods
+    };
+  })
+  .add("pinned", () => {
+    return {
+      components: { Task },
+      template: `<task :task="task" @archiveTask="onArchiveTask" @pinTask="onPinTask"/>`,
+      data: () => ({ task: { ...task, state: "TASK_PINNED" } }),
+      methods
+    };
+  })
+  .add("archived", () => {
+    return {
+      components: { Task },
+      template: `<task :task="task" @archiveTask="onArchiveTask" @pinTask="onPinTask"/>`,
+      data: () => ({ task: { ...task, state: "TASK_ARCHIVED" } }),
+      methods
+    };
+  })
+  .add("longTitle", () => {
+    return {
+      components: { Task },
+      template: `<task :task="task" @archiveTask="onArchiveTask" @pinTask="onPinTask"/>`,
+      data: () => ({ task: { ...task, title: longTitle } }),
+      methods
+    };
+  });
+```
+
+Agora que foi adicionada a estória, podemos reproduzir este caso extremo com relativa facilidade quando for necessário:
+
+![Aqui está ele no Storybook](/intro-to-storybook/addon-knobs-demo-edge-case-in-storybook.png)
+
+Se estiverem a ser usados [testes de regressão visual](/react/pt/test/), iremos ser informados se a nossa solução eliptica for quebrada.
+Tais casos extremos considerados obscuros têm tendência a ser esquecidos!
+
+## Fusão das alterações
+
+Não esquecer de fundir as alterações com o git!
+
+## Partilha de extras com a equipa
+
+Knobs é uma forma fantástica de forma a permitir que elementos não programadores brinquem com os componentes e estórias. No entanto, pode ser dificil para estes executarem o storybook nos seus ambientes locais. É por isso que uma implementação online pode ajudar em muito. No próximo capitulo iremos fazer exatamente isso!


### PR DESCRIPTION
With this pull request the following changes are introduced to the vue tutorial:
- Get started
   - Changed the `yarn run storybook` to `yarn storybook`.
   - The sentence "Taskbox reuses design elements from the GraphQL and React Tutorial example app, so we won’t need to write CSS in this tutorial......" was updated to be more concise and avoid misleading. Technically the reader will not compile any LESS, unless necessary. 
   - Data and Screen:
     - The code was updated, the code initially is setup as:
       ```html
          <style>
            @import "./index.css";
          </style>
       ```
        Then the code is changed to:
        ```js
         import '../src/index.css';
        ```
     - Added information that should the snapshots tests fail, the snaphots must be re-run with the appropriate flag.

  - Using addons
    - The section is introduced to prevent breaking navigation on the tutorial. The code to test the knobs addon is located [here](https://github.com/jonniebigodes/storybook-taskbox-vue) and a live example is running [here](https://amazing-noyce-0bca3d.netlify.com/)
  - Deploy
    - Changed `npm run build-storybook` to `yarn build-storybook` as the tutorial uses yarn.


In the portuguese translation:

- Get started
  - Corrected the image, as it was displaying the react version and now is pointing to the vue one.
  - Added the missing h2 for "Reuse CSS"
  - The translation was updated to reflect the change of the sentence mentioned above. The rest of the document was not touched, as there's already a open pr that is introducing some changes to the document.
 - Data, Screen, Using addons, Deploy were updated to reflect the changes to the original document.


The "creating addon" section was not introduced with this pr, as of this moment i'm still having some issues with it, i'm currently testing it to see if i can make it work without breaking the story code examples and i'm getting a error `Uncaught ReferenceError: h is not defined` and reading about it on the storybook repo it seems that the solution lies with changing the code to incorporate the render method to address it. I'm going to make some more tests and when all is fixed i'll make the pr to introduce the this section.

Feel free to provide feedback.