### PR TITLE
Moving `component` property to default export

### DIFF
--- a/content/design-systems-for-developers/react/en/document.md
+++ b/content/design-systems-for-developers/react/en/document.md
@@ -62,9 +62,9 @@ Start by adding more metadata that explains what the component does. In `src/Ava
 ```javascript
 export default {
   title: 'Design System|Avatar',
+  component: Avatar,
 
   parameters: {
-    component: Avatar,
     componentSubtitle: 'Displays an image that represents a user or organization',
   },
 };


### PR DESCRIPTION
Moving `component` property to align with documentation at https://storybook.js.org/docs/formats/component-story-format/#default-export

FYI - I just noticed this discrepancy when I was looking at https://github.com/storybookjs/storybook/blob/master/addons/docs/docs/docspage.md#component-parameter. But as far as I can tell having `parameters: { component: ... } }` was able to extract the JSDoc still.

Also, I noticed `component` being set differently in the Svelte examples. But I left that documentation alone since I don't know anything about Svelte.