### PR TITLE
docs: all conclusion sections aligned to changes introduced with PR 196

### DIFF
--- a/content/intro-to-storybook/angular/pt/conclusion.md
+++ b/content/intro-to-storybook/angular/pt/conclusion.md
@@ -3,21 +3,20 @@ title: 'Conclusão'
 description: 'Fusão de todo o conhecimento adquirido e aprendizagem de técnicas extra de Storybook'
 ---
 
-Parabéns! Acabaste de criar o teu primeiro interface de utilizador com Storybook. Durante esta jornada aprendeste como construir, compor, testar e implementar componentes de interface de utilizador.
-Se estiveste a seguir o tutorial, o repositório e o Storybook implementado irá ser idêntico a este:
+Parabéns! Acabou de criar o primeiro interface de utilizador com o Storybook. Ao longo do caminho, aprendeu a criar, compor, testar e implementar componentes de interface de utilizador. Se seguiu o tutorial o repositório e o Storybook deverão ficar assim:
 
 [📕 **GitHub repo: chromaui/learnstorybook-code**](https://github.com/chromaui/learnstorybook-code)
 <br/>
 [🌎 **Storybook implementado**](https://clever-banach-415c03.netlify.com/)
 
-O Storybook é uma ferramenta bastante poderosa para React, Vue, Angular.
-É composta por uma comunidade de desenvolvimento próspera e um número grande de extras. Esta introdução somente arranha a superfície das potencialidades existentes. Estamos confiantes que depois da adoção do Storybook, irá ficar impressionado com o quanto é produtivo a construção de interfaces de utilizador duradouros.
+O Storybook é uma ferramenta bastante poderosa para React, Vue e Angular.
+Possui uma comunidade de programadores próspera e uma grande variedade de extras. Esta introdução arranha a superfície do que é possível fazer. Estamos confiantes que ao adotar o Storybook, ficará impressionado com o quão produtivo é construir IUs duradouros.
 
 ## Saber mais
 
 Pretende saber mais? Aqui ficam alguns recursos que irão ajudar.
 
-- [**Documentação Oficial Storybook**](https://storybook.js.org/basics/introduction/) contem a documentação da API, links da comunidade e a galeria de extras.
+- [**Documentação Oficial Storybook**](https://storybook.js.org/basics/introduction/) contém a documentação da API, links da comunidade e a galeria de extras.
 
 - [**Manual de testes visuais**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07)
   enumera as boas práticas de fluxo de trabalho, usadas por equipas que operam a alta velocidade, tal como por exemplo a SquareSpace, a Major League Soccer, a Discovery Network e Apollo GraphQL.
@@ -26,8 +25,10 @@ Pretende saber mais? Aqui ficam alguns recursos que irão ajudar.
 
 ## Quem fez LearnStorybook.com?
 
-O texto, código e produção foram contribuições feitas pela [Chroma](http://blog.hichroma.com/). O tutorial foi inspirado na popular [Serie de tutoriais GraphQL + React](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858)
 
-Se pretender mais tutoriais e artigos tal como este? Subscreva a mailing list da Chroma.
+O texto, código e produção foram contribuídos pela [Chroma](http://blog.hichroma.com/). O tutorial foi inspirado pela [série de tutoriais populares de GraphQL + React](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858).
+
+
+Quer mais tutoriais e artigos como este? Subscreva a mailing list da Chroma.
 
 <iframe style="height:400px;width:100%;max-width:800px;margin:0px auto;" src="https://upscri.be/bface0?as_embed"></iframe>

--- a/content/intro-to-storybook/angular/pt/simple-component.md
+++ b/content/intro-to-storybook/angular/pt/simple-component.md
@@ -1,5 +1,5 @@
 ---
-title: 'Construção de um componente siples'
+title: 'Construção de um componente simples'
 tocTitle: 'Componente simples'
 description: 'Construção de um componente simples isolado'
 ---

--- a/content/intro-to-storybook/react/pt/conclusion.md
+++ b/content/intro-to-storybook/react/pt/conclusion.md
@@ -3,21 +3,20 @@ title: 'Conclusão'
 description: 'Fusão de todo o conhecimento adquirido e aprendizagem de técnicas extra de Storybook'
 ---
 
-Parabéns! Acabaste de criar o teu primeiro interface de utilizador com Storybook. Durante esta jornada aprendeste como construir, compor, testar e implementar componentes de interface de utilizador.
-Se estiveste a seguir o tutorial, o repositório e o Storybook implementado irá ser idêntico a este:
+Parabéns! Acabou de criar o primeiro interface de utilizador com o Storybook. Ao longo do caminho, aprendeu a criar, compor, testar e implementar componentes de interface de utilizador. Se seguiu o tutorial o repositório e o Storybook deverão ficar assim:
 
 [📕 **GitHub repo: chromaui/learnstorybook-code**](https://github.com/chromaui/learnstorybook-code)
 <br/>
 [🌎 **Storybook implementado**](https://clever-banach-415c03.netlify.com/)
 
-O Storybook é uma ferramenta bastante poderosa para React, Vue, Angular.
-É composta por uma comunidade de desenvolvimento próspera e um número grande de extras. Esta introdução somente arranha a superfície das potencialidades existentes. Estamos confiantes que depois da adoção do Storybook, irá ficar impressionado com o quanto é produtivo a construção de interfaces de utilizador duradouros.
+O Storybook é uma ferramenta bastante poderosa para React, Vue e Angular.
+Possui uma comunidade de programadores próspera e uma grande variedade de extras. Esta introdução arranha a superfície do que é possível fazer. Estamos confiantes que ao adotar o Storybook, ficará impressionado com o quão produtivo é construir IUs duradouros.
 
 ## Saber mais
 
 Pretende saber mais? Aqui ficam alguns recursos que irão ajudar.
 
-- [**Documentação Oficial Storybook**](https://storybook.js.org/basics/introduction/) contem a documentação da API, links da comunidade e a galeria de extras.
+- [**Documentação Oficial Storybook**](https://storybook.js.org/basics/introduction/) contém a documentação da API, links da comunidade e a galeria de extras.
 
 - [**Manual de testes visuais**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07)
   enumera as boas práticas de fluxo de trabalho, usadas por equipas que operam a alta velocidade, tal como por exemplo a SquareSpace, a Major League Soccer, a Discovery Network e Apollo GraphQL.
@@ -26,8 +25,10 @@ Pretende saber mais? Aqui ficam alguns recursos que irão ajudar.
 
 ## Quem fez LearnStorybook.com?
 
-O texto, código e produção foram contribuições feitas pela [Chroma](http://blog.hichroma.com/). O tutorial foi inspirado na popular [Serie de tutoriais GraphQL + React](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858)
 
-Se pretender mais tutoriais e artigos tal como este? Subscreva a mailing list da Chroma.
+O texto, código e produção foram contribuídos pela [Chroma](http://blog.hichroma.com/). O tutorial foi inspirado pela [série de tutoriais populares de GraphQL + React](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858).
+
+
+Quer mais tutoriais e artigos como este? Subscreva a mailing list da Chroma.
 
 <iframe style="height:400px;width:100%;max-width:800px;margin:0px auto;" src="https://upscri.be/bface0?as_embed"></iframe>

--- a/content/intro-to-storybook/react/pt/simple-component.md
+++ b/content/intro-to-storybook/react/pt/simple-component.md
@@ -1,5 +1,5 @@
 ---
-title: 'Construção de um componente siples'
+title: 'Construção de um componente simples'
 tocTitle: 'Componente simples'
 description: 'Construção de um componente simples isolado'
 commit: 403f19a

--- a/content/intro-to-storybook/vue/pt/conclusion.md
+++ b/content/intro-to-storybook/vue/pt/conclusion.md
@@ -14,19 +14,19 @@ Possui uma comunidade de programadores próspera e uma grande variedade de extra
 
 ## Saber mais
 
-Pretende saber mais? Aqui ficam algumas recursos que irão ajudar.
+Pretende saber mais? Aqui ficam alguns recursos que irão ajudar.
 
-- [**Documentação Oficial Storybook**](https://storybook.js.org/basics/introduction/) contem a documentação da API, links da comunidade e a galeria de extras.
+- [**Documentação Oficial Storybook**](https://storybook.js.org/basics/introduction/) contém a documentação da API, links da comunidade e a galeria de extras.
 
 - [**Manual de testes visuais**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07)
-  enumera as boas práticas de fluxo de trabalho, usadas por equipes que operam a alta velocidade, tal como por exemplo a SquareSpace, a Major League Soccer, a Discovery Network e Apollo GraphQL.
+  enumera as boas práticas de fluxo de trabalho, usadas por equipas que operam a alta velocidade, tal como por exemplo a SquareSpace, a Major League Soccer, a Discovery Network e Apollo GraphQL.
 
 - [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) aprofunda o uso de Storybook para testes visuais. Livro eletrónico livre de 31 páginas.
 
 ## Quem fez LearnStorybook.com?
 
 
-O texto, código e produção foram contribuídos pela [Chroma](http://blog.hichroma.com/). O tutorial foi inspirado pela [série de tutoriais populares](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858).
+O texto, código e produção foram contribuídos pela [Chroma](http://blog.hichroma.com/). O tutorial foi inspirado pela [série de tutoriais populares de GraphQL + React](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858).
 
 
 Quer mais tutoriais e artigos como este? Subscreva a mailing list da Chroma.

--- a/content/intro-to-storybook/vue/pt/simple-component.md
+++ b/content/intro-to-storybook/vue/pt/simple-component.md
@@ -1,5 +1,5 @@
 ---
-title: 'Construção de um componente siples'
+title: 'Construção de um componente simples'
 tocTitle: 'Componente simples'
 description: 'Construção de um componente simples isolado'
 ---


### PR DESCRIPTION
All conclusion sections are now aligned with #196 . Thank you very much for the groundwork @GilsonSantoss for your time in doing this.

Also i noticed that there was also a typo in the frontmatter for the portuguese translation of simple component and that was addressed. That slipped through and for that i'm very sorry, but is now fixed.

@domyen @tmeasday feel free to provide feedback.