### PR TITLE
Import actions in stories and correct reference to CSS in config

### DIFF
--- a/content/intro-to-storybook/svelte/en/simple-component.md
+++ b/content/intro-to-storybook/svelte/en/simple-component.md
@@ -66,6 +66,7 @@ Below we build out Task’s three test states in the story file:
 
 ```javascript
 // src/components/Task.stories.js
+import { action } from "@storybook/addon-actions";
 import Task from './Task.svelte';
 
 export default {
@@ -153,7 +154,7 @@ We also have to make one small change to the Storybook configuration setup (`.st
 ```javascript
 // .storybook/config.js
 import { configure } from '@storybook/svelte';
-import '../src/index.css';
+import "../public/global.css";
 configure(require.context('../src/components', true, /\.stories\.js$/), module);
 ```
 


### PR DESCRIPTION
I'm running on Windows 10. On "npm run storybook" I get "action not defined" feedback in browser. Importing actions fixes this. Previously we add style references to global.css but in the config index.css is referenced. I changed the reference to global.css.