### PR TITLE
Update design-system-for-developers/react/en with triconfig

### DIFF
--- a/content/design-systems-for-developers/react/en/build.md
+++ b/content/design-systems-for-developers/react/en/build.md
@@ -142,7 +142,7 @@ When you view a story, you often want to see the underlying code to understand h
 yarn add --dev  @storybook/addon-storysource
 ```
 
-Register the addon in `.storybook/main.js`:
+Add the addon in `.storybook/main.js`:
 
 ```javascript
 module.exports = {
@@ -170,7 +170,7 @@ Let’s see how this works by setting up knobs in the `Avatar` component:
 yarn add --dev @storybook/addon-knobs
 ```
 
-Register the addon in `.storybook/main.js`:
+Add the addon in `.storybook/main.js`:
 
 ```javascript
 module.exports = {

--- a/content/design-systems-for-developers/react/en/build.md
+++ b/content/design-systems-for-developers/react/en/build.md
@@ -49,15 +49,6 @@ You should see this:
 
 Nice, we’ve set up a component explorer!
 
-By default, Storybook has created a folder `src/stories` with some example stories. However, when we copied our components over, we brought their stories too. We can get them indexed in our Storybook by changing the search path in `.storybook/config.js` from `’src/stories’` to `’src’`, and removing the `src/stories` directory:
-
-```javascript
-import { configure } from '@storybook/react';
-
-// automatically import all files ending in *.stories.js
-configure(require.context('../src', true, /\.stories\.js$/), module);
-```
-
 Your Storybook should reload like this (notice that the font styles are a little off, for instance see the "Initials" story):
 
 ![Initial set of stories](/design-systems-for-developers/storybook-initial-stories.png)
@@ -83,11 +74,11 @@ export const GlobalStyle = createGlobalStyle`
 `;
 ```
 
-To use the `GlobalStyle` “component” in Storybook, we can make use of a decorator (a component wrapper). In an app we’d place that component in the top-level app layout.
+To use the `GlobalStyle` “component” in Storybook, we can make use of a decorator (a component wrapper). In an app we’d place that component in the top-level app layout, but in Storybook we wrap all stories in it using the preview config file `.storybook/preview.js`
 
 ```javascript
 import React from 'react';
-import { configure, addDecorator } from '@storybook/react';
+import { addDecorator } from '@storybook/react';
 import { GlobalStyle } from '../src/shared/global';
 
 addDecorator(story => (
@@ -96,9 +87,6 @@ addDecorator(story => (
     {story()}
   </>
 ));
-
-// automatically import all files ending in *.stories.js
-configure(require.context('../src', true, /\.stories\.js$/), module);
 ```
 
 The decorator will ensure the `GlobalStyle` is rendered no matter which story is selected.
@@ -154,25 +142,17 @@ When you view a story, you often want to see the underlying code to understand h
 yarn add --dev  @storybook/addon-storysource
 ```
 
-Register the addon in `.storybook/addons.js`:
+Register the addon in `.storybook/main.js`:
 
 ```javascript
-import '@storybook/addon-actions/register';
-import '@storybook/addon-links/register';
-import '@storybook/addon-storysource/register';
-```
-
-And update your webpack config in `.storybook/webpack.config.js`:
-
-```javascript
-module.exports = function({ config }) {
-  config.module.rules.unshift({
-    test: /\.stories\.jsx?$/,
-    loaders: [require.resolve('@storybook/source-loader')],
-    enforce: 'pre',
-  });
-
-  return config;
+module.exports = {
+  stories: ['../src/**/*.stories.js'],
+  addons: [
+    '@storybook/preset-create-react-app',
+    '@storybook/addon-actions',
+    '@storybook/addon-links',
+    '@storybook/addon-storysource',
+  ],
 };
 ```
 
@@ -190,13 +170,19 @@ Let’s see how this works by setting up knobs in the `Avatar` component:
 yarn add --dev @storybook/addon-knobs
 ```
 
-Register the addon in `.storybook/addons.js`:
+Register the addon in `.storybook/main.js`:
 
 ```javascript
-import '@storybook/addon-actions/register';
-import '@storybook/addon-links/register';
-import '@storybook/addon-storysource/register';
-import '@storybook/addon-knobs/register';
+module.exports = {
+  stories: ['../src/**/*.stories.js'],
+  addons: [
+    '@storybook/preset-create-react-app',
+    '@storybook/addon-actions',
+    '@storybook/addon-links',
+    '@storybook/addon-storysource',
+    '@storybook/addon-knobs',
+  ],
+};
 ```
 
 Add a story that uses knobs in `src/Avatar.stories.js`:

--- a/content/design-systems-for-developers/react/en/distribute.md
+++ b/content/design-systems-for-developers/react/en/distribute.md
@@ -301,11 +301,27 @@ Add your published design system as a dependency.
 yarn add <your-username>-learnstorybook-design-system
 ```
 
-Now, let’s update the example app’s `.storybook/config.js` to list the design system components, and to use the global styles defined by the design system. Make the following change to the file:
+Now, let’s update the example app’s `.storybook/main.js` to import the design system components:
+
+```javascript
+module.exports = {
+  stories: [
+    '../src/**/*.stories.js',
+    '../node_modules/<your-username>-learnstorybook-design-system/dist/*.stories.(js|mdx)',
+  ],
+  addons: [
+    '@storybook/preset-create-react-app',
+    '@storybook/addon-actions',
+    '@storybook/addon-links',
+  ],
+};
+```
+
+Also we can add a global decorator to a new `.storybook/preview.js` config file use the global styles defined by the design system. Make the following change to the file:
 
 ```javascript
 import React from 'react';
-import { configure, addDecorator } from '@storybook/react';
+import { addDecorator } from '@storybook/react';
 import { global as designSystemGlobal } from '<your-username>-learnstorybook-design-system';
 
 const { GlobalStyle } = designSystemGlobal;
@@ -316,19 +332,6 @@ addDecorator(story => (
     {story()}
   </>
 ));
-
-// automatically import all files ending in *.stories.js
-configure(
-  [
-    require.context('../src', true, /\.stories\.js$/),
-    require.context(
-      '../node_modules/<your-username>-learnstorybook-design-system/dist',
-      true,
-      /\.stories\.(js|mdx)$/
-    ),
-  ],
-  module
-);
 ```
 
 ![Example app storybook with design system stories](/design-systems-for-developers/example-app-storybook-with-design-system-stories.png)

--- a/content/design-systems-for-developers/react/en/document.md
+++ b/content/design-systems-for-developers/react/en/document.md
@@ -41,10 +41,20 @@ With the Storybook Docs addon, we can generate rich documentation from existing 
 yarn add --dev @storybook/addon-docs
 ```
 
-Also, we’ll add a _preset_ for the docs addon, in a new file `.storybook/presets.js`. Note that the use of this preset removes the need for our `.storybook/webpack.config.js` and we can remove it:
+We'll add it to our addons list in `.storybook/main.js`:
 
 ```javascript
-module.exports = ['@storybook/addon-docs/react/preset'];
+module.exports = {
+  stories: ['../src/**/*.stories.js'],
+  addons: [
+    '@storybook/preset-create-react-app',
+    '@storybook/addon-actions',
+    '@storybook/addon-links',
+    '@storybook/addon-storysource',
+    '@storybook/addon-knobs',
+    '@storybook/addon-docs',
+  ],
+};
 ```
 
 You should see two tabs in your Storybook. “Canvas” tab is your component development environment. “Docs” is your component documentation.
@@ -149,11 +159,22 @@ Every component is different and so are the documentation requirements. We used 
 
 Markdown is a straightforward format for writing text. MDX allows you to use interactive code (JSX) inside of Markdown. Storybook Docs uses MDX to give developers ultimate control over how documentation renders.
 
-First, let’s take control of the Avatar doc generation from the default. Register MDX files in `.storybook/config.js` like so.
+First, let’s take control of the Avatar doc generation from the default. Register MDX files in `.storybook/main.js` like so.
 
 ```javascript
-// automatically import all files ending in *.stories.js|mdx
-configure(require.context('../src', true, /\.stories\.(js|mdx)$/), module);
+module.exports = {
+  // automatically import all files ending in *.stories.js|mdx
+  stories: ['../src/**/*.stories.(js|mdx)'],
+  addons: [
+    '@storybook/preset-create-react-app',
+    '@storybook/addon-actions',
+    '@storybook/addon-links',
+    '@storybook/addon-storysource',
+    '@storybook/addon-knobs',
+    '@storybook/addon-a11y',
+    '@storybook/addon-docs',
+  ],
+};
 ```
 
 Create a new `src/Avatar.stories.mdx` file and supply some details. We’ll remove the `Avatar.stories.js` file and recreate the stories in the mdx file:

--- a/content/design-systems-for-developers/react/en/test.md
+++ b/content/design-systems-for-developers/react/en/test.md
@@ -187,7 +187,7 @@ yarn add --dev @storybook/addon-a11y
 
 ```
 
-Register the addon in `.storybook/main.js`:
+Add the addon in `.storybook/main.js`:
 
 ```javascript
 module.exports = {

--- a/content/design-systems-for-developers/react/en/test.md
+++ b/content/design-systems-for-developers/react/en/test.md
@@ -187,23 +187,29 @@ yarn add --dev @storybook/addon-a11y
 
 ```
 
-Register the addon in `.storybook/addons.js`:
+Register the addon in `.storybook/main.js`:
 
 ```javascript
-import '@storybook/addon-actions/register';
-import '@storybook/addon-links/register';
-import '@storybook/addon-storysource/register';
-import '@storybook/addon-knobs/register';
-import '@storybook/addon-a11y/register';
+module.exports = {
+  // automatically import all files ending in *.stories.js|mdx
+  stories: ['../src/**/*.stories.(js|mdx)'],
+  addons: [
+    '@storybook/preset-create-react-app',
+    '@storybook/addon-actions',
+    '@storybook/addon-links',
+    '@storybook/addon-storysource',
+    '@storybook/addon-knobs',
+    '@storybook/addon-a11y',
+  ],
+};
 ```
 
-And add the `withA11y` decorator to our `.storybook/config.js`:
+And add the `withA11y` decorator to `.storybook/preview.js`:
 
 ```javascript
 import React from 'react';
-import { configure, addDecorator } from '@storybook/react';
+import { addDecorator } from '@storybook/react';
 import { withA11y } from '@storybook/addon-a11y';
-import 'storybook-chromatic';
 
 import { GlobalStyle } from '../src/components/shared/global';
 
@@ -214,9 +220,6 @@ addDecorator(story => (
     {story()}
   </>
 ));
-
-// automatically import all files ending in \*.stories.js
-configure(require.context('../src', true, /\.stories\.js\$/), module);
 ```
 
 Once installed, you’ll see a new “Accessibility” tab in the Storybook addons panel.


### PR DESCRIPTION
(Base is currently set to `221-use-mainjs`)

Updated design systems to use `main.js` et al. Haven't actually run the code.