### PR TITLE
Use '@storybook/addon-docs/preset' instead of '@storybook/addon-docs/…

### DIFF
--- a/content/design-systems-for-developers/react/en/document.md
+++ b/content/design-systems-for-developers/react/en/document.md
@@ -44,7 +44,7 @@ yarn add --dev @storybook/addon-docs
 Also, we’ll add a _preset_ for the docs addon, in a new file `.storybook/presets.js`. Note that the use of this preset removes the need for our `.storybook/webpack.config.js` and we can remove it:
 
 ```javascript
-module.exports = ['@storybook/addon-docs/react/preset'];
+module.exports = ['@storybook/addon-docs/preset'];
 ```
 
 You should see two tabs in your Storybook. “Canvas” tab is your component development environment. “Docs” is your component documentation.


### PR DESCRIPTION
Just encountered the following warning that can be fixed by this PR.

```
DeprecationWarning: Framework-specific presets are no longer-needed as of Storybook 5.3 and will be removed in 6.0.

Please use '@storybook/addon-docs/preset' instead of '@storybook/addon-docs/react/preset'.
```