### PR TITLE
Move "Sharing Addons" to creating-addons.md, p.2/2

### DIFF
--- a/content/intro-to-storybook/react/en/creating-addons.md
+++ b/content/intro-to-storybook/react/en/creating-addons.md
@@ -479,4 +479,5 @@ https://github.com/storybookjs/storybook/tree/next/dev-kits
 More dev-kits will become available in the future.
 
 ## Sharing Addons With The Team
-Knobs is a great way to get non-developers playing with your components and stories. However, it can be difficult for them to run the storybook on their local machine. That's why deploying your storybook to an online location can be really helpful. In the next chapter we'll do just that!
+
+Addons are timesaving additions to your workflow, but it can be difficult for non-technical teammates and reviewers to take advantage of their features. You can't guarantee folks will run Storybook on their local machine. That's why deploying your Storybook to an online location for everyone to reference can be really helpful. In the next chapter we'll do just that!

--- a/content/intro-to-storybook/react/en/creating-addons.md
+++ b/content/intro-to-storybook/react/en/creating-addons.md
@@ -477,3 +477,6 @@ You can find this one and others here:
 https://github.com/storybookjs/storybook/tree/next/dev-kits
 
 More dev-kits will become available in the future.
+
+## Sharing Addons With The Team
+Knobs is a great way to get non-developers playing with your components and stories. However, it can be difficult for them to run the storybook on their local machine. That's why deploying your storybook to an online location can be really helpful. In the next chapter we'll do just that!

--- a/content/intro-to-storybook/react/en/creating-addons.md
+++ b/content/intro-to-storybook/react/en/creating-addons.md
@@ -478,6 +478,6 @@ https://github.com/storybookjs/storybook/tree/next/dev-kits
 
 More dev-kits will become available in the future.
 
-## Sharing Addons With The Team
+## Sharing addons with the team
 
 Addons are timesaving additions to your workflow, but it can be difficult for non-technical teammates and reviewers to take advantage of their features. You can't guarantee folks will run Storybook on their local machine. That's why deploying your Storybook to an online location for everyone to reference can be really helpful. In the next chapter we'll do just that!

--- a/content/intro-to-storybook/react/en/using-addons.md
+++ b/content/intro-to-storybook/react/en/using-addons.md
@@ -148,7 +148,3 @@ If we are using [visual regression testing](/react/en/test/), we will also be in
 ### Merge Changes
 
 Don't forget to merge your changes with git!
-
-## Sharing Addons With The Team
-
-Knobs is a great way to get non-developers playing with your components and stories. However, it can be difficult for them to run the storybook on their local machine. That's why deploying your storybook to an online location can be really helpful. In the next chapter we'll do just that!

--- a/content/intro-to-storybook/react/en/using-addons.md
+++ b/content/intro-to-storybook/react/en/using-addons.md
@@ -148,3 +148,7 @@ If we are using [visual regression testing](/react/en/test/), we will also be in
 ### Merge Changes
 
 Don't forget to merge your changes with git!
+
+## Creating your own addon
+
+As we've seen, Knobs is a great way to get non-developers playing with your components and stories. However, there are many more ways you can customize Storybook to fit your workflow with addons. In the next chapter, we'll guide you through creating an addon that shows your static design alongside your development.


### PR DESCRIPTION
The part "Sharing Addons" mentions that deploying will be handled in the next chapter. This is wrong as it is handled after the chapter `creating-addons`.