### PR TITLE
Delete the src directory instead

### DIFF
--- a/content/design-systems-for-developers/react/en/architecture.md
+++ b/content/design-systems-for-developers/react/en/architecture.md
@@ -84,7 +84,7 @@ Following this method, we end up with UI primitives: Avatar, Badge, Button, Chec
 
 ![Variants in one component](/design-systems-for-developers/design-system-consolidate-into-one-button.jpg)
 
-Add the components we found by downloading them to your computer and dropping them into your repository, as well as removing the application files that Create React App provided:
+At this stage it's safe to delete the src folder that Create React App created for us when we initialized our design system earlier. Don't worry we won't be needing it. Then you can add the components already found by downloading them to your computer and also into your local repository:
 
 ```bash
 rm -rf src

--- a/content/design-systems-for-developers/react/en/architecture.md
+++ b/content/design-systems-for-developers/react/en/architecture.md
@@ -87,7 +87,7 @@ Following this method, we end up with UI primitives: Avatar, Badge, Button, Chec
 Add the components we found by downloading them to your computer and dropping them into your repository, as well as removing the application files that Create React App provided:
 
 ```bash
-rm -rf src/*
+rm -rf src
 
 svn export https://github.com/chromaui/learnstorybook-design-system/tags/download-1/src
 ```


### PR DESCRIPTION
I encountered the following error message while downloading the sample UI primitives.

```
$ svn export https://github.com/chromaui/learnstorybook-design-system/tags/download-1/src
svn: E155000: Destination directory exists; please remove the directory or use --force to overwrite
svn: E155000: 'src' already exists
```

One easy solution would be to delete the src directory itself instead of only deleting all files inside.