### PR TITLE
chore: react/vue tutorials and translations reworded

### DIFF
--- a/content/intro-to-storybook/angular/en/conclusion.md
+++ b/content/intro-to-storybook/angular/en/conclusion.md
@@ -21,6 +21,10 @@ Want to dive deeper? Here are helpful resources.
 
 - [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) dives deep into using Storybook to visual test components. Free 31-page ebook.
 
+- [**Storybook Discord chat**](https://discord.gg/UUt2PJb) puts you in contact with the Storybook community. Get and give help to other Storybook users.
+
+- [**Storybook blog**](https://medium.com/storybookjs) showcases the latest releases and features to streamline your UI development workflow.
+
 ## Who made LearnStorybook.com?
 
 The text, code, and production were contributed by [Chroma](http://blog.hichroma.com/). The tutorial was inspired by Chroma’s popular [GraphQL + React tutorial series](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858).

--- a/content/intro-to-storybook/angular/pt/conclusion.md
+++ b/content/intro-to-storybook/angular/pt/conclusion.md
@@ -23,6 +23,11 @@ Pretende saber mais? Aqui ficam alguns recursos que irão ajudar.
 
 - [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) aprofunda o uso de Storybook para testes visuais. Livro eletrónico livre de 31 páginas.
 
+- [**Discord do Storybook**](https://discord.gg/UUt2PJb) põe-te em contacto direto com a comunidade Storybook. Onde podes oferecer e receber ajuda de outros utilizadores do Storybook.
+
+- [**Blog Storybook**](https://medium.com/storybookjs) demonstra tanto as novidades acerca das versões mais recentes, como as últimas funcionalidades existentes, de forma a otimizar o teu fluxo de trabalho no desenvolvimento de interface de utilizador 
+
+
 ## Quem fez LearnStorybook.com?
 
 

--- a/content/intro-to-storybook/react/en/conclusion.md
+++ b/content/intro-to-storybook/react/en/conclusion.md
@@ -9,7 +9,7 @@ Congratulations! You created your first UI in Storybook. Along the way you learn
 <br/>
 [🌎 **Deployed Storybook**](https://clever-banach-415c03.netlify.com/)
 
-Storybook is a powerful tool React, React Native, Vue, Angular, Svelte and many others frameworks. It has a thriving developer community and a wealth of addons. This introduction scratches the surface of what’s possible. We’re confident that once you adopt Storybook, you’ll be impressed by how productive it is to build durable UIs.
+Storybook is a powerful tool for React, React Native, Vue, Angular, Svelte and many others frameworks. It has a thriving developer community and a wealth of addons. This introduction scratches the surface of what’s possible. We’re confident that once you adopt Storybook, you’ll be impressed by how productive it is to build durable UIs.
 
 ## Learn more
 

--- a/content/intro-to-storybook/react/en/conclusion.md
+++ b/content/intro-to-storybook/react/en/conclusion.md
@@ -9,7 +9,7 @@ Congratulations! You created your first UI in Storybook. Along the way you learn
 <br/>
 [🌎 **Deployed Storybook**](https://clever-banach-415c03.netlify.com/)
 
-Storybook is a powerful tool for React, Vue, and Angular. It has a thriving developer community and a wealth of addons. This introduction scratches the surface of what’s possible. We’re confident that once you adopt Storybook, you’ll be impressed by how productive it is to build durable UIs.
+Storybook is a powerful tool React, React Native, Vue, Angular, Svelte and many others frameworks. It has a thriving developer community and a wealth of addons. This introduction scratches the surface of what’s possible. We’re confident that once you adopt Storybook, you’ll be impressed by how productive it is to build durable UIs.
 
 ## Learn more
 
@@ -21,9 +21,11 @@ Want to dive deeper? Here are helpful resources.
 
 - [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) dives deep into using Storybook to visual test components. Free 31-page ebook.
 
-- [**Storybook Discord**](https://discord.gg/UUt2PJb) will put you in touch with the Storybook community. Not only offers a means to help you but for you to help the community also.
+- [**Storybook Discord chat**](https://discord.gg/UUt2PJb) puts you in contact with the Storybook community. Get and give help to other Storybook users.
 
-- [**Storybook blog**](https://medium.com/storybookjs) where you'll read about the latest changes and some techniques to further improve your development workflows with Storybook.
+- [**Storybook blog**](https://medium.com/storybookjs) showcases the latest releases and features to streamline your UI development workflow.
+
+
 
 ## Who made LearnStorybook.com?
 

--- a/content/intro-to-storybook/react/en/conclusion.md
+++ b/content/intro-to-storybook/react/en/conclusion.md
@@ -21,6 +21,10 @@ Want to dive deeper? Here are helpful resources.
 
 - [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) dives deep into using Storybook to visual test components. Free 31-page ebook.
 
+- [**Storybook Discord**](https://discord.gg/UUt2PJb) will put you in touch with the Storybook community. Not only offers a means to help you but for you to help the community also.
+
+- [**Storybook blog**](https://medium.com/storybookjs) where you'll read about the latest changes and some techniques to further improve your development workflows with Storybook.
+
 ## Who made LearnStorybook.com?
 
 The text, code, and production were contributed by [Chroma](http://blog.hichroma.com/). The tutorial was inspired by Chroma’s popular [GraphQL + React tutorial series](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858).

--- a/content/intro-to-storybook/react/en/creating-addons.md
+++ b/content/intro-to-storybook/react/en/creating-addons.md
@@ -1,12 +1,12 @@
 ---
-title: "Creating addons"
-tocTitle: "Creating addons"
-description: "Learn how to build your own addons that will super charge your development"
+title: 'Creating addons'
+tocTitle: 'Creating addons'
+description: 'Learn how to build your own addons that will super charge your development'
 ---
 
 In the previous chapter we were introduced to one of the key features of Storybook, its robust system of [addons](https://storybook.js.org/addons/introduction/), which can be used to enhance not only yours but also your team's developer experience and workflows.
 
-In this chapter we're going to take a look on how we create our own addon. You might think that writting it can be a daunting task, but actually it's not, we just need to take a couple of steps to get started and we can start writting it.
+In this chapter we're going to take a look on how we create our own addon. You might think that writing it can be a daunting task, but actually it's not, we just need to take a couple of steps to get started and we can start writing it.
 
 But first thing is first, let's first scope out what our addon will do.
 
@@ -20,10 +20,7 @@ We have our goal, now let's define what features our addon will support:
 - Support images, but also urls for embedding
 - Should support multiple assets, just in case there will be multiple versions or themes
 
-
-The way we'll be attaching the list of assets to the stories is through [parameters](https://storybook.js.org/docs/configurations/options-parameter/), which is a Storybook option that allow us to inject custom parameters to our stories. The way to use it, it's quite similar on how we used a decorator in previous chapters.
-
-<!-- this is probably not needed as it's used below-->
+The way we'll be attaching the list of assets to the stories is through [parameters](https://storybook.js.org/docs/configurations/options-parameter/#per-story-options), which is a Storybook option that allow us to inject custom parameters to our stories. The way to use it, it's quite similar on how we used a decorator in previous chapters.
 
 ```javascript
 export default {
@@ -38,81 +35,62 @@ export default {
 };
 ```
 
-<!-- -->
-
 ## Setup
 
-We've outlined what our addon will do, time to setup our local development environment. We need some additional packages in our project. More specifically:
+We've outlined what our addon will do, it's time to start working on it.
 
-<!-- it would be nice that the readme files would have some minimal information for each package-->
+Inside your `.storybook` folder, create a new one called `addons` and inside it a new file called `register.js`.
 
-- 📦 [@storybook/api](https://www.npmjs.com/package/@storybook/api) for Storybook API usage.
-- 📦 [@storybook/components](https://www.npmjs.com/package/@storybook/components) to use Storybook's UI components.
-- 📦 [@storybook/theming ](https://www.npmjs.com/package/@storybook/theming) for styling.
-- 🛠 [@babel/preset-react](https://babeljs.io/docs/en/babel-preset-react) to transpile correctly some of React's new features.
+And that's it! Simple isn't it?
 
-Open a console, navigate to your project folder and run the following command:
-
-<!--using npm here until the whole tutorial set is moved into npm or yarn issue #153-->
-
-```bash
-  yarn add --dev @storybook/api @storybook/components @storybook/theming @babel/preset-react
-```
-
-We'll need to make a small change to the `.babelrc` file we created earlier. We need to add a reference to the `@babel/preset-react` package.
-
-Your updated file should look like this:
-
-```json
-{
-  "presets": ["@babel/preset-react"],
-  "plugins": ["macros"]
-}
-```
+<div class="aside">We're going to use the<code>.storybook</code> folder as a placeholder for our addon. The reason behind this, is to maintain a straightforward approach and avoid complicating it too much. Should this addon be transformed into a actual addon it would be best to move it to a separate package with it's own file and folder structure.</div>
 
 ## Writing the addon
 
-We have what we need, it's time to start working on the actual addon.
-
-Inside the `.storybook` folder create a new folder called `addons` and inside, a file called `design-assets.js` with the following:
+Add the following to your recently created file:
 
 ```javascript
-//.storybook/addons/design-assets.js
-import React from "react";
-import { AddonPanel } from "@storybook/components";
-import { addons, types } from "@storybook/addons";
+//.storybook/addons/register.js
+import React from 'react';
+import { AddonPanel } from '@storybook/components';
+import { addons, types } from '@storybook/addons';
 
-addons.register("my/design-assets", () => {
-  addons.add("design-assets/panel", {
-    title: "assets",
+addons.register('my/design-assets', () => {
+  addons.add('design-assets/panel', {
+    title: 'assets',
     type: types.PANEL,
     render: ({ active, key }) => (
       <AddonPanel active={active} key={key}>
         implement
       </AddonPanel>
-    )
+    ),
   });
 });
 ```
 
-<div class="aside">We're going to use the .storybook folder as a placeholder for our addon. The reason behind this, is to maintain a straightforward approach and avoid complicating it too much. Should this addon be transformed into a actual addon it would be best to move it to a separate package with it's own file and folder structure.</div>
-
 This is the a typical boilerplate code to get started and going over what the code is doing:
 
 - We're registering a new addon in our Storybook.
-- Add a new UI element for our addon with some options (a title that will define our addon and the type of element used) and render it with some text.
+- Add a new UI element for our addon with some options (a title that will define our addon and the type of element used) and render it with some text for now.
 
-Starting Storybook at this point, we won't be able to see the addon just yet. Like we did earlier with the Knobs addon, we need to register our own in the `.storybook/addons.js` file. Just add the following and should be able to see it working:
+Starting Storybook at this point, we won't be able to see the addon just yet. Like we did earlier with the Knobs addon, we need to register our own in the `.storybook/main.js` file. Just add the following to the already existing `addons` list:
 
 ```js
-import "./addons/design-assets";
+// .storybook/main.js
+module.exports = {
+  stories: ['../src/components/**/*.stories.js'],
+  addons: [
+    // same as before
+    './.storybook/addons/register.js', // our addon
+  ],
+};
 ```
 
 ![design assets addon running inside Storybook](/intro-to-storybook/create-addon-design-assets-added.png)
 
 Success! We have our newly created addon added to the Storybook UI.
 
-<div class="aside">Storybook allows you to add not only panels, but a whole range of different types of UI components. And most if not all of them are already created inside the @storybook/components package, so that you don't need waste too much time implementing the UI and focus on writting features.</div>
+<div class="aside">Storybook allows you to add not only panels, but a whole range of different types of UI components. And most if not all of them are already created inside the @storybook/components package, so that you don't need waste too much time implementing the UI and focus on writing features.</div>
 
 ### Creating the content component
 
@@ -123,15 +101,13 @@ To complete it, we need to make some changes to our imports and introduce a new 
 Make the following changes to the addon file:
 
 ```javascript
-//.storybook/addons/design-assets.js
-import React, { Fragment } from "react";
+//.storybook/addons/register.js
+import React, { Fragment } from 'react';
 /* same as before */
-import { useParameter } from "@storybook/api";
+import { useParameter } from '@storybook/api';
 
-//.storybook/addons/design-assets.js
 const Content = () => {
-  const results = useParameter("assets", []); // story's parameter being retrieved here
-
+  const results = useParameter('assets', []); // story's parameter being retrieved here
   return (
     <Fragment>
       {results.length ? (
@@ -145,22 +121,20 @@ const Content = () => {
   );
 };
 ```
-
 
 We've created the component, modified the imports, all that's missing is to connect the component to our panel and we'll have a working addon capable of displaying information relative to our stories.
 
 Your code should look like the following:
 
 ```javascript
-//.storybook/addons/design-assets.js
-import React, { Fragment } from "react";
-import { AddonPanel } from "@storybook/components";
-import { useParameter } from "@storybook/api";
-import { addons, types } from "@storybook/addons";
+//.storybook/addons/register.js
+import React, { Fragment } from 'react';
+import { AddonPanel } from '@storybook/components';
+import { useParameter } from '@storybook/api';
+import { addons, types } from '@storybook/addons';
 
 const Content = () => {
-  const results = useParameter("assets", []); // story's parameter being retrieved here
-
+  const results = useParameter('assets', []); // story's parameter being retrieved here
   return (
     <Fragment>
       {results.length ? (
@@ -174,27 +148,26 @@ const Content = () => {
   );
 };
 
-addons.register("my/design-assets", () => {
-  addons.add("design-assets/panel", {
-    title: "assets",
+addons.register('my/design-assets', () => {
+  addons.add('design-assets/panel', {
+    title: 'assets',
     type: types.PANEL,
     render: ({ active, key }) => (
       <AddonPanel active={active} key={key}>
         <Content />
       </AddonPanel>
-    )
+    ),
   });
 });
 ```
 
-Notice that we're using the [useParameter](https://storybook.js.org/docs/addons/api/#useparameter), this handy hook will allow us to read the information supplied by the `addParameters` option for each story, which in our case will be either a single path to a asset or a list of paths. You'll see it in effect shortly.
-
+Notice that we're using the [useParameter](https://storybook.js.org/docs/addons/api/#useparameter), this handy hook will allow us to read the information supplied by the `parameters` option for each story, which in our case will be either a single path to a asset or a list of paths. You'll see it in effect shortly.
 
 ### Using our addon with a story
 
 We've connected all the necessary pieces. But how can we see if it's actually working and showing anything?
 
-To do so, we're going to make a small change to the `Task.stories.js` file and add the [addParameters](https://storybook.js.org/docs/configurations/options-parameter/#per-story-options) option.
+To do so, we're going to make a small change to the `Task.stories.js` file and add the [parameters](https://storybook.js.org/docs/configurations/options-parameter/#per-story-options) option.
 
 ```javascript
 // src/components/Task.stories.js
@@ -204,10 +177,10 @@ export default {
   decorators: [withKnobs],
   parameters: {
     assets: [
-      "path/to/your/asset.png",
-      "path/to/another/asset.png",
-      "path/to/yet/another/asset.png"
-    ]
+      'path/to/your/asset.png',
+      'path/to/another/asset.png',
+      'path/to/yet/another/asset.png',
+    ],
   },
   // Our exports that end in "Data" are not stories.
   excludeStories: /.*Data$/,
@@ -219,34 +192,32 @@ Go ahead and restart your Storybook and select the Task story, you should see so
 
 ![storybook story showing contents with design assets addon](/intro-to-storybook/create-addon-design-assets-inside-story.png)
 
+### Showing content in our addon
 
-### Showing the actual assets
-
-At this stage we can see that the addon is working as it should our stories, but now let's change the `Content` component to actually display the assets:
-
+At this stage we can see that the addon is working as it should, but now let's change the `Content` component to actually display what we want:
 
 ```javascript
-//.storybook/addons/design-assets.js
-import React, { Fragment } from "react";
-import { AddonPanel } from "@storybook/components";
-import { useParameter, useStorybookState } from "@storybook/api";
-import { addons, types } from "@storybook/addons";
-import { styled } from "@storybook/theming";
+//.storybook/addons/register.js
+import React, { Fragment } from 'react';
+import { AddonPanel } from '@storybook/components';
+import { useParameter, useStorybookState } from '@storybook/api';
+import { addons, types } from '@storybook/addons';
+import { styled } from '@storybook/theming';
 
 const getUrl = input => {
-  return typeof input === "string" ? input : input.url;
+  return typeof input === 'string' ? input : input.url;
 };
 
 const Iframe = styled.iframe({
-  width: "100%",
-  height: "100%",
-  border: "0 none"
+  width: '100%',
+  height: '100%',
+  border: '0 none',
 });
 const Img = styled.img({
-  width: "100%",
-  height: "100%",
-  border: "0 none",
-  objectFit: "contain"
+  width: '100%',
+  height: '100%',
+  border: '0 none',
+  objectFit: 'contain',
 });
 
 const Asset = ({ url }) => {
@@ -261,9 +232,9 @@ const Asset = ({ url }) => {
   return <Iframe title={url} src={url} />;
 };
 
-export const Content = () => {
+const Content = () => {
   // story's parameter being retrieved here
-  const results = useParameter("assets", []);
+  const results = useParameter('assets', []);
   // the id of story retrieved from Storybook global state
   const { storyId } = useStorybookState();
 
@@ -271,59 +242,56 @@ export const Content = () => {
     return null;
   }
 
-  const url = getUrl(results[0]).replace("{id}", storyId);
+  const url = getUrl(results[0]).replace('{id}', storyId);
 
   return (
     <Fragment>
       <Asset url={url} />
     </Fragment>
   );
-
 };
 ```
 
 If you take a closer look, you'll see that we're using the `styled` tag, this tag comes from the `@storybook/theming` package. Using this tag, will allow us to customize not only Storybook's theme but also the UI to our needs. Also [useStorybookState](https://storybook.js.org/docs/addons/api/#usestorybookstate), which is a real handy hook, that allows us to tap into Storybook's internal state so that we can fetch any bit of information present. In our case we're using it to fetch only the id of each story created.
 
-### Displaying actual assets
+### Displaying the actual assets
 
 To actually see the assets displayed in our addon, we need to copy them over to the `public` folder and adjust the `addParameter` option to reflect these changes.
 
 Storybook will pick up on the change and will load the assets, but for now, only the first one.
 
-![actual assets loaded](/intro-to-storybook/design-assets-image-loaded.png) <!--needs to be created-->
+![actual assets loaded](/intro-to-storybook/design-assets-image-loaded.png)
 
 ## Stateful addons
 
 Going over our initial objectives:
 
-
 - ✔️ Display the design asset in a panel
 - ✔️ Support images, but also urls for embedding
 - ❌ Should support multiple assets, just in case there will be multiple versions or themes
 
-
 We're almost there, only one goal remaining.
 
-For the final one, we're going to need some sort of state, we could use React's `useState`, or if we were working with class components `this.setState()`. But instead we're going to use Storybook's own `useAddonState`, which gives us a means to persist the addon state, and avoid creating extra logic to persist the local state. We'll also use another UI element from Storybook, the `ActionBar`, which will allow us to change between items.
+For the final one, we're going to need some sort of state, we could use React's `useState` hook, or if we were working with class components `this.setState()`. But instead we're going to use Storybook's own `useAddonState`, which gives us a means to persist the addon state, and avoid creating extra logic to persist the local state. We'll also use another UI element from Storybook, the `ActionBar`, which will allow us to change between items.
 
 We need to adjust our imports for our needs:
 
 ```javascript
-//.storybook/addons/design-assets.js
-import { useParameter, useStorybookState, useAddonState } from "@storybook/api";
-import { AddonPanel, ActionBar } from "@storybook/components";
+//.storybook/addons/register.js
+import { useParameter, useStorybookState, useAddonState } from '@storybook/api';
+import { AddonPanel, ActionBar } from '@storybook/components';
 /* same as before */
 ```
 
 And modify our `Content` component, so that we can change between assets:
 
 ```javascript
-//.storybook/addons/design-assets.js
+//.storybook/addons/register.js
 export const Content = () => {
   // story's parameter being retrieved here
-  const results = useParameter("assets", []);
+  const results = useParameter('assets', []);
   // addon state being persisted here
-  const [selected, setSelected] = useAddonState("my/design-assets", 0);
+  const [selected, setSelected] = useAddonState('my/design-assets', 0);
   // the id of the story retrieved from Storybook global state
   const { storyId } = useStorybookState();
 
@@ -336,15 +304,15 @@ export const Content = () => {
     return null;
   }
 
-  const url = getUrl(results[selected]).replace("{id}", storyId);
+  const url = getUrl(results[selected]).replace('{id}', storyId);
   return (
     <Fragment>
       <Asset url={url} />
       {results.length > 1 ? (
         <ActionBar
           actionItems={results.map((i, index) => ({
-            title: typeof i === "string" ? `asset #${index + 1}` : i.name,
-            onClick: () => setSelected(index)
+            title: typeof i === 'string' ? `asset #${index + 1}` : i.name,
+            onClick: () => setSelected(index),
           }))}
         />
       ) : null}
@@ -361,28 +329,28 @@ We've accomplished what we set out to do, which is to create a fully functioning
   <summary>Click to expand and see the full code used in this example</summary>
 
 ```javascript
-// .storybook/addons
-import React, { Fragment } from "react";
+// .storybook/addons/register.js
+import React, { Fragment } from 'react';
 
-import { useParameter, useStorybookState, useAddonState } from "@storybook/api";
-import { addons, types } from "@storybook/addons";
-import { AddonPanel, ActionBar } from "@storybook/components";
-import { styled } from "@storybook/theming";
+import { useParameter, useStorybookState, useAddonState } from '@storybook/api';
+import { addons, types } from '@storybook/addons';
+import { AddonPanel, ActionBar } from '@storybook/components';
+import { styled } from '@storybook/theming';
 
 const getUrl = input => {
-  return typeof input === "string" ? input : input.url;
+  return typeof input === 'string' ? input : input.url;
 };
 
 const Iframe = styled.iframe({
-  width: "100%",
-  height: "100%",
-  border: "0 none"
+  width: '100%',
+  height: '100%',
+  border: '0 none',
 });
 const Img = styled.img({
-  width: "100%",
-  height: "100%",
-  border: "0 none",
-  objectFit: "contain"
+  width: '100%',
+  height: '100%',
+  border: '0 none',
+  objectFit: 'contain',
 });
 
 const Asset = ({ url }) => {
@@ -396,11 +364,9 @@ const Asset = ({ url }) => {
   return <Iframe title={url} src={url} />;
 };
 
-
-
-export const Content = () => {
-  const results = useParameter("assets", []); // story's parameter being retrieved here
-  const [selected, setSelected] = useAddonState("my/design-assets", 0); // addon state being persisted here
+const Content = () => {
+  const results = useParameter('assets', []); // story's parameter being retrieved here
+  const [selected, setSelected] = useAddonState('my/design-assets', 0); // addon state being persisted here
   const { storyId } = useStorybookState(); // the story«s unique identifier being retrieved from Storybook global state
 
   if (results.length === 0) {
@@ -412,7 +378,7 @@ export const Content = () => {
     return null;
   }
 
-  const url = getUrl(results[selected]).replace("{id}", storyId);
+  const url = getUrl(results[selected]).replace('{id}', storyId);
 
   return (
     <Fragment>
@@ -420,8 +386,8 @@ export const Content = () => {
       {results.length > 1 ? (
         <ActionBar
           actionItems={results.map((i, index) => ({
-            title: typeof i === "string" ? `asset #${index + 1}` : i.name,
-            onClick: () => setSelected(index)
+            title: typeof i === 'string' ? `asset #${index + 1}` : i.name,
+            onClick: () => setSelected(index),
           }))}
         />
       ) : null}
@@ -429,15 +395,15 @@ export const Content = () => {
   );
 };
 
-addons.register("my/design-assets", () => {
-  addons.add("design-assets/panel", {
-    title: "assets",
+addons.register('my/design-assets', () => {
+  addons.add('design-assets/panel', {
+    title: 'assets',
     type: types.PANEL,
     render: ({ active, key }) => (
       <AddonPanel active={active} key={key}>
         <Content />
       </AddonPanel>
-    )
+    ),
   });
 });
 ```
@@ -452,7 +418,6 @@ But that's beyond the scope of this tutorial. This example demonstrates how you 
 
 Learn how to further customize your addon:
 
-
 - [add buttons in the Storybook toolbar](https://github.com/storybookjs/storybook/blob/next/addons/viewport/src/register.tsx#L8-L15)
 - [communicate through the channel with the iframe](https://github.com/storybookjs/storybook/blob/next/dev-kits/addon-roundtrip/README.md)
 - [send commands and results](https://github.com/storybookjs/storybook/tree/next/addons/events)
@@ -466,7 +431,6 @@ And much more!
 <div class="aside">Should you create a new addon and you're interested in having it featured, feel free to open a PR in the Storybook documentation to have it featured.</div>
 
 ### Dev kits
-
 
 To help you jumpstart the addon development, the Storybook team has developed some `dev-kits`.
 

--- a/content/intro-to-storybook/react/en/creating-addons.md
+++ b/content/intro-to-storybook/react/en/creating-addons.md
@@ -39,7 +39,7 @@ export default {
 
 We've outlined what our addon will do, it's time to start working on it.
 
-Inside your `.storybook` folder, create a new one called `addons` and inside it a new file called `register.js`.
+Inside your `.storybook` folder, create a new one called `design-addon` and inside it a new file called `register.js`.
 
 And that's it! Simple isn't it?
 
@@ -50,13 +50,14 @@ And that's it! Simple isn't it?
 Add the following to your recently created file:
 
 ```javascript
-//.storybook/addons/register.js
+
+//.storybook/design-addon/register.js
 import React from 'react';
 import { AddonPanel } from '@storybook/components';
 import { addons, types } from '@storybook/addons';
 
-addons.register('my/design-assets', () => {
-  addons.add('design-assets/panel', {
+addons.register('my/design-addon', () => {
+  addons.add('design-addon/panel', {
     title: 'assets',
     type: types.PANEL,
     render: ({ active, key }) => (
@@ -76,12 +77,13 @@ This is the a typical boilerplate code to get started and going over what the co
 Starting Storybook at this point, we won't be able to see the addon just yet. Like we did earlier with the Knobs addon, we need to register our own in the `.storybook/main.js` file. Just add the following to the already existing `addons` list:
 
 ```js
+
 // .storybook/main.js
 module.exports = {
   stories: ['../src/components/**/*.stories.js'],
   addons: [
     // same as before
-    './.storybook/addons/register.js', // our addon
+    "./.storybook/design-addon/register.js" // our addon
   ],
 };
 ```
@@ -101,7 +103,8 @@ To complete it, we need to make some changes to our imports and introduce a new 
 Make the following changes to the addon file:
 
 ```javascript
-//.storybook/addons/register.js
+
+//.storybook/design-addon/register.js
 import React, { Fragment } from 'react';
 /* same as before */
 import { useParameter } from '@storybook/api';
@@ -127,7 +130,8 @@ We've created the component, modified the imports, all that's missing is to conn
 Your code should look like the following:
 
 ```javascript
-//.storybook/addons/register.js
+
+//.storybook/design-addon/register.js
 import React, { Fragment } from 'react';
 import { AddonPanel } from '@storybook/components';
 import { useParameter } from '@storybook/api';
@@ -148,8 +152,8 @@ const Content = () => {
   );
 };
 
-addons.register('my/design-assets', () => {
-  addons.add('design-assets/panel', {
+addons.register('my/design-addon', () => {
+  addons.add('design-addon/panel', {
     title: 'assets',
     type: types.PANEL,
     render: ({ active, key }) => (
@@ -170,6 +174,7 @@ We've connected all the necessary pieces. But how can we see if it's actually wo
 To do so, we're going to make a small change to the `Task.stories.js` file and add the [parameters](https://storybook.js.org/docs/configurations/options-parameter/#per-story-options) option.
 
 ```javascript
+
 // src/components/Task.stories.js
 export default {
   component: Task,
@@ -197,7 +202,8 @@ Go ahead and restart your Storybook and select the Task story, you should see so
 At this stage we can see that the addon is working as it should, but now let's change the `Content` component to actually display what we want:
 
 ```javascript
-//.storybook/addons/register.js
+
+//.storybook/design-addon/register.js
 import React, { Fragment } from 'react';
 import { AddonPanel } from '@storybook/components';
 import { useParameter, useStorybookState } from '@storybook/api';
@@ -256,7 +262,7 @@ If you take a closer look, you'll see that we're using the `styled` tag, this ta
 
 ### Displaying the actual assets
 
-To actually see the assets displayed in our addon, we need to copy them over to the `public` folder and adjust the `addParameter` option to reflect these changes.
+To actually see the assets displayed in our addon, we need to copy them over to the `public` folder and adjust the story's `parameters` option to reflect these changes.
 
 Storybook will pick up on the change and will load the assets, but for now, only the first one.
 
@@ -277,7 +283,8 @@ For the final one, we're going to need some sort of state, we could use React's 
 We need to adjust our imports for our needs:
 
 ```javascript
-//.storybook/addons/register.js
+
+//.storybook/design-addon/register.js
 import { useParameter, useStorybookState, useAddonState } from '@storybook/api';
 import { AddonPanel, ActionBar } from '@storybook/components';
 /* same as before */
@@ -286,12 +293,13 @@ import { AddonPanel, ActionBar } from '@storybook/components';
 And modify our `Content` component, so that we can change between assets:
 
 ```javascript
-//.storybook/addons/register.js
-export const Content = () => {
+
+//.storybook/design-addon/register.js
+const Content = () => {
   // story's parameter being retrieved here
   const results = useParameter('assets', []);
   // addon state being persisted here
-  const [selected, setSelected] = useAddonState('my/design-assets', 0);
+  const [selected, setSelected] = useAddonState('my/design-addon', 0);
   // the id of the story retrieved from Storybook global state
   const { storyId } = useStorybookState();
 
@@ -329,7 +337,8 @@ We've accomplished what we set out to do, which is to create a fully functioning
   <summary>Click to expand and see the full code used in this example</summary>
 
 ```javascript
-// .storybook/addons/register.js
+
+// .storybook/design-addon/register.js
 import React, { Fragment } from 'react';
 
 import { useParameter, useStorybookState, useAddonState } from '@storybook/api';
@@ -366,7 +375,7 @@ const Asset = ({ url }) => {
 
 const Content = () => {
   const results = useParameter('assets', []); // story's parameter being retrieved here
-  const [selected, setSelected] = useAddonState('my/design-assets', 0); // addon state being persisted here
+  const [selected, setSelected] = useAddonState('my/design-addon', 0); // addon state being persisted here
   const { storyId } = useStorybookState(); // the story«s unique identifier being retrieved from Storybook global state
 
   if (results.length === 0) {
@@ -395,8 +404,8 @@ const Content = () => {
   );
 };
 
-addons.register('my/design-assets', () => {
-  addons.add('design-assets/panel', {
+addons.register('my/design-addon', () => {
+  addons.add('design-addon/panel', {
     title: 'assets',
     type: types.PANEL,
     render: ({ active, key }) => (

--- a/content/intro-to-storybook/react/en/data.md
+++ b/content/intro-to-storybook/react/en/data.md
@@ -15,7 +15,7 @@ Our `TaskList` component as currently written is “presentational” (see [this
 
 This example uses [Redux](https://redux.js.org/), the most popular React library for storing data, to build a simple data model for our app. However, the pattern used here applies just as well to other data management libraries like [Apollo](https://www.apollographql.com/client/) and [MobX](https://mobx.js.org/).
 
-Add a new dependency on `package.json` with:
+Add the necessary dependencies to your project with:
 
 ```bash
 yarn add react-redux redux
@@ -165,5 +165,5 @@ export const Empty = () => <PureTaskList tasks={[]} {...actionsData} />;
 </video>
 
 <div class="aside">
-Should your snapshot tests fail at this stage, you must update the existing snapshots by running the test script with the <code>-u</code> flag. 
+Should your snapshot tests fail at this stage, you must update the existing snapshots by running the test script with the <code>-u</code> flag. Also as our app is progressively growing it might also a good place to run the tests with the <code> --watchAll</code> flag like mentioned in the <a href="/react/en/get-started/">Get Started</a> section.
 </div>

--- a/content/intro-to-storybook/react/en/deploy.md
+++ b/content/intro-to-storybook/react/en/deploy.md
@@ -14,19 +14,9 @@ In this tutorial we ran Storybook on our development machine. You may also want 
 
 ## Exporting as a static app
 
-To deploy Storybook we first need to export it as a static web app. This functionality is already built into Storybook, we just need to activate it by adding a script to `package.json`.
+To deploy Storybook we first need to export it as a static web app. This functionality is already built-in and configured for you, so you don't need to worry about any configuration. 
 
-```javascript
-// package.json
-
-{
-  "scripts": {
-    "build-storybook": "build-storybook -c .storybook"
-  }
-}
-```
-
-Now when you build Storybook via `npm run build-storybook`, it will output a static Storybook in the `storybook-static` directory.
+Now when you build Storybook via `yarn build-storybook`, it will output a static Storybook in the `storybook-static` directory.
 
 ## Continuous deploy
 
@@ -35,6 +25,8 @@ We want to share the latest version of components whenever we push code. To do t
 ### GitHub
 
 First you want to setup Git for your project in the local directory. If you're following along from the previous testing chapter jump to setting up a repository on GitHub.
+
+When the project was initialized with Create React App, a local repository was already setup for you. At this stage it's safe to add the files to the first commit.
 
 ```bash
 $ git init
@@ -51,6 +43,7 @@ Now commit the files.
 ```bash
 $ git commit -m "taskbox UI"
 ```
+### Setup a repository in GitHub
 
 Go to GitHub and setup a repository [here](https://github.com/new). Name your repo “taskbox”.
 
@@ -86,7 +79,7 @@ Now select the taskbox GitHub repo from the list of options.
 
 ![Netlify connect to repo](/intro-to-storybook/netlify-account-picker.png)
 
-Configure Netlify by highlighting which build command to run in its CI and which directory the static site is outputted in. For branch choose `master`. Directory is `.storybook-static`. Build command use `yarn build-storybook`.
+Configure Netlify by highlighting which build command to run in its CI and which directory the static site is outputted in. For branch choose `master`. Directory is `storybook-static`. Build command use `yarn build-storybook`.
 
 ![Netlify settings](/intro-to-storybook/netlify-settings.png)
 

--- a/content/intro-to-storybook/react/en/get-started.md
+++ b/content/intro-to-storybook/react/en/get-started.md
@@ -5,7 +5,7 @@ description: 'Setup Storybook in your development environment'
 commit: ebe2ae2
 ---
 
-Storybook runs alongside your app in development mode. It helps you build UI components isolated from the business logic and context of your app. This edition of Learn Storybook is for React; other editions exist for [Vue](/vue/en/get-started) and [Angular](/angular/en/get-started).
+Storybook runs alongside your app in development mode. It helps you build UI components isolated from the business logic and context of your app. This edition of Learn Storybook is for React; other editions exist for [React Native](/react-native/en/get-started), [Vue](/vue/en/get-started), [Angular](/angular/en/get-started) and [Svelte](/svelte/en/get-started).
 
 ![Storybook and your app](/intro-to-storybook/storybook-relationship.jpg)
 
@@ -16,27 +16,34 @@ We’ll need to follow a few steps to get the build process set up in your envir
 ```bash
 # Create our application:
 npx create-react-app taskbox
+
 cd taskbox
 
 # Add Storybook:
 npx -p @storybook/cli sb init
 ```
 
+<div class="aside">
+Throughout this version of the tutorial, we'll be using <code>yarn</code> to run the majority of our commands. 
+If you have Yarn installed, but prefer to use <code>npm</code> instead, don't worry, you can still go through the tutorial without any issues. Just add the <code>--use-npm</code> flag to the first command above and both CRA and Storybook will initialize based on this. Also while you progress through the tutorial, don't forget to adjust the commands used to their <code>npm</code> counterparts.
+</div>
+
+
 We can quickly check that the various environments of our application are working properly:
 
 ```bash
 # Run the test runner (Jest) in a terminal:
-yarn test
+yarn test --watchAll
 
 # Start the component explorer on port 9009:
-yarn run storybook
+yarn storybook
 
 # Run the frontend app proper on port 3000:
 yarn start
 ```
 
-<div class="aside">
-  NOTE: If <code>yarn test</code> throws an error, you may need to install <code>watchman</code> as advised in <a href="https://github.com/facebook/create-react-app/issues/871#issuecomment-252297884">this issue</a>.
+<div class="aside"> 
+You may have noticed we've added the <code>--watchAll</code> flag to our test command, don't worry it's intentional, this small change will ensure that all tests run and everything is ok with our application. While you progress through this tutorial you will be introduced to different test scenarios, so probably you might want to consider and add the flag to your test script in your <code>package.json</code> to ensure your entire test suite runs.
 </div>
 
 Our three frontend app modalities: automated test (Jest), component development (Storybook), and the app itself.
@@ -47,7 +54,7 @@ Depending on what part of the app you’re working on, you may want to run one o
 
 ## Reuse CSS
 
-Taskbox reuses design elements from the GraphQL and React Tutorial [example app](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858), so we won’t need to write CSS in this tutorial. We’ll simply compile the LESS to a single CSS file and include it in our app. Copy and paste [this compiled CSS](https://github.com/chromaui/learnstorybook-code/blob/master/src/index.css) into the src/index.css file per CRA’s convention.
+Taskbox reuses design elements from the GraphQL and React Tutorial [example app](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858), so we won’t need to write CSS in this tutorial. Copy and paste [this compiled CSS](https://github.com/chromaui/learnstorybook-code/blob/master/src/index.css) into the `src/index.css` file.
 
 ![Taskbox UI](/intro-to-storybook/ss-browserchrome-taskbox-learnstorybook.png)
 
@@ -57,4 +64,15 @@ If you want to modify the styling, the source LESS files are provided in the Git
 
 ## Add assets
 
-We also need to add the font and icon [directories](https://github.com/chromaui/learnstorybook-code/tree/master/public) to the `public/` folder. After adding styling and assets, the app will render a bit strangely. That’s OK. We aren’t working on the app right now. We’re starting off with building our first component!
+To match the intended design, you'll need to download both the font and icon directories and place its contents inside your `public` folder.
+
+<div class="aside">
+<p>We’ve used <code>svn</code> (Subversion) to easily download a folder of files from GitHub. If you don’t have subversion installed or want to just do it manually, you can grab the folders directly <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.</p></div>
+
+```bash
+svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/icon public/icon
+svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/font public/font
+```
+
+
+After adding styling and assets, the app will render a bit strangely. That’s OK. We aren’t working on the app right now. We’re starting off with building our first component!

--- a/content/intro-to-storybook/react/en/screen.md
+++ b/content/intro-to-storybook/react/en/screen.md
@@ -63,22 +63,20 @@ We also change the `App` component to render the `InboxScreen` (eventually we wo
 ```javascript
 // src/App.js
 
-import React, { Component } from 'react';
+import React from 'react';
 import { Provider } from 'react-redux';
 import store from './lib/redux';
 
 import InboxScreen from './components/InboxScreen';
 
-class App extends Component {
-  render() {
-    return (
-      <Provider store={store}>
-        <InboxScreen />
-      </Provider>
-    );
-  }
+import './index.css';
+function App() {
+  return (
+    <Provider store={store}>
+      <InboxScreen />
+    </Provider>
+  );
 }
-
 export default App;
 ```
 

--- a/content/intro-to-storybook/react/en/simple-component.md
+++ b/content/intro-to-storybook/react/en/simple-component.md
@@ -71,15 +71,11 @@ export const actionsData = {
   onArchiveTask: action('onArchiveTask'),
 };
 
-export const Default = () => {
-  return <Task task={{ ...taskData }} {...actionsData} />;
-};
+export const Default = () => <Task task={{ ...taskData }} {...actionsData} />;
 
 export const Pinned = () => <Task task={{ ...taskData, state: 'TASK_PINNED' }} {...actionsData} />;
 
-export const Archived = () => (
-  <Task task={{ ...taskData, state: 'TASK_ARCHIVED' }} {...actionsData} />
-);
+export const Archived = () => <Task task={{ ...taskData, state: 'TASK_ARCHIVED' }} {...actionsData} />;
 ```
 
 There are two basic levels of organization in Storybook: the component and its child stories. Think of each story as a permutation of a component. You can have as many stories per component as you need.
@@ -95,7 +91,7 @@ To tell Storybook about the component we are documenting, we create a `default` 
 - `title` -- how to refer to the component in the sidebar of the Storybook app,
 - `excludeStories` -- exports in the story file that should not be rendered as stories by Storybook.
 
-To define our stories, we export a function for each of our test states to generate a story. The story is a function that returns a rendered element (i.e. a component class with a set of props) in a given state---exactly like a React [Stateless Functional Component](https://reactjs.org/docs/components-and-props.html).
+To define our stories, we export a function for each of our test states to generate a story. The story is a function that returns a rendered element (i.e. a component with a set of props) in a given state---exactly like a [Stateless Functional Component](https://reactjs.org/docs/components-and-props.html).
 
 `action()` allows us to create a callback that appears in the **actions** panel of the Storybook UI when clicked. So when we build a pin button, we’ll be able to determine in the test UI if a button click is successful.
 
@@ -111,15 +107,16 @@ When creating a story we use a base task (`taskData`) to build out the shape of 
 
 ## Config
 
-We'll need to make a couple of changes to the Storybook configuration so it notices not only our recently created stories, but also allows us to use our CSS file.
+We'll need to make a couple of changes to the Storybook configuration so it notices not only our recently created stories, but also allows us to use the CSS file that was changed in the [previous chapter](/react/en/get-started).
 
 Start by changing your Storybook configuration file (`.storybook/main.js`) to the following:
 
 ```javascript
 // .storybook/main.js
+
 module.exports = {
   stories: ['../src/components/**/*.stories.js'],
-  addons: ['@storybook/addon-actions', '@storybook/addon-links'],
+  addons: ['@storybook/preset-create-react-app','@storybook/addon-actions', '@storybook/addon-links'],
 };
 ```
 
@@ -169,6 +166,7 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
 
       <div className="actions" onClick={event => event.stopPropagation()}>
         {state !== 'TASK_ARCHIVED' && (
+           // eslint-disable-next-line jsx-a11y/anchor-is-valid
           <a onClick={() => onPinTask(id)}>
             <span className={`icon-star`} />
           </a>
@@ -237,10 +235,10 @@ Snapshot testing refers to the practice of recording the “known good” output
 Make sure your components render data that doesn't change, so that your snapshot tests won't fail each time. Watch out for things like dates or randomly generated values.
 </div>
 
-With the [Storyshots addon](https://github.com/storybooks/storybook/tree/master/addons/storyshots) a snapshot test is created for each of the stories. Use it by adding a development dependency on the package:
+With the [Storyshots addon](https://github.com/storybooks/storybook/tree/master/addons/storyshots) a snapshot test is created for each of the stories. Use it by adding the following development dependencies:
 
 ```bash
-yarn add --dev @storybook/addon-storyshots react-test-renderer
+yarn add -D @storybook/addon-storyshots react-test-renderer
 ```
 
 Then create an `src/storybook.test.js` file with the following in it:

--- a/content/intro-to-storybook/react/en/test.md
+++ b/content/intro-to-storybook/react/en/test.md
@@ -53,8 +53,10 @@ $ git commit -m "taskbox UI"
 Add the package as a dependency.
 
 ```bash
-yarn add storybook-chromatic
+yarn add -D storybook-chromatic
 ```
+
+One fantastic thing about this addon is that it will use Git history to keep track of your UI components.
 
 Then [login to Chromatic](https://www.chromaticqa.com/start) with your GitHub account (Chromatic only asks for lightweight permissions). Create a project with name "taskbox" and copy your unique `app-code`.
 

--- a/content/intro-to-storybook/react/en/test.md
+++ b/content/intro-to-storybook/react/en/test.md
@@ -9,7 +9,7 @@ No Storybook tutorial would be complete without testing. Testing is essential to
 
 - **Visual tests** rely on developers to manually look at a component to verify it for correctness. They help us sanity check a component’s appearance as we build.
 - **Snapshot tests** with Storyshots capture a component’s rendered markup. They help us stay abreast of markup changes that cause rendering errors and warnings.
-- **Unit tests** with Jest verify that the output of a component remains the same given an fixed input. They’re great for testing the functional qualities of a component.
+- **Unit tests** with Jest verify that the output of a component remains the same given a fixed input. They’re great for testing the functional qualities of a component.
 
 ## “But does it look right?”
 

--- a/content/intro-to-storybook/react/en/using-addons.md
+++ b/content/intro-to-storybook/react/en/using-addons.md
@@ -32,7 +32,7 @@ Knobs is an amazing resource for designers and developers to experiment and play
 First, we will need to install all the necessary dependencies.
 
 ```bash
-yarn add @storybook/addon-knobs
+yarn add -D @storybook/addon-knobs
 ```
 
 Register Knobs in your `.storybook/main.js` file.
@@ -42,7 +42,7 @@ Register Knobs in your `.storybook/main.js` file.
 
 module.exports = {
   stories: ['../src/components/**/*.stories.js'],
-  addons: ['@storybook/addon-actions', '@storybook/addon-knobs', '@storybook/addon-links'],
+  addons: ['@storybook/preset-create-react-app','@storybook/addon-actions', '@storybook/addon-knobs', '@storybook/addon-links'],
 };
 ```
 

--- a/content/intro-to-storybook/react/es/get-started.md
+++ b/content/intro-to-storybook/react/es/get-started.md
@@ -5,6 +5,11 @@ description: 'Configurar React Storybook en tu entorno de desarrollo'
 commit: ebe2ae2
 ---
 
+
+<div class="aside"><p>
+¡Esta traducción está desactualizada! Ayúdenos a mejorarlo haciendo clic en el enlace en la parte inferior de la página. No solo el equipo te lo agradece, sino toda la comunidad.</p></div>
+
+
 Storybook se ejecuta junto con tu aplicación en modo desarrollo. Te ayuda a crear componentes de UI aislados de la lógica y el contexto de tu aplicación. Esta edición de Aprende Storybook es para React; existe una edición para [Angular](/angular/es/get-started) y para Vue vendrá pronto.
 
 ![Storybook and your app](/intro-to-storybook/storybook-relationship.jpg)

--- a/content/intro-to-storybook/react/pt/composite-component.md
+++ b/content/intro-to-storybook/react/pt/composite-component.md
@@ -10,8 +10,8 @@ No capitulo anterior, construímos o nosso primeiro componente, neste capitulo i
 ## TaskList
 
 A Taskbox dá prioridade a tarefas que foram confirmadas através do seu posicionamento acima de quaisquer outras.
-Isto gera duas variações da `TaskList`, para o qual será necessária a criação de estórias:
-os itens normais e itens normais e itens confirmados.
+Isto gera duas variações da `TaskList`, para a qual será necessária a criação de estórias:
+itens normais e itens normais e itens confirmados.
 
 ![tarefas confirmadas e padrão](/intro-to-storybook/tasklist-states-1.png)
 
@@ -27,6 +27,8 @@ Um componente composto não é em nada diferente do componente básico contido d
 Comece por uma implementação em bruto da `TaskList`. Será necessário importar o componente `Task` criado anteriormente e injetar os atributos e as respetivas ações como inputs.
 
 ```javascript
+// src/components/TaskList.js
+
 import React from 'react';
 
 import Task from './Task';
@@ -60,41 +62,50 @@ export default TaskList;
 Em seguida iremos criar os estados de teste do `TaskList` no ficheiro de estórias respetivo.
 
 ```javascript
+// src/components/TaskList.stories.js
+
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import TaskList from './TaskList';
-import { task, actions } from './Task.stories';
+import { taskData, actionsData } from './Task.stories';
 
-export const defaultTasks = [
-  { ...task, id: '1', title: 'Task 1' },
-  { ...task, id: '2', title: 'Task 2' },
-  { ...task, id: '3', title: 'Task 3' },
-  { ...task, id: '4', title: 'Task 4' },
-  { ...task, id: '5', title: 'Task 5' },
-  { ...task, id: '6', title: 'Task 6' },
+export default {
+  component: TaskList,
+  title: 'TaskList',
+  decorators: [story => <div style={{ padding: '3rem' }}>{story()}</div>],
+  excludeStories: /.*Data$/,
+};
+
+export const defaultTasksData = [
+  { ...taskData, id: '1', title: 'Task 1' },
+  { ...taskData, id: '2', title: 'Task 2' },
+  { ...taskData, id: '3', title: 'Task 3' },
+  { ...taskData, id: '4', title: 'Task 4' },
+  { ...taskData, id: '5', title: 'Task 5' },
+  { ...taskData, id: '6', title: 'Task 6' },
 ];
 
-export const withPinnedTasks = [
-  ...defaultTasks.slice(0, 5),
+export const withPinnedTasksData = [
+  ...defaultTasksData.slice(0, 5),
   { id: '6', title: 'Task 6 (pinned)', state: 'TASK_PINNED' },
 ];
 
-storiesOf('TaskList', module)
-  .addDecorator(story => <div style={{ padding: '3rem' }}>{story()}</div>)
-  .add('default', () => <TaskList tasks={defaultTasks} {...actions} />)
-  .add('withPinnedTasks', () => <TaskList tasks={withPinnedTasks} {...actions} />)
-  .add('loading', () => <TaskList loading tasks={[]} {...actions} />)
-  .add('empty', () => <TaskList tasks={[]} {...actions} />);
+export const Default = () => <TaskList tasks={defaultTasksData} {...actionsData} />;
+
+export const WithPinnedTasks = () => <TaskList tasks={withPinnedTasksData} {...actionsData} />;
+
+export const Loading = () => <TaskList loading tasks={[]} {...actionsData} />;
+
+export const Empty = () => <TaskList tasks={[]} {...actionsData} />;
 ```
 
-A função `addDecorator()` permite que seja adicionado algum "contexto" á renderização de cada tarefa. Neste caso a lista é envolvida com um ligeiro preenchimento, de forma que seja possível ser feita uma verificação visual com maior eficácia.
-
 <div class="aside">
-    Os <a href="https://storybook.js.org/addons/introduction/#1-decorators"><b>Decoradores</b></a>, oferecem uma forma de embrulho arbitrária ás estórias. Neste caso estamos a usar um decorador para gerar elementos de estilo. Mas podem ser usados para envolver as estórias definidas em "providers", nomeadamente, bibliotecas ou componentes que usam o contexto React.
+    Os <a href="https://storybook.js.org/addons/introduction/#1-decorators"><b>Decoradores</b></a>, oferecem uma forma de envolver arbitráriamente as estórias. Neste caso estamos a usar um decorador para gerar elementos de estilo. Mas podem ser usados para envolver as estórias definidas em "providers", nomeadamente, bibliotecas ou componentes que usam o contexto React.
 </div>
 
-O adereço `task` irá definir a forma da `Task` que foi criada e exportada a partir do ficheiro `Task.stories.js`. E como tal, as `actions` irão definir quais as ações (através de uma callback simulada) que o componente `Task` se encontra á espera. Cujas quais também necessárias á `TaskList`.
+Com a importação da `taskData` para este ficheiro (ou arquivo), está a ser adicionada a forma que uma tarefa (ou `Task`) assume, isto a partir do ficheiro `Task.stories.js` criado anteriormente. Como tal também a `actionsData` que irá definir quais as ações (através de uma callback simulada) que o componente Task se encontra á espera.
+
+Estes também necessários á TaskList.
 
 Pode agora verificar-se o Storybook com as estórias novas associadas á `Tasklist`.
 
@@ -106,10 +117,11 @@ Pode agora verificar-se o Storybook com as estórias novas associadas á `Taskli
 </video>
 
 ## Definir os estados
-
-O componente ainda se encontra num estado bruto, mas temos já uma ideia de quais são as estórias com que temos que trabalhar. Poderá estar a pensar que o embrulho `.list-items` é deveras simples. Mas tem razão, na maioria dos casos não iria ser criado um novo componente somente para adicionar um embrulho. A **verdadeira complexidade** do componente `TaskList` é revelada com os casos extremos `withPinnedTasks`, `loading` e `empty`.
+O componente ainda se encontra num estado bruto, mas já temos uma ideia de quais são as estórias com que temos que trabalhar. Poderá estar a pensar que ao usar-se o `.list-items` no componente como invólucro é deveras simples. Mas tem razão, na maioria dos casos não iria ser criado um novo componente somente para adicionar um invólucro. A **verdadeira complexidade** do componente `TaskList` é revelada com os casos extremos `WithPinnedTasks`, `loading` e `empty`.
 
 ```javascript
+// src/components/TaskList.js
+
 import React from 'react';
 
 import Task from './Task';
@@ -180,16 +192,20 @@ O markup adicional irá resultar no seguinte interface de utilizador:
   />
 </video>
 
-Reparem na posição do item confirmado na lista. Pretende-se que este item seja renderizado no topo da lista e torná-lo uma prioridade aos utilizadores.
+Repare na posição do item que está confirmado na lista. Pretende-se que este item seja renderizado no topo da lista e torná-lo uma prioridade aos utilizadores.
 
 ## Requisitos de dados e adereços
 
-Á medida que o componente tem tendência em crescer, o mesmo irá acontecer com os seus requisitos. Visto que `Task` é um componente filho, é necessário fornecer os dados estruturados correctamente ao componente `TaskList` de forma que possa ser renderizado correctamente.
+À medida que o componente tem tendência em crescer, o mesmo irá acontecer com os seus requisitos. Visto que `Task` é um componente filho, é necessário fornecer os dados estruturados corretamente ao componente `TaskList` de forma que possa ser renderizado corretamente.
 De forma a poupar tempo podemos reutilizar os adereços (propTypes) que foram definidos anteriormente no componente `Task`.
 
 ```javascript
+// src/components/TaskList.js
+
 import React from 'react';
 import PropTypes from 'prop-types';
+
+import Task from './Task';
 
 function TaskList() {
   ...
@@ -212,7 +228,7 @@ export default TaskList;
 
 ## Testes automatizados
 
-No capitulo anterior, aprendeu-se a usar o Storyshots para implementar estórias de testes snapshot. Com o componente `Task` não existia muita complexidade para testar além do sucesso da renderização. Visto que o componente `TaskList` adiciona uma camada extra de complexidade, pretende-se verificar que determinados valores de entrada produzam determinados valores de saída, isto implementado de forma responsável para os testes automáticos. Para tal irão ser criados testes unitários utilizando [Jest](https://facebook.github.io/jest/) em conjunção com um renderizador de testes como por exemplo [Enzyme](http://airbnb.io/enzyme/).
+No capítulo anterior, aprendemos a usar o Storyshots para efetuar testes snapshot nas estórias. Com o componente `Task` não existia muita complexidade para testar além do sucesso da renderização. Visto que o componente `TaskList` adiciona uma camada extra de complexidade, pretende-se verificar que determinados valores de entrada produzam determinados valores de saída, isto implementado de forma responsável para os testes automáticos. Para tal irão ser criados testes unitários utilizando [Jest](https://facebook.github.io/jest/) em conjunção com um renderizador de testes.
 
 ![Jest logo](/intro-to-storybook/logo-jest.png)
 
@@ -230,15 +246,15 @@ De forma a evitar este problema em concreto, podemos usar o Jest, de forma que e
 Iremos começar por criar um ficheiro de testes denominado `TaskList.test.js`. Neste ficheiro estarão contidos os testes que irão fazer asserções acerca do valor de saída.
 
 ```javascript
+// src/components/TaskList.test.js
+
 import React from 'react';
 import ReactDOM from 'react-dom';
-import TaskList from './TaskList';
-import { withPinnedTasks } from './TaskList.stories';
+import { WithPinnedTasks } from './TaskList.stories';
 
 it('renders pinned tasks at the start of the list', () => {
   const div = document.createElement('div');
-  const events = { onPinTask: jest.fn(), onArchiveTask: jest.fn() };
-  ReactDOM.render(<TaskList tasks={withPinnedTasks} {...events} />, div);
+  ReactDOM.render(<WithPinnedTasks />, div);
 
   // We expect the task titled "Task 6 (pinned)" to be rendered first, not at the end
   const lastTaskInput = div.querySelector('.list-item:nth-child(1) input[value="Task 6 (pinned)"]');
@@ -250,6 +266,6 @@ it('renders pinned tasks at the start of the list', () => {
 
 ![Execução de testes da TaskList](/intro-to-storybook/tasklist-testrunner.png)
 
-Podemos verificar que foi possível reutilizar a lista de tarefas `withPinnedTasks` quer na estória, quer no teste unitário. Desta forma podemos continuar a aproveitar um recurso existente(os exemplos que representam configurações de um componente) de cada vez mais formas.
+Podemos verificar que foi possível reutilizar a lista de tarefas `withPinnedTasks` quer na estória, quer no teste unitário. Desta forma podemos continuar a aproveitar um recurso existente (os exemplos que representam configurações de um componente) de cada vez mais formas.
 
 Mas também que este teste é algo frágil. É possível que á medida que o projeto amadurece, a implementação concreta do componente `Task` seja alterada; isto quer pelo uso de uma classe com um nome diferente ou um elemento `textarea` ao invés de um `input`, por exemplo--com isto, este teste específico irá falhar e será necessária uma atualização. Isto não é necessariamente um problema, mas um indicador para ser cuidadoso no uso liberal de testes unitários para o interface de utilizador. Visto que não são de fácil manutenção. Ao invés deste tipo de testes, é preferível depender de testes visuais, snapshot ou de regressão visual (ver [capitulo de testes](/react/pt/test/)) sempre que for possível.

--- a/content/intro-to-storybook/react/pt/conclusion.md
+++ b/content/intro-to-storybook/react/pt/conclusion.md
@@ -9,7 +9,7 @@ Parabéns! Acabou de criar o primeiro interface de utilizador com o Storybook. A
 <br/>
 [🌎 **Storybook implementado**](https://clever-banach-415c03.netlify.com/)
 
-O Storybook é uma ferramenta bastante poderosa para React, Vue e Angular.
+O Storybook é uma ferramenta bastante poderosa para React, React Native, Vue, Angular e Svelte entre outras frameworks.
 Possui uma comunidade de programadores próspera e uma grande variedade de extras. Esta introdução arranha a superfície do que é possível fazer. Estamos confiantes que ao adotar o Storybook, ficará impressionado com o quão produtivo é construir IUs duradouros.
 
 ## Saber mais

--- a/content/intro-to-storybook/react/pt/conclusion.md
+++ b/content/intro-to-storybook/react/pt/conclusion.md
@@ -23,6 +23,11 @@ Pretende saber mais? Aqui ficam alguns recursos que irão ajudar.
 
 - [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) aprofunda o uso de Storybook para testes visuais. Livro eletrónico livre de 31 páginas.
 
+- [**Discord do Storybook**](https://discord.gg/UUt2PJb) põe-te em contacto direto com a comunidade Storybook. Além de oferecer uma forma de te ajudar, mas também para tu ajudares a comunidade.
+
+- [**Blog Storybook**](https://medium.com/storybookjs) onde poderás ler acerca das mais recentes alterações e ainda algumas técnicas para melhorares o teu fluxo de desenvolvimento com o Storybook.
+
+
 ## Quem fez LearnStorybook.com?
 
 

--- a/content/intro-to-storybook/react/pt/conclusion.md
+++ b/content/intro-to-storybook/react/pt/conclusion.md
@@ -23,9 +23,10 @@ Pretende saber mais? Aqui ficam alguns recursos que irão ajudar.
 
 - [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) aprofunda o uso de Storybook para testes visuais. Livro eletrónico livre de 31 páginas.
 
-- [**Discord do Storybook**](https://discord.gg/UUt2PJb) põe-te em contacto direto com a comunidade Storybook. Além de oferecer uma forma de te ajudar, mas também para tu ajudares a comunidade.
+- [**Discord do Storybook**](https://discord.gg/UUt2PJb) põe-te em contacto direto com a comunidade Storybook. Onde podes oferecer e receber ajuda de outros utilizadores do Storybook.
 
-- [**Blog Storybook**](https://medium.com/storybookjs) onde poderás ler acerca das mais recentes alterações e ainda algumas técnicas para melhorares o teu fluxo de desenvolvimento com o Storybook.
+- [**Blog Storybook**](https://medium.com/storybookjs) demonstra tanto as novidades acerca das versões mais recentes, como as últimas funcionalidades existentes, de forma a otimizar o teu fluxo de trabalho no desenvolvimento de interface de utilizador 
+
 
 
 ## Quem fez LearnStorybook.com?

--- a/content/intro-to-storybook/react/pt/creating-addons.md
+++ b/content/intro-to-storybook/react/pt/creating-addons.md
@@ -39,7 +39,7 @@ export default {
 
 Já delineamos o que o nosso extra irá fazer, está na altura de começar a implementação.
 
-No interior da pasta (ou diretório) `.storybook`, crie uma nova e dentro desta um ficheiro (ou arquivo) chamado `register.js`.
+Dentro da sua pasta (ou diretório) `.storybook`, crie uma nova pasta (ou diretório) chamada `design-addon` e dentro desta um ficheiro (ou arquivo) chamado `register.js`.
 
 E já está! Fácil não é?
 
@@ -50,13 +50,14 @@ E já está! Fácil não é?
 Adicione o conteúdo abaixo ao ficheiro (ou arquivo) que acabámos de criar:
 
 ```javascript
-//.storybook/addons/register.js
+
+//.storybook/design-addon/register.js
 import React from 'react';
 import { AddonPanel } from '@storybook/components';
 import { addons, types } from '@storybook/addons';
 
-addons.register('my/design-assets', () => {
-  addons.add('design-assets/panel', {
+addons.register('my/design-addon', () => {
+  addons.add('design-addon/panel', {
     title: 'assets',
     type: types.PANEL,
     render: ({ active, key }) => (
@@ -76,12 +77,13 @@ Este é o código inicial para se começar com qualquer extra. Analisando o que 
 Se iniciarmos o Storybook agora, não será ainda possível ver o nosso extra. Este tem que ser registado no ficheiro (ou arquivo) `.storybook/main.js`, tal como foi feito anteriormente com o extra Knobs. Com isto em mente, adicione o seguinte a lista de addons:
 
 ```js
+
 // .storybook/main.js
 module.exports = {
   stories: ['../src/components/**/*.stories.js'],
   addons: [
     // same as before
-    './.storybook/addons/register.js', // our addon
+    "./.storybook/design-addon/register.js", // our addon
   ],
 };
 ```
@@ -101,7 +103,8 @@ Para este objetivo, precisamos de efetuar umas pequenas alterações aos imports
 Faça a seguinte alteração no seu ficheiro (ou arquivo):
 
 ```javascript
-//.storybook/addons/register.js
+
+//.storybook/design-addon/register.js
 import React, { Fragment } from 'react';
 /* same as before */
 import { useParameter } from '@storybook/api';
@@ -127,7 +130,7 @@ Acabámos de criar o componente, modificámos os imports, somente o que falta é
 O seu código deverá ser semelhante a isto:
 
 ```javascript
-//.storybook/addons/register.js
+//.storybook/design-addon/register.js
 import React, { Fragment } from 'react';
 import { AddonPanel } from '@storybook/components';
 import { useParameter } from '@storybook/api';
@@ -148,8 +151,8 @@ const Content = () => {
   );
 };
 
-addons.register('my/design-assets', () => {
-  addons.add('design-assets/panel', {
+addons.register('my/design-addon', () => {
+  addons.add('design-addon/panel', {
     title: 'assets',
     type: types.PANEL,
     render: ({ active, key }) => (
@@ -170,6 +173,7 @@ Temos as peças todas ligadas. Mas como podemos verificar que está tudo a funci
 Para isto, vamos fazer uma ligeira alteração ao ficheiro (ou arquivo) `Task.stories.js` e adicionar a opção [parameters](https://storybook.js.org/docs/configurations/options-parameter/#per-story-options).
 
 ```javascript
+
 // src/components/Task.stories.js
 export default {
   component: Task,
@@ -197,7 +201,8 @@ Reinicie o seu Storybook e escolha a estória associada à Task e deverá ver al
 Podemos ver que o extra está a funcionar corretamente, mas vamos fazer uma ligeira alteração ao componente `Content` para que este mostre o pretendido:
 
 ```javascript
-//.storybook/addons/register.js
+
+//.storybook/design-addon/register.js
 import React, { Fragment } from 'react';
 import { AddonPanel } from '@storybook/components';
 import { useParameter, useStorybookState } from '@storybook/api';
@@ -256,7 +261,7 @@ Se olhar com atenção, irá reparar que está a ser usada a tag `styled`, esta 
 
 ### Apresentar os itens
 
-Para que possamos ver os nossos itens através do nosso extra, temos que copiá-los para a pasta `public` e ajustar a opção `parameter` de acordo.
+Para que possamos ver os nossos itens no nosso extra, temos que copiá-los para a pasta `public` e ajustar a opção `parameters` da nossa estória de acordo.
 
 O storybook irá detetar a alteração e irá carregar os itens, mas por agora somente o primeiro item.
 
@@ -277,7 +282,8 @@ Para este objetivo, vamos precisar de uma forma qualquer de guardar o estado do 
 Com isto vamos ajustar os imports que estão a ser usados para se adequarem às nossas necessidades:
 
 ```javascript
-//.storybook/addons/register.js
+
+//.storybook/design-addon/register.js
 import { useParameter, useStorybookState, useAddonState } from '@storybook/api';
 import { AddonPanel, ActionBar } from '@storybook/components';
 /* same as before */
@@ -286,12 +292,13 @@ import { AddonPanel, ActionBar } from '@storybook/components';
 E modificar o componente `Content`, para que possamos movimentar-nos entre itens:
 
 ```javascript
-//.storybook/addons/register.js
-export const Content = () => {
+
+//.storybook/design-addon/register.js
+const Content = () => {
   // story's parameter being retrieved here
   const results = useParameter('assets', []);
   // addon state being persisted here
-  const [selected, setSelected] = useAddonState('my/design-assets', 0);
+  const [selected, setSelected] = useAddonState('my/design-addon', 0);
   // the id of the story retrieved from Storybook global state
   const { storyId } = useStorybookState();
 
@@ -329,7 +336,8 @@ Atingimos tudo o que nos propusemos a fazer. Ou seja criar um extra do Storybook
   <summary>Clique aqui para expandir e ver o código completo usado neste exemplo</summary>
 
 ```javascript
-// .storybook/addons/register.js
+
+//.storybook/design-addon/register.js
 import React, { Fragment } from 'react';
 
 import { useParameter, useStorybookState, useAddonState } from '@storybook/api';
@@ -366,7 +374,7 @@ const Asset = ({ url }) => {
 
 const Content = () => {
   const results = useParameter('assets', []); // story's parameter being retrieved here
-  const [selected, setSelected] = useAddonState('my/design-assets', 0); // addon state being persisted here
+  const [selected, setSelected] = useAddonState('my/design-addon', 0); // addon state being persisted here
   const { storyId } = useStorybookState(); // the story«s unique identifier being retrieved from Storybook global state
 
   if (results.length === 0) {
@@ -395,8 +403,8 @@ const Content = () => {
   );
 };
 
-addons.register('my/design-assets', () => {
-  addons.add('design-assets/panel', {
+addons.register('my/design-addon', () => {
+  addons.add('design-addon/panel', {
     title: 'assets',
     type: types.PANEL,
     render: ({ active, key }) => (

--- a/content/intro-to-storybook/react/pt/creating-addons.md
+++ b/content/intro-to-storybook/react/pt/creating-addons.md
@@ -1,0 +1,447 @@
+---
+title: 'Criação de extras'
+tocTitle: 'Criação de extras'
+description: 'Aprende a criar os teus próprios extras que irão impulsionar o teu desenvolvimento'
+---
+
+No capítulo anterior foi apresentada uma das funcionalidades chave do Storybook, o seu sistema robusto de [extras](https://storybook.js.org/addons/introduction/), que pode ser usado para melhorar não somente a tua experiência de desenvolvimento e fluxos de trabalho, mas também para a tua equipa.
+
+Neste capítulo vamos ver como podemos criar o nosso próprio extra. Pode pensar que implementá-lo pode ser uma tarefa extremamente difícil, mas muito pelo contrário. Somente é necessário seguir alguns pequenos passos e podemos começar a sua implementação.
+
+Mas antes de tudo, vamos primeiro definir o que irá fazer.
+
+## O que vamos criar
+
+Neste exemplo, vamos assumir que a nossa equipa tem alguns items de design que estão de alguma forma ligados aos nossos componentes de IU. Olhando para o presente estado do IU do Storybook esta relação não é aparente. Como podemos resolver isto?
+
+Temos o nosso objetivo, vamos agora definir quais as funcionalidades que o nosso extra irá suportar:
+
+- Apresentar os items de design num painel
+- Suporte de não somente imagens, mas também urls que podem ser embebidos
+- Deverá suportar vários items, para o caso de existirem múltiplas versões ou temas.
+
+A forma que vamos usar para adicionar a lista de items às estórias é através de uma opção do Storybook, chamada [parâmetros](https://storybook.js.org/docs/configurations/options-parameter/#per-story-options), esta opção permite injetar informação customizada às nossas estórias. São usados de forma semelhante aos decoradores que vimos anteriormente.
+
+```javascript
+export default {
+  title: 'Your component',
+  decorators: [
+    /*...*/
+  ],
+  parameters: {
+    assets: ['path/to/your/asset.png'],
+  },
+  //
+};
+```
+
+## Configuração
+
+Já delineamos o que o nosso extra irá fazer, está na altura de começar a implementação.
+
+No interior da pasta (ou diretório) `.storybook`, crie uma nova e dentro desta um ficheiro (ou arquivo) chamado `register.js`.
+
+E já está! Fácil não é?
+
+<div class="aside">Vamos usar a pasta (ou diretório)<code>.storybook</code> como base para o nosso extra. A razão por detrás disto, é para manter a implementação simples e evitar muita complicação. Caso este exemplo fosse transformado num extra verdadeiro, a abordagem correta seria mover a implementação para um pacote com a sua própria estrutura de ficheiros (ou arquivos) e pastas (ou diretórios).</div>
+
+## Implementar o extra
+
+Adicione o conteúdo abaixo ao ficheiro (ou arquivo) que acabámos de criar:
+
+```javascript
+//.storybook/addons/register.js
+import React from 'react';
+import { AddonPanel } from '@storybook/components';
+import { addons, types } from '@storybook/addons';
+
+addons.register('my/design-assets', () => {
+  addons.add('design-assets/panel', {
+    title: 'assets',
+    type: types.PANEL,
+    render: ({ active, key }) => (
+      <AddonPanel active={active} key={key}>
+        implement
+      </AddonPanel>
+    ),
+  });
+});
+```
+
+Este é o código inicial para se começar com qualquer extra. Analisando o que o código está a fazer um pouco mais em detalhe:
+
+- Estamos a registar um novo extra no nosso Storybook.
+- Adicionamos um novo elemento de IU para o nosso extra com algumas opções (um título que irá definir o nosso extra e o tipo de elemento usado) e renderizamos um bloco de texto por enquanto.
+
+Se iniciarmos o Storybook agora, não será ainda possível ver o nosso extra. Este tem que ser registado no ficheiro (ou arquivo) `.storybook/main.js`, tal como foi feito anteriormente com o extra Knobs. Com isto em mente, adicione o seguinte a lista de addons:
+
+```js
+// .storybook/main.js
+module.exports = {
+  stories: ['../src/components/**/*.stories.js'],
+  addons: [
+    // same as before
+    './.storybook/addons/register.js', // our addon
+  ],
+};
+```
+
+![Extra design assets a ser executado no Storybook](/intro-to-storybook/create-addon-design-assets-added.png)
+
+Sucesso! Temos o nosso extra adicionado ao IU do Storybook.
+
+<div class="aside">Storybook permite que adicione não só painéis, mas também uma vasta gama de componentes de IU. E quase todos encontram-se disponíveis no interior do pacote @storybook/components, para que não se perca muito tempo a implementar o IU e focar-se na implementação de funcionalidades.</div>
+
+### Criar o componente de conteúdo
+
+Atingimos o primeiro objetivo. É agora tempo de começar a trabalhar no objetivo seguinte.
+
+Para este objetivo, precisamos de efetuar umas pequenas alterações aos imports e introduzir um novo componente que irá mostrar a informação acerca do item.
+
+Faça a seguinte alteração no seu ficheiro (ou arquivo):
+
+```javascript
+//.storybook/addons/register.js
+import React, { Fragment } from 'react';
+/* same as before */
+import { useParameter } from '@storybook/api';
+
+const Content = () => {
+  const results = useParameter('assets', []); // story's parameter being retrieved here
+  return (
+    <Fragment>
+      {results.length ? (
+        <ol>
+          {results.map(i => (
+            <li>{i}</li>
+          ))}
+        </ol>
+      ) : null}
+    </Fragment>
+  );
+};
+```
+
+Acabámos de criar o componente, modificámos os imports, somente o que falta é ligar o componente ao nosso painel e temos um extra completamente funcional capaz de apresentar a informação que está contida na estória.
+
+O seu código deverá ser semelhante a isto:
+
+```javascript
+//.storybook/addons/register.js
+import React, { Fragment } from 'react';
+import { AddonPanel } from '@storybook/components';
+import { useParameter } from '@storybook/api';
+import { addons, types } from '@storybook/addons';
+
+const Content = () => {
+  const results = useParameter('assets', []); // story's parameter being retrieved here
+  return (
+    <Fragment>
+      {results.length ? (
+        <ol>
+          {results.map(i => (
+            <li>{i}</li>
+          ))}
+        </ol>
+      ) : null}
+    </Fragment>
+  );
+};
+
+addons.register('my/design-assets', () => {
+  addons.add('design-assets/panel', {
+    title: 'assets',
+    type: types.PANEL,
+    render: ({ active, key }) => (
+      <AddonPanel active={active} key={key}>
+        <Content />
+      </AddonPanel>
+    ),
+  });
+});
+```
+
+Repare que estamos a usar [useParameter](https://storybook.js.org/docs/addons/api/#useparameter), este hook bastante útil permite que possamos ler o conteúdo fornecido pela opção `parameters` de cada uma das estórias, o que no nosso caso será uma lista de localizações ou somente uma. Mas não se preocupe com isso agora, em breve vamos ver isto a funcionar.
+
+### Usar uma estória com o nosso extra
+
+Temos as peças todas ligadas. Mas como podemos verificar que está tudo a funcionar e conseguimos ver alguma coisa?
+
+Para isto, vamos fazer uma ligeira alteração ao ficheiro (ou arquivo) `Task.stories.js` e adicionar a opção [parameters](https://storybook.js.org/docs/configurations/options-parameter/#per-story-options).
+
+```javascript
+// src/components/Task.stories.js
+export default {
+  component: Task,
+  title: 'Task',
+  decorators: [withKnobs],
+  parameters: {
+    assets: [
+      'path/to/your/asset.png',
+      'path/to/another/asset.png',
+      'path/to/yet/another/asset.png',
+    ],
+  },
+  // Our exports that end in "Data" are not stories.
+  excludeStories: /.*Data$/,
+};
+/* same as before  */
+```
+
+Reinicie o seu Storybook e escolha a estória associada à Task e deverá ver algo semelhante a isto:
+
+![storybook story showing contents with design assets addon](/intro-to-storybook/create-addon-design-assets-inside-story.png)
+
+### Apresentar o conteúdo no nosso extra
+
+Podemos ver que o extra está a funcionar corretamente, mas vamos fazer uma ligeira alteração ao componente `Content` para que este mostre o pretendido:
+
+```javascript
+//.storybook/addons/register.js
+import React, { Fragment } from 'react';
+import { AddonPanel } from '@storybook/components';
+import { useParameter, useStorybookState } from '@storybook/api';
+import { addons, types } from '@storybook/addons';
+import { styled } from '@storybook/theming';
+
+const getUrl = input => {
+  return typeof input === 'string' ? input : input.url;
+};
+
+const Iframe = styled.iframe({
+  width: '100%',
+  height: '100%',
+  border: '0 none',
+});
+const Img = styled.img({
+  width: '100%',
+  height: '100%',
+  border: '0 none',
+  objectFit: 'contain',
+});
+
+const Asset = ({ url }) => {
+  if (!url) {
+    return null;
+  }
+  if (url.match(/\.(png|gif|jpeg|tiff|svg|anpg|webp)/)) {
+    // do image viewer
+    return <Img alt="" src={url} />;
+  }
+
+  return <Iframe title={url} src={url} />;
+};
+
+const Content = () => {
+  // story's parameter being retrieved here
+  const results = useParameter('assets', []);
+  // the id of story retrieved from Storybook global state
+  const { storyId } = useStorybookState();
+
+  if (results.length === 0) {
+    return null;
+  }
+
+  const url = getUrl(results[0]).replace('{id}', storyId);
+
+  return (
+    <Fragment>
+      <Asset url={url} />
+    </Fragment>
+  );
+};
+```
+
+Se olhar com atenção, irá reparar que está a ser usada a tag `styled`, esta tag vem do pacote `@storybook/theming`. Com esta, podemos costumizar não somente o tema usado pelo Storybook, mas também o IU de acordo com as nossas necessidades. E ainda o [useStorybookState](https://storybook.js.org/docs/addons/api/#usestorybookstate), um hook deveras útil, que permite que possamos aceder ao estado interno do Storybook e obter toda a informação disponível. No nosso caso vamos usá-lo somente para obter o identificador de cada estória que foi criada.
+
+### Apresentar os itens
+
+Para que possamos ver os nossos itens através do nosso extra, temos que copiá-los para a pasta `public` e ajustar a opção `parameter` de acordo.
+
+O storybook irá detetar a alteração e irá carregar os itens, mas por agora somente o primeiro item.
+
+![Items a serem carregados](/intro-to-storybook/design-assets-image-loaded.png)
+
+## Extras com estado
+
+Olhando uma vez mais para os nossos objetivos:
+
+- ✔️ Apresentar os items de design num painel
+- ✔️ Suporte de não somente imagens, mas também urls que podem ser embebidos
+- ❌ Deverá suportar vários items, para o caso de existirem múltiplas versões ou temas.
+
+Estamos quase lá, falta somente um objetivo.
+
+Para este objetivo, vamos precisar de uma forma qualquer de guardar o estado do componente, isto podia ser feito com o hook `useState` do React, ou se estivéssemos a usar classes com `this.setState()`. Mas para evitar implementar lógica adicional ao componente vamos antes usar o `useAddonState` do Storybook, esta funcionalidade ajuda-nos não só a evitar ter de criar lógica adicional, mas também garante uma forma de persistir o estado do nosso extra. Além desta funcionalidade, vamos usar um outro elemento de IU do Storybook, o `ActionBar`, que permite selecionar elementos.
+
+Com isto vamos ajustar os imports que estão a ser usados para se adequarem às nossas necessidades:
+
+```javascript
+//.storybook/addons/register.js
+import { useParameter, useStorybookState, useAddonState } from '@storybook/api';
+import { AddonPanel, ActionBar } from '@storybook/components';
+/* same as before */
+```
+
+E modificar o componente `Content`, para que possamos movimentar-nos entre itens:
+
+```javascript
+//.storybook/addons/register.js
+export const Content = () => {
+  // story's parameter being retrieved here
+  const results = useParameter('assets', []);
+  // addon state being persisted here
+  const [selected, setSelected] = useAddonState('my/design-assets', 0);
+  // the id of the story retrieved from Storybook global state
+  const { storyId } = useStorybookState();
+
+  if (results.length === 0) {
+    return null;
+  }
+
+  if (results.length && !results[selected]) {
+    setSelected(0);
+    return null;
+  }
+
+  const url = getUrl(results[selected]).replace('{id}', storyId);
+  return (
+    <Fragment>
+      <Asset url={url} />
+      {results.length > 1 ? (
+        <ActionBar
+          actionItems={results.map((i, index) => ({
+            title: typeof i === 'string' ? `asset #${index + 1}` : i.name,
+            onClick: () => setSelected(index),
+          }))}
+        />
+      ) : null}
+    </Fragment>
+  );
+};
+```
+
+## Extra construído
+
+Atingimos tudo o que nos propusemos a fazer. Ou seja criar um extra do Storybook, completamente funcional que irá apresentar itens de design associados aos componentes de IU.
+
+<details>
+  <summary>Clique aqui para expandir e ver o código completo usado neste exemplo</summary>
+
+```javascript
+// .storybook/addons/register.js
+import React, { Fragment } from 'react';
+
+import { useParameter, useStorybookState, useAddonState } from '@storybook/api';
+import { addons, types } from '@storybook/addons';
+import { AddonPanel, ActionBar } from '@storybook/components';
+import { styled } from '@storybook/theming';
+
+const getUrl = input => {
+  return typeof input === 'string' ? input : input.url;
+};
+
+const Iframe = styled.iframe({
+  width: '100%',
+  height: '100%',
+  border: '0 none',
+});
+const Img = styled.img({
+  width: '100%',
+  height: '100%',
+  border: '0 none',
+  objectFit: 'contain',
+});
+
+const Asset = ({ url }) => {
+  if (!url) {
+    return null;
+  }
+  if (url.match(/\.(png|gif|jpeg|tiff|svg|anpg|webp)/)) {
+    return <Img alt="" src={url} />;
+  }
+
+  return <Iframe title={url} src={url} />;
+};
+
+const Content = () => {
+  const results = useParameter('assets', []); // story's parameter being retrieved here
+  const [selected, setSelected] = useAddonState('my/design-assets', 0); // addon state being persisted here
+  const { storyId } = useStorybookState(); // the story«s unique identifier being retrieved from Storybook global state
+
+  if (results.length === 0) {
+    return null;
+  }
+
+  if (results.length && !results[selected]) {
+    setSelected(0);
+    return null;
+  }
+
+  const url = getUrl(results[selected]).replace('{id}', storyId);
+
+  return (
+    <Fragment>
+      <Asset url={url} />
+      {results.length > 1 ? (
+        <ActionBar
+          actionItems={results.map((i, index) => ({
+            title: typeof i === 'string' ? `asset #${index + 1}` : i.name,
+            onClick: () => setSelected(index),
+          }))}
+        />
+      ) : null}
+    </Fragment>
+  );
+};
+
+addons.register('my/design-assets', () => {
+  addons.add('design-assets/panel', {
+    title: 'assets',
+    type: types.PANEL,
+    render: ({ active, key }) => (
+      <AddonPanel active={active} key={key}>
+        <Content />
+      </AddonPanel>
+    ),
+  });
+});
+```
+
+</details>
+
+## Próximos passos
+
+O passo lógico seguinte para o seu extra, será transformá-lo no seu próprio pacote e permitir que seja distribuído e consumido pela sua equipa e possivelmente com o resto da comunidade.
+
+Mas este vai além do pretendido com este tutorial. Este exemplo somente demonstra como pode usar a API do Storybook para criar o seu próprio extra de forma a otimizar o seu fluxo de desenvolvimento.
+
+Aprenda a costumizar ainda mais o seu extra:
+
+- [adicionar botões na barra de tarefas do Storybook](https://github.com/storybookjs/storybook/blob/next/addons/viewport/src/register.tsx#L8-L15)
+- [comunicação através de um canal com a iframe](https://github.com/storybookjs/storybook/blob/next/dev-kits/addon-roundtrip/README.md)
+- [envio de comandos e resultados](https://github.com/storybookjs/storybook/tree/next/addons/events)
+- [efetuar análise ao html/css obtido do componente](https://github.com/storybookjs/storybook/tree/next/addons/a11y)
+- [envolver componentes e renderizar de novo com outros dados](https://github.com/storybookjs/storybook/tree/next/addons/knobs)
+- [disparar eventos na DOM e alterar a DOM](https://github.com/storybookjs/storybook/tree/next/addons/events)
+- [efetuar testes](https://github.com/storybookjs/storybook/tree/next/addons/jest)
+
+E muito mais!
+
+<div class="aside">Caso crie um novo extra e esteja interessado em apresentá-lo á comunidade, esteja á vontade para abrir um PR no repositório do Storybook. </div>
+
+### Kits de desenvolvimento
+
+De forma a ajudá-lo com o desenvolvimento de extras, a equipa do Storybook criou um conjunto de kits de desenvolvimento.
+
+Estes pacotes são nada mais nada menos que kits de principiante para ajudá-lo a começar a implementar os seus próprios extras.
+
+O extra que acabámos de criar é baseado num destes, mais especificamente o kit `addon-parameters`.
+
+Não só este mas outros estão disponíveis aqui: https://github.com/storybookjs/storybook/tree/next/dev-kits
+
+Futuramente mais e mais kits de desenvolvimento irão estar disponíveis.
+
+## Partilha de extras com a equipa
+
+Os extras são adições ao fluxo de trabalho que poupam imenso tempo, mas não esquecer que para outros elementos da equipa não técnicos, tais como revisores, para estes tirarem proveito de todas estas funcionalidades pode ser algo difícil. Não podemos garantir que as pessoas vão executar o seu Storybook localmente. É por isto que uma implementação do Storybook online e de fácil acesso pode ser algo deveras útil. No próximo capítulo, vamos fazer isso mesmo!

--- a/content/intro-to-storybook/react/pt/data.md
+++ b/content/intro-to-storybook/react/pt/data.md
@@ -1,7 +1,7 @@
 ---
 title: 'Ligação de dados'
 tocTitle: 'Dados'
-description: 'Aprendizagem da metodologia de ligação de dados ao componente interface utilizador'
+description: 'Aprenda a efetuar a ligação de dados ao seu componente de interface de utilizador'
 commit: 9c50472
 ---
 
@@ -17,7 +17,7 @@ Para conter dados, irá ser necessário um "contentor".
 Este exemplo utiliza [Redux](https://redux.js.org/), que é a biblioteca mais popular quando se pretende guardar dados, ou construir um modelo de dados para a aplicação.
 No entanto o padrão a ser usado aqui, pode ser aplicado a outras bibliotecas de gestão de dados tal como [Apollo](https://www.apollographql.com/client/) e [MobX](https://mobx.js.org/).
 
-Adiciona-se uma nova dependência ao `package.json` com:
+Adicione as dependências necessárias ao projeto através de:
 
 ```bash
 yarn add react-redux redux
@@ -26,6 +26,8 @@ yarn add react-redux redux
 Irá ser construída (intencionalmente definida de forma simples) uma loja Redux, que responde ao desencadear de ações que alteram o estado das tarefas. Isto no ficheiro `lib/redux.js`, contido dentro de `src`
 
 ```javascript
+// src/lib/redux.js
+
 // A simple redux store/actions/reducer implementation.
 // A true app would be more complex and separated into different files.
 import { createStore } from 'redux';
@@ -77,9 +79,11 @@ const defaultTasks = [
 export default createStore(reducer, { tasks: defaultTasks });
 ```
 
-Em seguida o componente `TaskList` vai ser atualizado de forma que possa conectar á loja Redux e renderizar as tarefas que pretendemos:
+Em seguida o componente `Tasklist` irá ser alterado, para receber dados oriundos da loja e apresentar as tarefas que pretendemos:
 
 ```javascript
+// src/components/TaskList.js
+
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -118,32 +122,41 @@ Nesta altura os testes com Storybook terão deixado de funcionar, visto que `Tas
 No entanto este problema pode ser resolvido com relativa facilidade, ao renderizar-se o componente de apresentação `PureTaskList` nas estórias do Storybook:
 
 ```javascript
+// src/components/TaskList.stories.js
+
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { PureTaskList } from './TaskList';
-import { task, actions } from './Task.stories';
+import { taskData, actionsData } from './Task.stories';
 
-export const defaultTasks = [
-  { ...task, id: '1', title: 'Task 1' },
-  { ...task, id: '2', title: 'Task 2' },
-  { ...task, id: '3', title: 'Task 3' },
-  { ...task, id: '4', title: 'Task 4' },
-  { ...task, id: '5', title: 'Task 5' },
-  { ...task, id: '6', title: 'Task 6' },
+export default {
+  component: PureTaskList,
+  title: 'TaskList',
+  decorators: [story => <div style={{ padding: '3rem' }}>{story()}</div>],
+  excludeStories: /.*Data$/,
+};
+
+export const defaultTasksData = [
+  { ...taskData, id: '1', title: 'Task 1' },
+  { ...taskData, id: '2', title: 'Task 2' },
+  { ...taskData, id: '3', title: 'Task 3' },
+  { ...taskData, id: '4', title: 'Task 4' },
+  { ...taskData, id: '5', title: 'Task 5' },
+  { ...taskData, id: '6', title: 'Task 6' },
 ];
 
-export const withPinnedTasks = [
-  ...defaultTasks.slice(0, 5),
+export const withPinnedTasksData = [
+  ...defaultTasksData.slice(0, 5),
   { id: '6', title: 'Task 6 (pinned)', state: 'TASK_PINNED' },
 ];
 
-storiesOf('TaskList', module)
-  .addDecorator(story => <div style={{ padding: '3rem' }}>{story()}</div>)
-  .add('default', () => <PureTaskList tasks={defaultTasks} {...actions} />)
-  .add('withPinnedTasks', () => <PureTaskList tasks={withPinnedTasks} {...actions} />)
-  .add('loading', () => <PureTaskList loading tasks={[]} {...actions} />)
-  .add('empty', () => <PureTaskList tasks={[]} {...actions} />);
+export const Default = () => <PureTaskList tasks={defaultTasksData} {...actionsData} />;
+
+export const WithPinnedTasks = () => <PureTaskList tasks={withPinnedTasksData} {...actionsData} />;
+
+export const Loading = () => <PureTaskList loading tasks={[]} {...actionsData} />;
+
+export const Empty = () => <PureTaskList tasks={[]} {...actionsData} />;
 ```
 
 <video autoPlay muted playsInline loop>
@@ -153,23 +166,6 @@ storiesOf('TaskList', module)
   />
 </video>
 
-Similarmente, será usado o `PureTaskList` nos testes com Jest:
-
-```js
-import React from 'react';
-import ReactDOM from 'react-dom';
-import { PureTaskList } from './TaskList';
-import { withPinnedTasks } from './TaskList.stories';
-
-it('renders pinned tasks at the start of the list', () => {
-  const div = document.createElement('div');
-  const events = { onPinTask: jest.fn(), onArchiveTask: jest.fn() };
-  ReactDOM.render(<PureTaskList tasks={withPinnedTasks} {...events} />, div);
-
-  // We expect the task titled "Task 6 (pinned)" to be rendered first, not at the end
-  const lastTaskInput = div.querySelector('.list-item:nth-child(1) input[value="Task 6 (pinned)"]');
-  expect(lastTaskInput).not.toBe(null);
-
-  ReactDOM.unmountComponentAtNode(div);
-});
-```
+<div class="aside">
+Se os testes snapshot falharem, deverá ter que atualizar os snapshots existentes, executando o comando de testes de novo com a flag -u. Como a nossa aplicação está a crescer exponencialmente, poderá ser agora um bom momento para executar os testes com a opção <code> --watchAll</code> tal como mencionado na <a href="/react/pt/get-started">introdução</a>
+</div>

--- a/content/intro-to-storybook/react/pt/deploy.md
+++ b/content/intro-to-storybook/react/pt/deploy.md
@@ -1,45 +1,40 @@
 ---
 title: 'Implementar Storybook'
 tocTitle: 'Implementação'
-descrição: 'Implemntação online do Storybook com GitHub e Netlify'
+descrição: 'Implementação online do Storybook com GitHub e Netlify'
 ---
 
 Neste tutorial o Storybook foi executado na máquina local. Poderá ser necessária a partilha com o resto da equipa, em particular com membros considerados não técnicos. Felizmente, é bastante fácil implementar o Storybook online.
 
 <div class="aside">
-    <strong>Foram seguidos os passos para implementar os teste com Chromatic, tal como mencionado anteriormente?</strong>
+    <strong>Seguiu os passos para implementar testes com Chromatic, tal como mencionado anteriormente?</strong>
     <br/>
     Então as estórias já se encontram implementadas!🎉 O Chromatic indexa-as e segue-as ao longo das ramificações feitas e dos commits
     Pode saltar-se este capítulo e seguir para <a href="/react/pt/conclusion">conclusão</a>.
 </div>
 
+
 ## Exportação sob a forma de uma app estática
 
-Para implementar o Storybook será necessário ser exportado como uma aplicação estática para a web. Esta funcionalidade já está implementada, somente será necessária a sua ativação através da adição de um script ao ficheiro `package.json`.
+Para implementar o Storybook será necessário ser exportado como uma aplicação estática para a web.  Esta funcionalidade já está implementada e configurada, como tal não precisamos preocupar-nos com qualquer tipo de configuração.
 
-```javascript
-{
-  "scripts": {
-    "build-storybook": "build-storybook -c .storybook"
-  }
-}
-```
-
-E pode agora construir-se o Storybook via `npm run build-storybook`, o que irá popular a pasta `storybook-static` com esta versão.
+Quando executar o Storybook através de `yarn build-storybook`, irá gerar a pasta `storybook-static` com o conteúdo estático do seu Storybook.
 
 ## Implementação contínua
 
-Pretende-se que seja partilhada ultima versão dos componentes á medida que o código é produzido. Para tal é necessário que o Storybook também o seja. Dependendo do GitHub e Netlify para implementar o site estático. Será usado o plano gratuito.
+Pretende-se que seja partilhada a última versão dos componentes á medida que o código é produzido. Para tal é necessário que o Storybook também o seja. Vamos depender do GitHub e do Netlify (com o plano gratuito) para implementar o site estático.
 
 ### GitHub
 
-Primeiro, será necessário configurar o Git localmente. Se este tutorial estiver a ser seguido, poderá saltar-se para a configuração de um repositório no GitHub.
+Se estiver a seguir o tutorial a partir da secção anterior de testes pode saltar para a configuração do repositório no GitHub.
+
+Quando o projeto foi inicializado pelo Create React App, foi criado um repositório local. Nesta altura é seguro adicionar os ficheiros ao primeiro commit.
 
 ```bash
 $ git init
 ```
 
-Adicionam-se os ficheiros ao primeiro commit.
+Agora pode ser feito o commit dos ficheiros.
 
 ```bash
 $ git add .
@@ -48,14 +43,15 @@ $ git add .
 Agora pode ser feito o commit dos ficheiros.
 
 ```bash
-$ git commit -m &quot;taskbox UI&quot;
+$ git commit -m "taskbox UI";
 ```
+### Criar um repositório no GitHub
 
-Navegue até ao GitHub e configure [aqui](https://github.com/new) um repositório. E vai ser atribuído o nome “taskbox”.
+Navegue até ao GitHub e configure [aqui](https://github.com/new) um repositório. Como nome use “taskbox”.
 
 ![Configuração GitHub](/intro-to-storybook/github-create-taskbox.png)
 
-No novo repositório de código, copia-se o URL original deste, e adicionado ao projeto com o seguinte comando:
+No novo repositório de código, copie o URL de origem, e adicione-o ao projeto com o seguinte comando:
 
 ```bash
 $ git remote add origin https://github.com/<your username>/taskbox.git
@@ -79,13 +75,13 @@ Se for usado um IC (CI na forma nativa) na empresa, é necessário adicionar um 
 
 ![Criação Site Netlify](/intro-to-storybook/netlify-create-site.png)
 
-Em seguida click no botão GitHub para ser feita a ligação do Netlify ao GitHub. O que permite o acesso ao repositorio remoto Taskbox.
+Em seguida click no botão GitHub para ser feita a ligação do Netlify ao GitHub. O que permite o acesso ao repositório remoto Taskbox.
 
 Seguida da seleção do repositório da lista de opções.
 
 ![Conexão Netlify para o repositorio](/intro-to-storybook/netlify-account-picker.png)
 
-É feita a configuração no Netlify ao selecionar-se o comando apropriado para executar no IC(CI na forma nativa) e qual a pasta de output. Como ramo, seleciona-se `master`. Pasta `.storybook-static`. Comando `yarn build-storybook`.
+É feita a configuração no Netlify ao selecionar-se o comando apropriado para executar no IC (CI na forma nativa) e qual a pasta de output. Como ramo, seleciona-se `master`. Pasta `storybook-static`. Comando `yarn build-storybook`.
 
 ![Configurações Netlify](/intro-to-storybook/netlify-settings.png)
 

--- a/content/intro-to-storybook/react/pt/get-started.md
+++ b/content/intro-to-storybook/react/pt/get-started.md
@@ -1,35 +1,39 @@
 ---
-title: 'Storybook para o React tutorial'
+title: 'Tutorial do Storybook para o React'
 tocTitle: 'Introdução'
-description: 'Configuração do React Storybook no ambiente de desenvolvimento'
+description: 'Configuração do React Storybook no ambiente de desenvolvimento React'
 commit: ebe2ae2
 ---
 
-Storybook funciona em paralelo á aplicação em modo de desenvolvimento.
-Ajuda na construção de componentes de interface de utilizador isolados de qualquer lógica e contexto da aplicação.
+O Storybook executa paralelamente à aplicação em desenvolvimento.
+Ajuda-o a construir componentes de interface de utilizador (UI na forma original) isolados da lógica de negócio e contexto da aplicação.
 Esta edição de Aprendizagem de Storybook é destinada para React.
 Encontram-se disponíveis outras edições quer para [Vue](/vue/pt/get-started), quer para [Angular](/angular/pt/get-started).
 
 ![Storybook e a aplicação](/intro-to-storybook/storybook-relationship.jpg)
 
-## Configuração de Storybook com React
+## Configurar o Storybook com React
 
-Irão ser necessárias algumas etapas adicionais de forma a ser possível configurar o processo de compilação no nosso ambiente de desenvolvimento.
-Para começar queremos usar o pacote [Create React App](https://github.com/facebook/create-react-app) ou como é vulgarmente conhecido (CRA), para configurar o nosso ambiente local e ativar o modo de testes com [Storybook](https://storybook.js.org/) e
-[Jest](https://facebook.github.io/jest/) na nossa aplicação.
-
-Para tal vamos executar os seguintes comandos:
+Precisamos de alguns passos extra para configurar o processo de compilação no nosso ambiente de desenvolvimento.
+Para começar queremos usar o pacote [Create React App](https://github.com/facebook/create-react-app) ou como é vulgarmente conhecido (CRA), para compilação e permitir ao [Storybook](https://storybook.js.org/) e
+[Jest](https://facebook.github.io/jest/) fazerem testes na nossa aplicação. Vamos executar os seguintes comandos:
 
 ```bash
 # Create our application:
 npx create-react-app taskbox
+
 cd taskbox
 
 # Add Storybook:
 npx -p @storybook/cli sb init
 ```
 
-Podemos rapidamente verificar que os vários ecossistemas da nossa aplicação estão a funcionar corretamente através de:
+<div class="aside">
+Ao longo desta versão do tutorial, vai ser usado o <code>yarn</code> para executar a maioria dos comandos.
+Se tiver o Yarn instalado, mas preferir usar <code>npm</code>, não há qualquer problema, pode continuar a seguir o tutorial sem problemas. Somente terá que adicionar a seguinte opção: <code> --use-npm</code> ao primeiro comando mencionado acima e tanto o CRA como o Storybook irão inicializar com base nesta opção. À medida que progride no tutorial, não esqueça de ajustar os comandos mencionados para os equivalentes <code>npm</code>.
+</div>
+
+Podemos rapidamente verificar que os vários ecossistemas da nossa aplicação estão a funcionar corretamente:
 
 ```bash
 # Run the test runner (Jest) in a terminal:
@@ -43,24 +47,21 @@ yarn start
 ```
 
 <div class="aside">
-  Nota: Se <code>yarn test</code> emitir um erro, será necessário instalar o pacote <code>watchman</code>, tal como recomendado neste <a href="https://github.com/facebook/create-react-app/issues/871#issuecomment-252297884">problema</a>
+Pode ter reparado que foi adicionada a opção <code>--watchAll</code> no comando de testes, não se preocupe, é intencional. Esta pequena alteração irá garantir que todos os testes sejam executados e que a nossa aplicação está a funcionar corretamente. À medida que progride no tutorial, irão ser apresentados diversos cenários de testes, talvez queira considerar e adicionar esta opção ao script de testes no ficheiro (ou arquivo) <code>package.json</code> para garantir que todos os testes sejam executados.
 </div>
 
-Sendo estes os seguintes: testes automáticos (Jest), desenvolvimento de componentes (Storybook) e a aplicação em si.
+
+As três modalidades de frontend da aplicação: testes automáticos (Jest), desenvolvimento de componentes (Storybook) e a aplicação em si.
 
 ![3 modalidades](/intro-to-storybook/app-three-modalities.png)
 
-Dependendo de qual parte da aplicação que estamos a trabalhar, podemos querer executar um ou mais simultâneamente.
-Visto que neste caso, o foco é a criação de um componente de interface de utilizador simples, iremos cingir-nos somente á execução de Storybook.
+Dependendo de qual parte da aplicação em que está a trabalhar, pode querer executar uma ou mais simultaneamente.
+Mas, visto que o nosso foco é a criação de um único componente de interface de utilizador (UI na forma original), vamos ficar somente pela execução do Storybook.
 
-## Reutilização CSS
+## Reutilizar CSS
 
-A Taskbox reutiliza elementos de design do tutorial de React e GraphQL
-[Tutorial React e GraphQL](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858), como tal não será necessária a criação de CSS neste tutorial.
+A Taskbox reutiliza elementos de design deste [tutorial React e GraphQL](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858), logo não precisamos escrever CSS neste tutorial. Copie e cole o [CSS compilado](https://github.com/chromaui/learnstorybook-code/blob/master/src/index.css) no ficheiro (ou arquivo) `src/index.css`.
 
-Com isto o conteúdo do ficheiro LESS será compilado num único ficheiro CSS e incluido na aplicação.
-
-O CSS compilado encontra-se disponível [aqui](https://github.com/chromaui/learnstorybook-code/blob/master/src/index.css) e pela convenção CRA(Create React App) será necessário copiar seu conteúdo para o seguinte ficheiro src/index.css.
 
 ![Interface Utilizador Taskbox](/intro-to-storybook/ss-browserchrome-taskbox-learnstorybook.png)
 
@@ -70,6 +71,14 @@ O CSS compilado encontra-se disponível [aqui](https://github.com/chromaui/learn
 
 ## Adicionar recursos
 
-Irá ser necessário adicionar também as pastas com o tipo de letra e ícones que se encontram disponíveis [aqui](https://github.com/chromaui/learnstorybook-code/tree/master/public) á pasta `public`. Ao adicionar estes elementos, a aplicação irá renderizar de forma algo estranha.
-Mas isto é de esperar, visto que não iremos trabalhar na aplicação agora.
-Iremos então iniciar o desenvolvimento do nosso primeiro componente!
+De forma a igualar o design pretendido do tutorial, terá que transferir as pastas (ou diretórios) dos ícones e fontes para dentro da pasta `public`.
+
+<div class="aside"> Foi usado o svn (Subversion) para facilitar a transferência das pastas (ou diretórios) do GitHub. Se não tiver o subversion instalado, ou pretender transferir manualmente, pode obtê-las <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">aqui</a>.</p></div>
+
+
+```bash
+svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/icon public/icon
+svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/font public/font
+```
+
+Após adicionar os estilos e assets, a aplicação irá renderizar de forma estranha. Tudo bem. Não vamos trabalhar nela agora. Vamos antes começar por construir o nosso primeiro componente.

--- a/content/intro-to-storybook/react/pt/screen.md
+++ b/content/intro-to-storybook/react/pt/screen.md
@@ -6,15 +6,17 @@ commit: e56e345
 ---
 
 Tem sido focada a construção de interfaces de utilizador da base para o topo.
-Começando de forma simples e sendo adicionada complexidade á medida que a aplicação é desenvolvida. Com isto permitiu que cada componente fosse desenvolvido de forma isolada, definindo quais os requisitos de dados e "brincar" com ele em Storybook. Isto tudo sem a necessidade de instanciar um servidor ou ser necessária a construção de ecrãs!
+Começando de forma simples e sendo adicionada complexidade á medida que a aplicação é desenvolvida. Com isto permitiu que cada componente fosse desenvolvido de forma isolada, definindo quais os requisitos de dados e "brincar" com ele no Storybook. Isto tudo sem a necessidade de instanciar um servidor ou ser necessária a construção de ecrãs!
 
 Neste capitulo, irá ser acrescida um pouco mais a sofisticação, através da composição de diversos componentes, originando um ecrã, que será desenvolvido no Storybook.
 
 ## Componentes contentores agrupados
 
-Visto que a aplicação é deveras simples, o ecrã a ser construído é bastante trivial, simplesmente envolvendo o componente `TaskList` (que fornece os seus dados via Redux), a um qualquer layout e extraindo o campo de topo `erro` oriundo do Redux(assumindo que este irá ser definido caso exista algum problema na ligação ao servidor). Dentro da pasta `components` vai ser adicionado o ficheiro `InboxScreen.js`:
+Visto que a aplicação é deveras simples, o ecrã a ser construído é bastante trivial, simplesmente envolvendo o componente `TaskList` (que fornece os seus dados via Redux), a um qualquer layout e extraindo o campo de topo `erro` oriundo do Redux (assumindo que este irá ser definido caso exista algum problema na ligação ao servidor). Dentro da pasta `components` vai ser adicionado o ficheiro `InboxScreen.js`:
 
 ```javascript
+// src/components/InboxScreen.js
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -57,49 +59,53 @@ PureInboxScreen.defaultProps = {
 export default connect(({ error }) => ({ error }))(PureInboxScreen);
 ```
 
-Vai ser necessário alterar o componente `App` de forma a ser possível renderizar o `InboxScreen` (eventualmente iria ser usado um roteador para escolher o ecrã apropriado, mas não e necessário preocupar-se com isso agora):
+Vai ser necessário alterar o componente `App` de forma a ser possível renderizar o `InboxScreen` (eventualmente iria ser usado um roteador para escolher o ecrã apropriado, mas não é necessário preocupar-se com isso agora):
 
 ```javascript
-import React, { Component } from 'react';
+import React from 'react';
 import { Provider } from 'react-redux';
 import store from './lib/redux';
 
 import InboxScreen from './components/InboxScreen';
 
-class App extends Component {
-  render() {
-    return (
-      <Provider store={store}>
-        <InboxScreen />
-      </Provider>
-    );
-  }
+import './index.css';
+function App() {
+  return (
+    <Provider store={store}>
+      <InboxScreen />
+    </Provider>
+  );
 }
-
 export default App;
 ```
 
 No entanto as coisas irão tornar-se interessantes ao renderizar-se a estória no Storybook.
 
-Tal como visto anteriormente, o componente `TaskList` é um **contentor** que renderiza o componente de apresentação. Por definição estes componentes, os componentes contentor não podem ser renderizados de forma isolada, estes encontram-se "á espera" de um determinado contexto ou ligação a serviço. O que isto significa, é que para ser feita a renderização de um contentor em Storybook, é necessário simular o contexto ou serviço necessário(ou seja, providenciar uma versão fingida)
+Tal como visto anteriormente, o componente `TaskList` é um **contentor** que renderiza o componente de apresentação `PureTaskList`. Por definição estes componentes, os componentes contentor não podem ser renderizados de forma isolada, estes encontram-se "á espera" de um determinado contexto ou ligação a um serviço. O que isto significa, é que para ser feita a renderização de um contentor em Storybook, é necessário simular o contexto ou serviço necessário (ou seja, providenciar uma versão fingida).
 
 Ao colocar-se a `TaskList` no Storybook, foi possível fugir a este problema através da renderização do `PureTaskList` e com isto evitando o contentor por completo.
 Irá ser feito algo similar para o `PureInboxScreen` no Storybook também.
 
-No entanto para o `PureInboxScreen` existe um problema, isto porque apesar deste ser de apresentação, o seu "filho", ou seja a `TaskList` não o é. De certa forma o `PureInboxScreen` foi poluído pelo "container-ness". Com isto as estórias no ficheiro `InboxScreen.stories.js` terão que ser definidas da seguinte forma:
+No entanto para o `PureInboxScreen` existe um problema, isto porque apesar deste ser de apresentação, o seu "filho", ou seja a `TaskList` não o é. De certa forma o `PureInboxScreen` foi poluído pelo "container-ness". Com isto quando forem adicionadas as estórias ao ficheiro `InboxScreen.stories.js`:
 
 ```javascript
+// src/components/InboxScreen.stories.js
+
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 
 import { PureInboxScreen } from './InboxScreen';
 
-storiesOf('InboxScreen', module)
-  .add('default', () => <PureInboxScreen />)
-  .add('error', () => <PureInboxScreen error="Something" />);
+export default {
+  component: PureInboxScreen,
+  title: 'InboxScreen',
+};
+
+export const Default = () => <PureInboxScreen />;
+
+export const Error = () => <PureInboxScreen error="Something" />;
 ```
 
-Pode verificar-se que apesar da estória `erro` funcionar correctamente, existe um problema na estória `default`, isto porque a `TaskList` não tem uma loja Redux á qual conectar-se. (Poderão surgir problemas similares ao testar o `PureInboxScreen` com um teste unitário).
+Pode verificar-se que apesar da estória `error` funcionar corretamente, existe um problema na estória `Default`, isto porque a `TaskList` não tem uma loja Redux á qual conectar-se. (Poderão surgir problemas similares ao testar o `PureInboxScreen` com um teste unitário).
 
 ![Inbox quebrada](/intro-to-storybook/broken-inboxscreen.png)
 
@@ -108,42 +114,48 @@ Uma forma de evitar este tipo de situações, consiste em evitar por completo a 
 No entanto, algum programador **irá querer** renderizar contentores num nível mais baixo na hierarquia de componentes. Já que pretendemos renderizar a maioria da aplicação no Storybook (sim queremos!), é necessária uma solução para esta situação.
 
 <div class="aside">
-    Como aparte, a transmissão de dados ao longo da hierarquia é uma abordagem legitima, particulamente quando é utilizado <a href="http://graphql.org/">GrapQL</a>. Foi desta forma que foi construido o <a href="https://www.chromaticqa.com">Chromatic</a>, juntamente com mais de 670 estórias.
+    Como aparte, a transmissão de dados ao longo da hierarquia é uma abordagem legitima, particularmente quando é utilizado <a href="http://graphql.org/">GrapQL</a>. Foi desta forma que foi construido o <a href="https://www.chromaticqa.com">Chromatic</a>, juntamente com mais de 800+ estórias.
 </div>
 
-## Fornecimento do contexto com recurso a decoradores
+## Fornecer contexto ás estórias
 
 As boas noticias é que é extremamente fácil fornecer uma loja Redux ao componente `InboxScreen` numa estória! Pode ser usada uma versão simulada, que é fornecida através de um decorador:
 
 ```javascript
+// src/components/InboxScreen.stories.js
+
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { Provider } from 'react-redux';
 
 import { PureInboxScreen } from './InboxScreen';
-import { defaultTasks } from './TaskList.stories';
+import { defaultTasksData } from './TaskList.stories';
+
+export default {
+  component: PureInboxScreen,
+  title: 'InboxScreen',
+  decorators: [story => <Provider store={store}>{story()}</Provider>],
+};
 
 // A super-simple mock of a redux store
 const store = {
   getState: () => {
     return {
-      tasks: defaultTasks,
+      tasks: defaultTasksData,
     };
   },
   subscribe: () => 0,
   dispatch: action('dispatch'),
 };
 
-storiesOf('InboxScreen', module)
-  .addDecorator(story => <Provider store={store}>{story()}</Provider>)
-  .add('default', () => <PureInboxScreen />)
-  .add('error', () => <PureInboxScreen error="Something" />);
+export const Default = () => <PureInboxScreen />;
+
+export const Error = () => <PureInboxScreen error="Something" />;
 ```
 
 Existem abordagens semelhantes de forma a fornecer contextos simulados para outras bibliotecas de dados tal como [Apollo](https://www.npmjs.com/package/apollo-storybook-decorator), [Relay](https://github.com/orta/react-storybooks-relay-container) assim como outras.
 
-A iteração de estados no Storybook faz com que seja bastante fácil testar, se for feito correctamente:
+A iteração de estados no Storybook faz com que seja bastante fácil testar, se for feito corretamente:
 
 <video autoPlay muted playsInline loop >
 
@@ -153,7 +165,7 @@ A iteração de estados no Storybook faz com que seja bastante fácil testar, se
   />
 </video>
 
-## Desenvolmento orientado a Componentes
+## Desenvolvimento orientado a Componentes
 
 Começou-se do fundo com `Task`, prosseguindo para `TaskList` e agora chegou-se ao ecrã geral do interface de utilizador. O `InboxScreen`, acomoda um componente contentor que foi adicionado e inclui também estórias que o acompanham.
 
@@ -164,7 +176,7 @@ Começou-se do fundo com `Task`, prosseguindo para `TaskList` e agora chegou-se 
   />
 </video>
 
-[**Desenvolvimento Orientado a Componentes**](https://blog.hichroma.com/component-driven-development-ce1109d56c8e) permite a expansão gradual da complexidade á medida que se prossegue de forma ascendente na hierarquia de componentes. Dos benefícios ao utilizar-se esta abordagem, estão o processo de desenvolvimento focado e cobertura adicional das permutações possíveis do interface de utilizador.
+[**Component-Driven Development**](https://blog.hichroma.com/component-driven-development-ce1109d56c8e) permite a expansão gradual da complexidade á medida que se prossegue de forma ascendente na hierarquia de componentes. Dos benefícios ao utilizar-se esta abordagem, estão o processo de desenvolvimento focado e cobertura adicional das permutações possíveis do interface de utilizador.
 Resumidamente esta abordagem ajuda na produção de interfaces de utilizador de uma qualidade extrema e assim como complexidade.
 
 Ainda não finalizamos, o trabalho não acaba quando o interface de utilizador estiver construído. É necessário garantir que resiste ao teste do tempo.

--- a/content/intro-to-storybook/react/pt/simple-component.md
+++ b/content/intro-to-storybook/react/pt/simple-component.md
@@ -5,13 +5,13 @@ description: 'Construção de um componente simples isolado'
 commit: 403f19a
 ---
 
-Iremos construir o interface de utilizador de acordo com a metodologia de [Desenvolvimento orientada a componentes](https://blog.hichroma.com/component-driven-development-ce1109d56c8e), ou nativamente por (CDD, Component-Driven Development). É um processo que cria interfaces de utilizador a partir da base para o topo, iniciando com componentes e terminando com ecrãs. O DOC(CDD nativamente) ajuda no escalonamento da complexidade á qual o programador é sujeito á medida que constrói o interface de utilizador.
+Iremos construir o interface de utilizador de acordo com a metodologia de [Desenvolvimento orientada a componentes](https://blog.hichroma.com/component-driven-development-ce1109d56c8e), ou nativamente por (CDD, Component-Driven Development). É um processo que cria interfaces de utilizador a partir da base para o topo, iniciando com componentes e terminando com ecrãs. O DOC (CDD nativamente) ajuda no escalonamento da complexidade á qual o programador é sujeito á medida que constrói o interface de utilizador.
 
 ## Tarefa
 
 ![Componente Task ao longo de três estados](/intro-to-storybook/task-states-learnstorybook.png)
 
-`Task` é o componente nuclear da nossa aplicação. Cada tarefa é apresentada de forma diferente dependendo do estado em que se encontra.
+A `Task` é o componente nuclear da nossa aplicação. Cada tarefa é apresentada de forma diferente dependendo do estado em que se encontra.
 O que vai ser apresentado é uma caixa de confirmação, selecionada (ou não), alguma informação adicional acerca da tarefa e um botão "fixador", que permite a movimentação para cima e para baixo das tarefas ao longo da lista.
 Para que seja possível implementar isto serão necessárias os seguintes adereços (props):
 
@@ -28,9 +28,11 @@ Este processo é algo similar ao [Desenvolvimento orientado a testes](https://en
 Primeiro irá ser criado o componente tarefa e o ficheiro de estórias que o acompanha:
 `src/components/Task.js` e `src/components/Task.stories.js` respetivamente.
 
-Iremos iniciar por uma implementação básica da `Task`, que recebe os atributos conhecidos até agora, assim como as duas ações que podem ser desencadeadas (a movimentação entre listas):
+Iremos iniciar por uma implementação rudimentar da `Task`, que recebe os atributos conhecidos até agora, assim como as duas ações que podem ser desencadeadas (a movimentação entre listas):
 
 ```javascript
+// src/components/Task.js
+
 import React from 'react';
 
 export default function Task({ task: { id, title, state }, onArchiveTask, onPinTask }) {
@@ -47,28 +49,37 @@ O bloco de código acima, quando renderizado, não é nada mais nada menos que a
 Em seguida irão ser criados os três testes ao estado da tarefa no ficheiro de estórias correspondente:
 
 ```javascript
+// src/components/Task.stories.js
+
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import Task from './Task';
 
-export const task = {
+export default {
+  component: Task,
+  title: 'Task',
+  // Our exports that end in "Data" are not stories.
+  excludeStories: /.*Data$/,
+};
+
+export const taskData = {
   id: '1',
   title: 'Test Task',
   state: 'TASK_INBOX',
   updatedAt: new Date(2018, 0, 1, 9, 0),
 };
 
-export const actions = {
+export const actionsData = {
   onPinTask: action('onPinTask'),
   onArchiveTask: action('onArchiveTask'),
 };
 
-storiesOf('Task', module)
-  .add('default', () => <Task task={task} {...actions} />)
-  .add('pinned', () => <Task task={{ ...task, state: 'TASK_PINNED' }} {...actions} />)
-  .add('archived', () => <Task task={{ ...task, state: 'TASK_ARCHIVED' }} {...actions} />);
+export const Default = () => <Task task={{ ...taskData }} {...actionsData} />;
+
+export const Pinned = () => <Task task={{ ...taskData, state: 'TASK_PINNED' }} {...actionsData} />;
+
+export const Archived = () => <Task task={{ ...taskData, state: 'TASK_ARCHIVED' }} {...actionsData} />;
 ```
 
 Existem dois tipos de organização com Storybook. O componente em si e as estórias associadas. É preferível pensar em cada estória como uma permutação de um componente. Como tal podem existir tantas estórias, tantas as que forem necessárias.
@@ -78,18 +89,22 @@ Existem dois tipos de organização com Storybook. O componente em si e as estó
   - Story
   - Story
 
-Ao ser invocada a função `storiesOf()`, está a registar-se o componente, e com isto o processo de arranque do Storybook. É adicionado um nome, nome esse que será usado na barra lateral da aplicação Storybook para identificar o componente.
+De forma a informar o Storybook acerca do componente que está a ser documentado, é criado um default export que contém:
+
+- `component` -- o componente em si,
+- `title` -- o nome que irá ser apresentado na barra lateral da aplicação Storybook,
+- `excludeStories` -- Informação que é necessária à estória, mas que não deverá ser renderizada pela aplicação Storybook.
+
+Para definir as nossas estórias, exportamos uma função para cada um dos casos de teste. A estória não é nada mais nada menos que uma função que devolve um elemento renderizado (por exemplo um componente com um conjunto de adereços) num determinado estado -- exatamente tal como um [Componente Funcional sem estado](https://reactjs.org/docs/components-and-props.html).
 
 A função `action()` permite a criação de um callback, que irá surgir no painel adequado, ou seja o painel **actions** do interface de utilizador Storybook quando for feito o click. Como tal assim que for criado o botão para afixar tarefas, irá ser possível determinar o sucesso ou não do click no interface de utilizador de testes.
 
-Visto que é necessário fornecer o mesmo conjunto de tarefas a todas as permutações do componente, é extremamente conveniente agrupar numa única variável denominada `actions` e usar a expansão de adereços (props) em React `{...actions}` de forma que possam ser enviados de uma só vez.
+Visto que é necessário fornecer o mesmo conjunto de tarefas a todas as permutações do componente, é extremamente conveniente agrupar numa única variável denominada `actionsData` e usar a expansão de adereços (props) em React `{...actions}` de forma que possam ser enviados de uma só vez.
 Usar `<Task {...actions}>` não é nada mais nada menos que `<Task onPinTask={actions.onPinTask} onArchiveTask={actions.onArchiveTask}>`.
 
-Outro aspeto fantástico ao agrupar as `actions` necessárias ao componente, é que as podemos exportar com recurso á clausula `export` de forma que seja possível serem usadas por estórias que reutilizam este componente, tal como se poderá ver futuramente.
+Outro aspeto fantástico ao agrupar as `actions` necessárias ao componente na `actionsData`, é que as podemos exportar com recurso à clausula `export` de forma que seja possível serem usadas por estórias que reutilizam este componente, tal como iremos ver posteriormente.
 
-Para definir as estórias, invoca-se o metodo `add()`, uma única vez para cada um dos estados de teste, de forma a gerar uma estória. A estória ação é uma função que irá retornar um elemento renderizado( ou seja, uma classe de componente com um conjunto de adereços (props)) para um determinado estado, tal como [Componente funcional sem estado](https://reactjs.org/docs/components-and-props.html), ou nativamente (Stateless Functional Component).
-
-Ao ser criada uma estória, é usada uma tarefa base (`task`) para definir a forma da tarefa em questão que é necessária ao componente. Geralmente modelada a partir de dados concretos. Mais uma vez o uso da cláusula `export`, neste caso para a estrutura dos dados irá permitir a sua reutilização em estórias futuras, tal como veremos.
+Ao ser criada uma estória, é usada uma tarefa base (`taskData`) para definir a forma da tarefa em questão que é necessária ao componente. Geralmente modelada a partir de dados concretos. Mais uma vez o uso da cláusula `export`, neste caso para a estrutura dos dados irá permitir a sua reutilização em estórias futuras, tal como veremos.
 
 <div class="aside">
     <a href="https://storybook.js.org/addons/introduction/#2-native-addons"><b>Ações</b></a> ajudam na verificação das interações quando são construídos componentes de interface de utilizador isolados. Na grande maioria das vezes não existirá qualquer tipo de acesso ao estado e funções definidas no contexto da aplicação. Como tal é preferível o uso de<code>action()</code> para esta situação.
@@ -97,23 +112,28 @@ Ao ser criada uma estória, é usada uma tarefa base (`task`) para definir a for
 
 ## Configuração
 
-Será necessária uma alteração minúscula ao ficheiro de configuração do Storybook (`storybook/config.js`) de forma que este reconheça os ficheiros com extensão `stories.js`, mas também utilize o ficheiro CSS.
-Por norma o Storybook pesquisa numa pasta denominada `/stories` para conter as estórias; este tutorial usa uma nomenclatura similar a `.test.js`, cuja qual favorecida pelo CRA para testes automatizados.
+É necessário efetuar algumas alterações á configuração do Storybook, de forma que saiba não só onde procurar onde estão as estórias que acabámos de criar, mas também usar o CSS que foi adicionado no [capítulo anterior](/react/pt/get-started).
+
+Vamos começar por alterar o ficheiro de configuração do Storybook(`.storybook/main.js`) para o seguinte:
 
 ```javascript
-import { configure } from '@storybook/react';
-import '../src/index.css';
+// .storybook/main.js
 
-const req = require.context('../src', true, /\.stories.js$/);
-
-function loadStories() {
-  req.keys().forEach(filename => req(filename));
-}
-
-configure(loadStories, module);
+module.exports = {
+  stories: ['../src/components/**/*.stories.js'],
+  addons: ['@storybook/preset-create-react-app','@storybook/addon-actions', '@storybook/addon-links'],
+};
 ```
 
-Após esta alteração, ao ser reiniciado o servidor Storybook, deverá produzir os casos de teste para os três estados definidos para a tarefa:
+Após efetuar esta alteração, uma vez mais dentro da pasta (ou diretório) `.storybook`, crie um novo ficheiro (ou arquivo) chamado `preview.js` com o seguinte conteúdo:
+
+```javascript
+// .storybook/preview.js
+
+import '../src/index.css';
+```
+
+Após esta alteração, quando reiniciar o servidor Storybook, deverá produzir os casos de teste para os três diferentes estados da tarefa:
 
 <video autoPlay muted playsInline controls >
   <source
@@ -122,9 +142,58 @@ Após esta alteração, ao ser reiniciado o servidor Storybook, deverá produzir
   />
 </video>
 
+## Construção dos estados
+
+Neste momento já possuímos o Storybook configurado, os elementos de estilo importados, assim como os casos de teste, podemos agora iniciar a implementação HTML do componente de forma a igualar o design.
+
+O componente neste momento ainda está algo rudimentar. Vamos fazer algumas alterações de forma a atingir o design pretendido, sem entrar em muitos detalhes:
+
+```javascript
+// src/components/Task.js
+
+import React from 'react';
+
+export default function Task({ task: { id, title, state }, onArchiveTask, onPinTask }) {
+  return (
+    <div className={`list-item ${state}`}>
+      <label className="checkbox">
+        <input
+          type="checkbox"
+          defaultChecked={state === 'TASK_ARCHIVED'}
+          disabled={true}
+          name="checked"
+        />
+        <span className="checkbox-custom" onClick={() => onArchiveTask(id)} />
+      </label>
+      <div className="title">
+        <input type="text" value={title} readOnly={true} placeholder="Input title" />
+      </div>
+
+      <div className="actions" onClick={event => event.stopPropagation()}>
+        {state !== 'TASK_ARCHIVED' && (
+           // eslint-disable-next-line jsx-a11y/anchor-is-valid
+          <a onClick={() => onPinTask(id)}>
+            <span className={`icon-star`} />
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+O markup adicional descrito acima, combinado com o CSS que foi importado anteriormente irá originar o seguinte interface de utilizador:
+
+<video autoPlay muted playsInline loop>
+  <source
+    src="/intro-to-storybook/finished-task-states.mp4"
+    type="video/mp4"
+  />
+</video>
+
 ## Especificação de requisitos de dados
 
-É boa prática serem usados `propTypes` React de forma a especificar a forma que os dados tomam para um componente. Não somente é auto documentável, mas ajuda a detectar problemas cedo.
+É considerada boa prática usar `propTypes` com o React, de forma a especificar a forma que os dados assumem num componente. Não somente é auto documentável, mas ajuda a detetar problemas cedo.
 
 ```javascript
 import React from 'react';
@@ -147,7 +216,7 @@ Task.propTypes = {
 export default Task;
 ```
 
-Com isto irá surgir um aviso no modo de desenvolvimento quando o componente Task for mal utilizado.
+Enquanto estivermos a desenvolver o nosso componente irá ser emitido um aviso sempre que o componente não for usado de forma correta.
 
 <div class="aside">
   Uma forma alternativa de se atingir o mesmo resultado consiste no uso de um sistema de tipos Javascript tal como o TypeScript para criar um determinado tipo para as propriedades do componente.
@@ -155,57 +224,40 @@ Com isto irá surgir um aviso no modo de desenvolvimento quando o componente Tas
 
 ## Componente construido!
 
-Foi construído com sucesso, sem ser necessário qualquer tipo de servidor, ou que seja necessário executar a aplicação frontend. O próximo passo é construir os restantes componentes da Taskbox um por um de forma similar.
+Construímos com sucesso um componente, sem ser necessário qualquer tipo de servidor, ou que seja necessário executar a aplicação frontend. O próximo passo é construir os restantes componentes da Taskbox um por um de forma similar.
 
-Como se pode ver, começar a construir componentes isoladamente é fácil e rápido.
+Como se pode ver, começar a construir componentes de forma isolada é fácil e rápido.
 Com isto espera-se que seja possível construir um interface de utilizador de qualidade superior com um número de problemas menor e mais polido. Isto devido ao facto que é possível aprofundar e testar qualquer estado possível.
 
 ## Testes automatizados
 
-O Storybook oferece uma forma fantástica de testar visualmente a aplicação durante o desenvolvimento. As "estórias" irão garantir que a tarefa não seja visualmente destruída á medida que a aplicação continua a ser desenvolvida. Mas no entanto continua a ser um processo manual neste momento e alguém terá que fazer o esforço de clickar em cada estado de teste de forma a garantir que irá renderizar sem qualquer tipo de problemas. Não poderíamos automatizar isto?
+O Storybook oferece uma forma fantástica de testar visualmente a aplicação durante o desenvolvimento. As "estórias" irão garantir que a tarefa não seja visualmente destruída á medida que a aplicação continua a ser desenvolvida. Mas no entanto continua a ser um processo manual neste momento e alguém terá que fazer o esforço de clicar em cada estado de teste de forma a garantir que irá renderizar sem qualquer tipo de problemas. Não poderíamos automatizar isto?
 
 ## Testes de snapshot
 
-Este tipo de testes refere-se á pratica de guardar o output considerado "bom" de um determinado componente com base num input e marcar o componente caso o output seja alterado. Isto complementa o Storybook, visto que é uma forma rápida de se visualizar a nova versão de um componente e verificar as alterações.
+Este tipo de testes refere-se á pratica de guardar o output considerado "bom" de um determinado componente com base num input e marcar o componente caso o output seja alterado. Isto complementa o Storybook, visto que é uma forma rápida de se visualizar a nova versão de um componente e verificar as alterações feitas.
 
 <div class="aside">
   É necessário garantir que os componentes renderizam dados que não serão alterados, de forma a garantir que os testes snapshot não falhem sempre. É necessário ter atenção a datas ou valores gerados aleatoriamente.
 </div>
 
-Com o [extra Storyshots](https://github.com/storybooks/storybook/tree/master/addons/storyshots) é criado um teste de snapshot para cada uma das estórias. Para que este possa ser usado, adiciona-se a dependência de desenvolvimento:
+Com o [extra Storyshots](https://github.com/storybooks/storybook/tree/master/addons/storyshots) é criado um teste de snapshot para cada uma das estórias. Para que este possa ser usado, adicionam-se as seguintes dependências de desenvolvimento:
 
 ```bash
-yarn add --dev @storybook/addon-storyshots react-test-renderer require-context.macro
+yarn add -D @storybook/addon-storyshots react-test-renderer
 ```
 
 Quando esta operação terminar, será necessário criar o ficheiro `src/storybook.test.js` com o seguinte conteúdo:
 
 ```javascript
+// src/storybook.test.js
+
 import initStoryshots from '@storybook/addon-storyshots';
 initStoryshots();
 ```
 
-Será necessário usar uma [macro babel](https://github.com/kentcdodds/babel-plugin-macros), de forma a garantir que `require.context` seja executado pelo Jest (o nosso contexto de testes), para isso atualiza-se o conteúdo do ficheiro `.storybook/config.js` (de forma a que o webpack faça a sua magia):
+E é só isto, podemos agora executar o comando `yarn test` e verificar o seguinte resultado:
 
-```js
-import { configure } from '@storybook/react';
-import requireContext from 'require-context.macro';
+![Task test runner](/intro-to-storybook/task-testrunner.png)
 
-import '../src/index.css';
-
-const req = requireContext('../src/components', true, /\.stories\.js$/);
-
-function loadStories() {
-  req.keys().forEach(filename => req(filename));
-}
-
-configure(loadStories, module);
-```
-
-(Note-se que foi substituído `require.context` com uma invocação de `requireContext` importada da macro).
-
-Quando for concluída esta operação, pode ser executado `yarn test` e obter o seguinte output:
-
-![Execução testes da Tarefa](/intro-to-storybook/task-testrunner.png)
-
-Com isto encontra-se agora á disposição um teste snapshot para cada uma das estórias `Task`. Se a implementação da `Task` for alterada, será apresentada uma notificação.
+Temos à nossa disposição um teste de snapshot para cada uma das estórias da `Task`. Se a implementação da `Task` for alterada, será apresentada uma notificação para serem verificadas a alterações que foram feitas.

--- a/content/intro-to-storybook/react/pt/test.md
+++ b/content/intro-to-storybook/react/pt/test.md
@@ -9,11 +9,11 @@ Qualquer tutorial de Storybook não estaria completo sem serem mencionados os te
 
 - **Testes visuais** dependem do programador para olhar para o componente manualmente e verificar se está tudo de acordo. Ajudam a manter um nível de coerência em termos de aparência á medida que é construído.
 - **Testes snapshot** com o extra Storyshots é capturado o markup renderizado do componente. Ajudam a ficar a par das alterações no markup que causam erros de renderização e avisos.
-- **Unit tests** com Jest é verificado que o output de um determinado componente mantém-se idêntico dado um input fixo. São óptimos para efectuar testes das qualidades funcionais de um componente.
+- **Unit tests** com Jest é verificado que o output de um determinado componente mantém-se idêntico dado um input fixo. São ótimos para efetuar testes das qualidades funcionais de um componente.
 
-## "Mas aparenta ser correcto"?
+## "Mas aparenta ser correto"?
 
-Infelizmente as metodologias de teste acima mencionadas, sozinhas não são suficientes para prevenir problemas no interface de utilizador. Estes são complicados para testar, visto que o design é algo subjectivo e com nuances. Os testes visuais são demasiado manuais, os testes de snapshot poderão originar demasiados falsos positivos quando usados para interface de utilizador e os testes unitários ao nível de pixel são pobres. Uma estratégia de testes considerada completa para o Storybook incluí também testes visuais de regressão.
+Infelizmente as metodologias de teste acima mencionadas, sozinhas não são suficientes para prevenir problemas no interface de utilizador. Estes são complicados para testar, visto que o design é algo subjetivo e com nuances. Os testes visuais são demasiado manuais, os testes de snapshot poderão originar demasiados falsos positivos quando usados para interface de utilizador e os testes unitários ao nível de pixel são pobres. Uma estratégia de testes considerada completa para o Storybook incluí também testes visuais de regressão.
 
 ## Testes visuais de regressão para o Storybook
 
@@ -28,16 +28,16 @@ Os testes visuais de regressão são desenhados para capturar alterações de ap
 
 O Storybook é uma ferramenta fantástica para este tipo de testes, por que cada estória é na sua essência uma especificação de teste. Cada vez que é escrita ou atualizada uma estória, obtemos uma especificação de graça!
 
-Existem inúmeras ferramentas para este propósito. Para equipas profissionais é recomendado o [**Chromatic**](https://www.chromaticqa.com/), um extra desenvolvido pela equipa de manutenção do Storybook que efectua testes na núvem.
+Existem inúmeras ferramentas para este propósito. Para equipas profissionais é recomendado o [**Chromatic**](https://www.chromaticqa.com/), um extra desenvolvido pela equipa de manutenção do Storybook que efetua testes na núvem.
 
 ## Configuração de testes de regressão visual
 
 O Chromatic é um extra sem complicações para este tipo de testes. Visto que é um serviço pago (mas com o período de testes grátis), logo poderá não ser para toda a gente. No entanto este é um exemplo de uma ferramenta ao nível profissional que irá usada gratuitamente.
 Em seguida vai ser elaborada uma breve introdução desta.
 
-## Atualizando o git
+## Atualizar o git
 
-O Create React App, iniciou um repositório git para o projecto, com isto vão ser adicionadas as alterações feitas até agora:
+Quando o projeto foi inicializado, o Create React App criou um repositório local. Vamos adicionar as alterações efetuadas:
 
 ```bash
 $ git add -A
@@ -54,28 +54,12 @@ $ git commit -m "taskbox UI"
 Adiciona-se o pacote como dependência.
 
 ```bash
-yarn add storybook-chromatic
+yarn add -D storybook-chromatic
 ```
 
-O Chromatic é importado para o ficheiro `.storybook/config.js`.
+Um aspeto fantástico acerca deste extra é que recorre á Git history para se manter a par dos componentes de interface de utilizador.
 
-```javascript
-import { configure } from '@storybook/react';
-import requireContext from 'require-context.macro';
-import 'storybook-chromatic';
-
-import '../src/index.css';
-
-const req = requireContext('../src/components', true, /\.stories\.js$/);
-
-function loadStories() {
-  req.keys().forEach(filename => req(filename));
-}
-
-configure(loadStories, module);
-```
-
-É feita a [autenticação na plataforma Chromatic](https://www.chromaticqa.com/start), com a conta GitHub (O Chromatic pede permissões ligeiras). Em seguida criado um projecto com o nome "taskbox" e copie e guarde o `app-code` único.
+Faça a [autenticação na plataforma Chromatic](https://www.chromaticqa.com/start), com a conta GitHub (O Chromatic pede permissões ligeiras). Em seguida crie um projeto com o nome "taskbox" e copie e guarde seu o `app-code` único.
 
 <video autoPlay muted playsInline loop style="width:520px; margin: 0 auto;">
   <source
@@ -84,23 +68,23 @@ configure(loadStories, module);
   />
 </video>
 
-Executa-se o comando de testes na consola de forma a configurar os testes visuais de regressão para o Storybook. Não esquecer de adicionar o `app-code` fornecido ao invés de `<app-code>`.
+Execute o comando de testes na consola de forma a configurar os testes visuais de regressão para o Storybook. Não esquecer de adicionar o `app-code` fornecido ao invés de `<app-code>`.
 
 ```bash
-./node_modules/.bin/chromatic test --app-code=<app-code>
+npx chromatic --app-code=<app-code>
 ```
 
 <div class="aside">
-    O argumento <code>--do-not-start</code> é uma opção que informa o Chromatic para não iniciar o Storybook. Isto usado se o Storybook já se encontrar em execução. Caso contrário omite-se o <code>--do-not-start</code>.
+     O argumento <code>--do-not-start</code> é uma opção que informa o Chromatic para não iniciar o Storybook. Isto usado se o Storybook já se encontrar em execução. Caso contrário omite-se o <code>--do-not-start</code>.
 </div>
 
 Assim que o primeiro teste estiver concluído, é obtida a base de testes para cada estória. Por outras palavras, uma captura de cada estória considerada "boa". Alterações futuras a estas estórias, irão ser comparadas com esta base.
 
 ![Bases Chromatic](/intro-to-storybook/chromatic-baselines.png)
 
-## Captura de uma alteração interface utilizador
+## Captura de uma alteração no interface utilizador
 
-Os testes de regressão visual dependem da comparação de imagens do novo código do interface de utilizador que foi agora renderizado com as imagens de base. Se for capturada uma alteração no interface de utilizador irá surgir uma notificação. Para isto ser observado altera-se o fundo do do componente `Task`:
+Os testes de regressão visual dependem da comparação de imagens do novo código do interface de utilizador que foi agora renderizado com as imagens de base. Se for capturada uma alteração no interface de utilizador irá surgir uma notificação. Para isto ser observado altera-se o fundo do componente `Task`:
 
 ![alteração código](/intro-to-storybook/chromatic-change-to-task-component.png)
 
@@ -111,7 +95,7 @@ O que irá gerar uma nova cor de fundo para o item.
 Usando agora o comando de testes, para efectuar um outro teste com o Chromatic.
 
 ```bash
-./node_modules/.bin/chromatic test --app-code=<app-code>
+npx chromatic --app-code=<app-code>
 ```
 
 Ao abrir-se o link, irão ser apresentadas a alterações.
@@ -136,7 +120,8 @@ Se uma alteração é intencional, é necessária a atualização da linha de ba
   />
 </video>
 
-Visto que as aplicações modernas são construidas a partir de componentes, é importante testar ao nível destes. Ao efectuar-se isto ajuda a identificar a principal causa da alteração, ou seja o componente ao invés de reagir aos sintomas de uma alteração, ecrãs ou componentes compostos.
+
+Visto que as aplicações modernas são construidas a partir de componentes, é importante testar ao nível destes. Ao efetuar-se isto ajuda a identificar a principal causa da alteração, ou seja o componente, ao invés de reagir aos sintomas de uma alteração, ecrãs ou componentes compostos.
 
 ## Fusão de alterações
 

--- a/content/intro-to-storybook/react/pt/using-addons.md
+++ b/content/intro-to-storybook/react/pt/using-addons.md
@@ -19,22 +19,30 @@ Poderíamos ficar aqui eternamente a discutir como configurar e usar os extras p
 
 Knobs é um recurso fantástico quer para designers quer para programadores, para fazerem experiências com componentes num ambiente controlado sem ser necessário qualquer tipo de código! Essencialmente, são fornecidos dados com os quais um qualquer utilizador irá manipular e fornecer aos componentes que se encontram definidos nas estórias. Isto é o que iremos implementar....
 
-![Knobs in action](/addon-knobs-demo.gif)
+<video autoPlay muted playsInline loop>
+  <source
+    src="/intro-to-storybook/addon-knobs-demo.mp4"
+    type="video/mp4"
+  />
+</video>
 
 ## Instalação
 
 Primeiro irá ser necessário instalar todas as dependências necessárias.
 
 ```bash
-yarn add @storybook/addon-knobs
+yarn add -D @storybook/addon-knobs
 ```
 
-Registar o Knobs no ficheiro `.storybook/addons.js`.
+Registe o Knobs no ficheiro (ou arquivo) `.storybook/main.js`.
 
 ```javascript
-import '@storybook/addon-actions/register';
-import '@storybook/addon-knobs/register';
-import '@storybook/addon-links/register';
+// .storybook/main.js
+
+module.exports = {
+  stories: ['../src/components/**/*.stories.js'],
+  addons: ['@storybook/preset-create-react-app','@storybook/addon-actions', '@storybook/addon-knobs', '@storybook/addon-links'],
+};
 ```
 
 <div class="aside">
@@ -47,51 +55,61 @@ E já está! É tempo de usar o extra numa estória.
 
 ### Utilização
 
-Vamos usar o objecto knob no componente `Task`.
+Vamos usar o objeto knob no componente `Task`.
 
-Primeiro, importamos o decorador `withKnobs` e o tipo `object` de knob para o ficheiro `Task.stories.js`:
+Primeiro, importamos o decorador `withKnobs` e o tipo `object` de knob para o ficheiro (ou arquivo) `Task.stories.js`:
 
 ```javascript
+// src/components/Task.stories.js
+
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, object } from '@storybook/addon-knobs/react';
 ```
 
-Em seguida, dentro das estórias do componente `Task`, iremos fornecer `withKnobs` como parâmetro da função `addDecorator()`:
+Em seguida, dentro do `default` export do ficheiro (ou arquivo) `Task.stories`, vamos fornecer `withKnobs` como elemento do `decorators`:
 
 ```javascript
-storiesOf('Task', module)
-  .addDecorator(withKnobs)
-  .add(/*...*/);
+// src/components/Task.stories.js
+
+export default {
+  component: Task,
+  title: 'Task',
+  decorators: [withKnobs],
+  excludeStories: /.*Data$/,
+};
 ```
 
 Finalmente, integramos o tipo `object` do knob na estória "padrão":
 
 ```javascript
-storiesOf('Task', module)
-  .addDecorator(withKnobs)
-  .add('default', () => {
-    return <Task task={object('task', { ...task })} {...actions} />;
-  })
-  .add('pinned', () => <Task task={{ ...task, state: 'TASK_PINNED' }} {...actions} />)
-  .add('archived', () => <Task task={{ ...task, state: 'TASK_ARCHIVED' }} {...actions} />);
+// src/components/Task.stories.js
+
+export const Default = () => {
+  return <Task task={object('task', { ...taskData })} {...actionsData} />;
+};
 ```
 
-Tal como se encontra documentado [aqui](https://github.com/storybooks/storybook/tree/master/addons/knobs#object), este tipo aceita uma "etiqueta" e um objeto padrão como parâmetros.
+Agora um novo item denominado "Knobs" deverá surgir próximo do "Action Logger" no painel inferior da aplicação.
+
+Tal como documentado [aqui](https://github.com/storybooks/storybook/tree/master/addons/knobs#object), este tipo aceita uma "etiqueta" e um objeto padrão como parâmetros.
 A etiqueta é constante e irá aparecer no painel de extras á esquerda do campo de texto. O objeto fornecido será representado como um blob JSON que pode ser editado. Desde que seja submetido JSON válido, o componente irá ajustar-se com base na informação fornecida ao objeto!
 
 ## Os extras aumentam a esfera de ação do teu Storybook
 
-Não somente a tua instância Storybook serve como um [ambiente CDD](https://blog.hichroma.com/component-driven-development-ce1109d56c8e) fantástico, mas agora estamos também a fornecer uma forma de documentação interativa. Os PropTypes são fantásticos, mas quer um designer quer uma outra pessoa qualquer nova que é apresentada ao código do componente irá ser capaz de entender qual é o seu comportamento rapidamente graças ao Storybook e a este extra.
+Não somente a tua instância Storybook serve como um [ambiente CDD](https://blog.hichroma.com/component-driven-development-ce1109d56c8e) fantástico, mas agora estamos também a fornecer uma forma de documentação interativa. Os adereços (ou props) são fantásticos, mas quer um designer quer uma outra pessoa qualquer nova que é apresentada ao código do componente irá ser capaz de entender qual é o seu comportamento rapidamente graças ao Storybook e a este extra.
 
 ## Utilização de Knobs para afinar os casos extremos
 
-Adicionalmente com a facilidade de edição de dados fornecidos ao componente, engenheiros QA ou Engenheiros UI, podem levar o componente ao extremo! Como exemplo o que irá acontecer ao nosso componente se contém uma cadeia de caracteres _GIGANTESCA_ ? [OHH não! O conteúdo á direita aparece corto!](/intro-to-storybook/addon-knobs-demo-edge-case.png) 😥
+Adicionalmente com a facilidade de edição de dados fornecidos ao componente, engenheiros QA ou Engenheiros UI, podem levar o componente ao extremo! Como exemplo o que irá acontecer ao nosso componente se contém uma cadeia de caracteres _GIGANTESCA_ ?
 
-Devido a facilidade com que é possível testar inputs diferentes podemos descobrir e resolver estes problemas com facilidade! Vamos então resolver o nosso problema, através da adição de um elemento de estilo ao `Task.js`:
+![OHH não! O conteúdo á direita aparece corto!](/intro-to-storybook/addon-knobs-demo-edge-case.png) 😥
+
+Devido a facilidade com que é possível testar inputs diferentes podemos descobrir e resolver estes problemas com facilidade! Vamos então resolver o nosso problema, através da adição de um elemento de estilo ao`Task.js`:
 
 ```javascript
+// src/components/Task.js
+
 // This is the input for our task title. In practice we would probably update the styles for this element
 // but for this tutorial, let's fix the problem with an inline style:
 <input
@@ -103,7 +121,7 @@ Devido a facilidade com que é possível testar inputs diferentes podemos descob
 />
 ```
 
-[Assim sim.](/intro-to-storybook/addon-knobs-demo-edge-case-resolved.png) 👍
+![Assim sim.](/intro-to-storybook/addon-knobs-demo-edge-case-resolved.png) 👍
 
 ## Criação de uma nova estória para evitar regressões
 
@@ -113,20 +131,20 @@ Isto irá expandir os testes de regressão e delinear com maior facilidade quais
 Vamos então adicionar uma estória para o caso da ocorrência de um texto grande no ficheiro Task.stories.js
 
 ```javascript
-const longTitle = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not`;
+// src/components/Task.stories.js
 
-storiesOf('Task', module)
-  .add('default', () => <Task task={task} {...actions} />)
-  .add('pinned', () => <Task task={{ ...task, state: 'TASK_PINNED' }} {...actions} />)
-  .add('archived', () => <Task task={{ ...task, state: 'TASK_ARCHIVED' }} {...actions} />)
-  .add('long title', () => <Task task={{ ...task, title: longTitle }} {...actions} />);
+const longTitleString = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not!`;
+
+export const LongTitle = () => (
+  <Task task={{ ...taskData, title: longTitleString }} {...actionsData} />
+);
 ```
 
 Agora que foi adicionada a estória, podemos reproduzir este caso extremo com relativa facilidade quando for necessário:
 
-[Aqui está ele no Storybook](/intro-to-storybook/addon-knobs-demo-edge-case-in-storybook.png)
+![Aqui está ele no Storybook](/intro-to-storybook/addon-knobs-demo-edge-case-in-storybook.png)
 
-Se estiverem a ser usados [testes de regressão visual](/react/pt/test/), iremos ser informados se a nossa solução eliptica for quebrada.
+Se estiverem a ser usados [testes de regressão visual](/react/pt/test/), iremos ser informados se a nossa solução elíptica for quebrada.
 Tais casos extremos considerados obscuros têm tendência a ser esquecidos!
 
 ## Fusão das alterações
@@ -135,4 +153,4 @@ Não esquecer de fundir as alterações com o git!
 
 ## Partilha de extras com a equipa
 
-Knobs é uma forma fantástica de forma a permitir que elementos não programadores brinquem com os componentes e estórias. No entanto, pode ser dificil para estes executarem o storybook nos seus ambientes locais. É por isso que uma implementação online pode ajudar em muito. No próximo capitulo iremos fazer exatamente isso!
+Knobs é uma forma fantástica de forma a permitir que elementos não programadores brinquem com os componentes e estórias. No entanto, pode ser difícil para estes executarem o Storybook nos seus ambientes locais. É por isso que uma implementação online pode ajudar em muito. No próximo capitulo iremos fazer exatamente isso!!

--- a/content/intro-to-storybook/react/zh-CN/get-started.md
+++ b/content/intro-to-storybook/react/zh-CN/get-started.md
@@ -5,6 +5,13 @@ description: '在你的开发环境下, 设置 React Storybook '
 commit: ebe2ae2
 ---
 
+<div class="aside">
+<p>
+  此翻译未更新！您可以通过单击页面底部的链接来帮助我们改进它，不仅团队会感激它，而且整个社区都会感激不尽
+</p>
+</div>
+
+
 Storybook 是在开发模式下 与 您的应用程序一起运行的. 它可以帮助您构建 UI 组件,并与 应用程序的 业务逻辑和上下文 隔离开来. 本期"学习 Storybook"适用于 **React**; `Vue和Angular`版本即将推出.
 
 ![Storybook and your app](/intro-to-storybook/storybook-relationship.jpg)

--- a/content/intro-to-storybook/react/zh-TW/get-started.md
+++ b/content/intro-to-storybook/react/zh-TW/get-started.md
@@ -5,6 +5,9 @@ description: '在你的開發環境下, 設定 React Storybook '
 commit: ebe2ae2
 ---
 
+<div class="aside"><p>
+此翻譯尚未更新！您可以通過單擊頁面底部的鏈接來幫助我們改進它，不僅團隊會感激它，而且整個社區也會感激不盡。
+</p></div>
 Storybook 是在開發模式下 與 您的應用程式一起執行的. 它可以幫助您構建 UI 元件,並與 應用程式的 業務邏輯和上下文 隔離開來. 本期"學習 Storybook"適用於 **React**; `Vue和Angular`版本即將推出.
 
 ![Storybook and your app](/intro-to-storybook/storybook-relationship.jpg)

--- a/content/intro-to-storybook/svelte/en/conclusion.md
+++ b/content/intro-to-storybook/svelte/en/conclusion.md
@@ -21,6 +21,10 @@ Want to dive deeper? Here are helpful resources.
 
 - [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) dives deep into using Storybook to visual test components. Free 31-page ebook.
 
+- [**Storybook Discord chat**](https://discord.gg/UUt2PJb) puts you in contact with the Storybook community. Get and give help to other Storybook users.
+
+- [**Storybook blog**](https://medium.com/storybookjs) showcases the latest releases and features to streamline your UI development workflow.
+
 ## Who made LearnStorybook.com?
 
 The text, code, and production were contributed by [Chroma](http://blog.hichroma.com/). The tutorial was inspired by Chroma’s popular [GraphQL + React tutorial series](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858).

--- a/content/intro-to-storybook/vue/en/conclusion.md
+++ b/content/intro-to-storybook/vue/en/conclusion.md
@@ -21,9 +21,9 @@ Want to dive deeper? Here are helpful resources.
 
 - [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) dives deep into using Storybook to visual test components. Free 31-page ebook.
 
-- [**Storybook Discord**](https://discord.gg/UUt2PJb) will put you in touch with the Storybook community. Not only offers a means to help you but for you to help the community also.
+- [**Storybook Discord chat**](https://discord.gg/UUt2PJb) puts you in contact with the Storybook community. Get and give help to other Storybook users.
 
-- [**Storybook blog**](https://medium.com/storybookjs) where you'll read about the latest changes and some techniques to further improve your development workflows with Storybook.
+- [**Storybook blog**](https://medium.com/storybookjs) showcases the latest releases and features to streamline your UI development workflow.
 
 
 ## Who made LearnStorybook.com?

--- a/content/intro-to-storybook/vue/en/conclusion.md
+++ b/content/intro-to-storybook/vue/en/conclusion.md
@@ -21,6 +21,11 @@ Want to dive deeper? Here are helpful resources.
 
 - [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) dives deep into using Storybook to visual test components. Free 31-page ebook.
 
+- [**Storybook Discord**](https://discord.gg/UUt2PJb) will put you in touch with the Storybook community. Not only offers a means to help you but for you to help the community also.
+
+- [**Storybook blog**](https://medium.com/storybookjs) where you'll read about the latest changes and some techniques to further improve your development workflows with Storybook.
+
+
 ## Who made LearnStorybook.com?
 
 The text, code, and production were contributed by [Chroma](http://blog.hichroma.com/). The tutorial was inspired by Chroma’s popular [GraphQL + React tutorial series](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858).

--- a/content/intro-to-storybook/vue/en/data.md
+++ b/content/intro-to-storybook/vue/en/data.md
@@ -59,7 +59,7 @@ export default new Vuex.Store({
 });
 ```
 
-In our top-level app component (`src/App.vue`) we can wire the store into our component heirarchy fairly easily:
+In our top-level app component (`src/App.vue`) we can wire the store into our component hierarchy fairly easily:
 
 ```html
 

--- a/content/intro-to-storybook/vue/en/get-started.md
+++ b/content/intro-to-storybook/vue/en/get-started.md
@@ -23,6 +23,11 @@ cd taskbox
 npx -p @storybook/cli sb init
 ```
 
+<div class="aside">
+Throughout this version of the tutorial, we'll be using <code>yarn</code> to run the majority of our commands. 
+If you have Yarn installed, but prefer to use <code>npm</code> instead, don't worry, you can still go through the tutorial without any issues. Just add the <code> --packageManager=npm</code> flag to the first command above and both Vue CLI and Storybook will initialize based on this. Also while you progress through the tutorial, don't forget to adjust the commands used to their <code>npm</code> counterparts.
+</div>
+
 We can quickly check that the various environments of our application are working properly:
 
 ```bash
@@ -60,15 +65,16 @@ If you want to modify the styling, the source LESS files are provided in the Git
 
 ## Add assets
 
-Add the font and icon directories by downloading them to your computer and dropping them into your repository.
+To match the intended design, you'll need to download both the font and icon directories and place its contents inside your `public` folder.
+
+<div class="aside">
+<p>We’ve used <code>svn</code> (Subversion) to easily download a folder of files from GitHub. If you don’t have subversion installed or want to just do it manually, you can grab the folders directly <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.</p></div>
 
 ```bash
 svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/icon public/icon
 svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/font public/font
 ```
 
-<div class="aside">
-<p>We’ve used <code>svn</code> (Subversion) to easily download a folder of files from GitHub. If you don’t have subversion installed or want to just do it manually, you can grab the folders directly <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.</p></div>
 
 We also need to update our storybook script to serve the `public` directory (in `package.json`):
 

--- a/content/intro-to-storybook/vue/en/simple-component.md
+++ b/content/intro-to-storybook/vue/en/simple-component.md
@@ -108,10 +108,10 @@ export const Archived = () => ({
   template: taskTemplate,
   props: {
     task: {
-      default: {
+      default: () => ({
         ...taskData,
         state: 'TASK_ARCHIVED',
-      },
+      }),
     },
   },
   methods: actionsData,
@@ -131,7 +131,7 @@ To tell Storybook about the component we are documenting, we create a `default` 
 - `title` -- how to refer to the component in the sidebar of the Storybook app,
 - `excludeStories` -- information required by the story, but should not be rendered by the Storybook app.
 
-To define our stories, we export a function for each of our test states to generate a story. The story is a function that returns a rendered element (i.e. a component class with a set of props) in a given state---exactly like a Vue [Stateless Functional Component](https://vuejs.org/v2/guide/render-function.html#Functional-Components).
+To define our stories, we export a function for each of our test states to generate a story. The story is a function that returns a rendered element (i.e. a component class with a set of props) in a given state---exactly like a [Stateless Functional Component](https://vuejs.org/v2/guide/render-function.html#Functional-Components).
 
 `action()` allows us to create a callback that appears in the **actions** panel of the Storybook UI when clicked. So when we build a pin button, we’ll be able to determine in the test UI if a button click is successful.
 
@@ -147,7 +147,7 @@ When creating a story we use a base task (`taskData`) to build out the shape of 
 
 ## Config
 
-We'll need to make a couple of changes to the Storybook configuration so it notices not only our recently created stories, but also allows us to use our CSS file.
+We'll need to make a couple of changes to the Storybook configuration so it notices not only our recently created stories, but also allows us to use the CSS file that was changed in the [previous chapter](/vue/en/get-started).
 
 Start by changing your Storybook configuration file (`.storybook/main.js`) to the following:
 

--- a/content/intro-to-storybook/vue/en/using-addons.md
+++ b/content/intro-to-storybook/vue/en/using-addons.md
@@ -93,34 +93,8 @@ export const Default = () => ({
   },
   methods: actionsData,
 });
-// pinned task state
-export const Pinned = () => ({
-  components: { Task },
-  template: taskTemplate,
-  props: {
-    task: {
-      default: () => ({
-        ...taskData,
-        state: 'TASK_PINNED',
-      }),
-    },
-  },
-  methods: actionsData,
-});
-// archived task state
-export const Archived = () => ({
-  components: { Task },
-  template: taskTemplate,
-  props: {
-    task: {
-      default: () => ({
-        ...taskData,
-        state: 'TASK_ARCHIVED',
-      }),
-    },
-  },
-  methods: actionsData,
-});
+
+// same as before
 ```
 
 Now a new "Knobs" tab should show up next to the "Action Logger" tab in the bottom pane.
@@ -167,45 +141,8 @@ Let's add a story for the long text case in `Task.stories.js`:
 
 const longTitle = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not!`;
 
-// default task state
-export const Default = () => ({
-  components: { Task },
-  template: taskTemplate,
-  props: {
-    task: {
-      default: object('task', { ...taskData }),
-    },
-  },
-  methods: actionsData,
-});
-// pinned task state
-export const Pinned = () => ({
-  components: { Task },
-  template: taskTemplate,
-  props: {
-    task: {
-      default: () => ({
-        ...taskData,
-        state: 'TASK_PINNED',
-      }),
-    },
-  },
-  methods: actionsData,
-});
-// archived task state
-export const Archived = () => ({
-  components: { Task },
-  template: taskTemplate,
-  props: {
-    task: {
-      default: () => ({
-        ...taskData,
-        state: 'TASK_ARCHIVED',
-      }),
-    },
-  },
-  methods: actionsData,
-});
+// same as before
+
 export const LongTitle = () => ({
   components: { Task },
   template: taskTemplate,

--- a/content/intro-to-storybook/vue/pt/composite-component.md
+++ b/content/intro-to-storybook/vue/pt/composite-component.md
@@ -111,7 +111,7 @@ export const Default = () => ({
   template: `<task-list :tasks="tasks" @archiveTask="onArchiveTask" @pinTask="onPinTask"/>`,
   props: {
     tasks: {
-      default: defaultTasksData
+      default: () => defaultTasksData
     }
   },
   methods: actionsData
@@ -122,7 +122,7 @@ export const WithPinnedTasks = () => ({
   template: `<task-list :tasks="tasks" @archiveTask="onArchiveTask" @pinTask="onPinTask"/>`,
   props: {
     tasks: {
-      default: withPinnedTasksData
+      default: () => withPinnedTasksData
     }
   },
   methods: actionsData

--- a/content/intro-to-storybook/vue/pt/conclusion.md
+++ b/content/intro-to-storybook/vue/pt/conclusion.md
@@ -23,9 +23,9 @@ Pretende saber mais? Aqui ficam alguns recursos que irão ajudar.
 
 - [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) aprofunda o uso de Storybook para testes visuais. Livro eletrónico livre de 31 páginas.
 
-- [**Discord do Storybook**](https://discord.gg/UUt2PJb) põe-te em contacto direto com a comunidade Storybook. Além de oferecer uma forma de te ajudar, mas também para tu ajudares a comunidade.
+- [**Discord do Storybook**](https://discord.gg/UUt2PJb) põe-te em contacto direto com a comunidade Storybook. Onde podes oferecer e receber ajuda de outros utilizadores do Storybook.
 
-- [**Blog Storybook**](https://medium.com/storybookjs) onde poderás ler acerca das mais recentes alterações e ainda algumas técnicas para melhorares o teu fluxo de desenvolvimento com o Storybook.
+- [**Blog Storybook**](https://medium.com/storybookjs) demonstra tanto as novidades acerca das versões mais recentes, como as últimas funcionalidades existentes, de forma a otimizar o teu fluxo de trabalho no desenvolvimento de interface de utilizador 
 
 ## Quem fez LearnStorybook.com?
 

--- a/content/intro-to-storybook/vue/pt/conclusion.md
+++ b/content/intro-to-storybook/vue/pt/conclusion.md
@@ -23,6 +23,10 @@ Pretende saber mais? Aqui ficam alguns recursos que irão ajudar.
 
 - [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) aprofunda o uso de Storybook para testes visuais. Livro eletrónico livre de 31 páginas.
 
+- [**Discord do Storybook**](https://discord.gg/UUt2PJb) põe-te em contacto direto com a comunidade Storybook. Além de oferecer uma forma de te ajudar, mas também para tu ajudares a comunidade.
+
+- [**Blog Storybook**](https://medium.com/storybookjs) onde poderás ler acerca das mais recentes alterações e ainda algumas técnicas para melhorares o teu fluxo de desenvolvimento com o Storybook.
+
 ## Quem fez LearnStorybook.com?
 
 

--- a/content/intro-to-storybook/vue/pt/data.md
+++ b/content/intro-to-storybook/vue/pt/data.md
@@ -173,7 +173,7 @@ export const Default = () => ({
   template: `<pure-task-list :tasks="tasks" @archiveTask="onArchiveTask" @pinTask="onPinTask"/>`,
   props: {
     tasks: {
-      default: defaultTasksData
+      default: () => defaultTasksData
     }
   },
   methods: actionsData
@@ -184,7 +184,7 @@ export const WithPinnedTasks = () => ({
   template: `<pure-task-list :tasks="tasks" @archiveTask="onArchiveTask" @pinTask="onPinTask"/>`,
   props: {
     tasks: {
-      default: withPinnedTasksData
+      default: () => withPinnedTasksData
     }
   },
   methods: actionsData

--- a/content/intro-to-storybook/vue/pt/deploy.md
+++ b/content/intro-to-storybook/vue/pt/deploy.md
@@ -76,7 +76,7 @@ O Netlify possui um serviço de implementação contínua, o que permite a imple
 
 ![Criação Site Netlify](/intro-to-storybook/netlify-create-site.png)
 
-Em seguida click no botão GitHub para ser feita a ligação entre ambos. O que permite o acesso ao repositório remoto taskbox.
+Em seguida click no botão GitHub para ser feita a ligação entre ambos. O que permite o acesso ao repositório remoto Taskbox.
 
 Seguida da seleção do repositório da lista de opções.
 

--- a/content/intro-to-storybook/vue/pt/get-started.md
+++ b/content/intro-to-storybook/vue/pt/get-started.md
@@ -26,6 +26,11 @@ cd taskbox
 npx -p @storybook/cli sb init
 ```
 
+<div class="aside">
+Ao longo desta versão do tutorial, vai ser usado o <code>yarn</code> para executar a maioria dos comandos.
+Se tiver o Yarn instalado, mas preferir usar <code>npm</code>, não há qualquer problema, pode continuar a seguir o tutorial sem problemas. Somente terá que adicionar a seguinte opção: <code> --packageManager=npm</code> ao primeiro comando mencionado acima e tanto o Vue CLI como o Storybook irão inicializar com base nesta opção. À medida que progride no tutorial, não esqueça de ajustar os comandos mencionados para os equivalentes <code>npm</code>.
+</div>
+
 Podemos rapidamente verificar que os vários ambientes da nossa aplicação estão a funcionar corretamente:
 
 ```bash

--- a/content/intro-to-storybook/vue/pt/screen.md
+++ b/content/intro-to-storybook/vue/pt/screen.md
@@ -5,7 +5,7 @@ description: 'Construção de um ecrã a partir de componentes'
 ---
 
 Tem sido focada a construção de interfaces de utilizador da base para o topo.
-Começando de forma simples e sendo adicionada complexidade á medida que a aplicação é desenvolvida. Com isto permitiu que cada componente fosse desenvolvido de forma isolada, definindo quais os requisitos de dados e "brincar" com ele em Storybook. Isto tudo sem a necessidade de instanciar um servidor ou ser necessária a construção de ecrãs!
+Começando de forma simples e sendo adicionada complexidade á medida que a aplicação é desenvolvida. Com isto permitiu que cada componente fosse desenvolvido de forma isolada, definindo quais os requisitos de dados e "brincar" com ele no Storybook. Isto tudo sem a necessidade de instanciar um servidor ou ser necessária a construção de ecrãs!
 
 Neste capitulo, irá ser acrescida um pouco mais a sofisticação, através da composição de diversos componentes, originando um ecrã, que será desenvolvido no Storybook.
 

--- a/content/intro-to-storybook/vue/pt/simple-component.md
+++ b/content/intro-to-storybook/vue/pt/simple-component.md
@@ -86,7 +86,7 @@ export const Default = () => ({
   template: taskTemplate,
   props: {
     task: {
-      default: taskData,
+      default: () => taskData,
     },
   },
   methods: actionsData,
@@ -97,10 +97,10 @@ export const Pinned = () => ({
   template: taskTemplate,
   props: {
     task: {
-      default: {
+      default: () => ({
         ...taskData,
         state: 'TASK_PINNED',
-      },
+      }),
     },
   },
   methods: actionsData,
@@ -109,13 +109,13 @@ export const Pinned = () => ({
 export const Archived = () => ({
   components: { Task },
   template: taskTemplate,
-   props: {
+  props: {
     task: {
-      default: {
+      default: () => ({
         ...taskData,
-        state: "TASK_ARCHIVED"
-      }
-    }
+        state: 'TASK_ARCHIVED',
+      }),
+    },
   },
   methods: actionsData,
 });
@@ -164,7 +164,7 @@ module.exports = {
 
 ```
 
-Após efetuar esta alteração, uma vez mais dentro da pasta `.storybook`, crie um novo ficheiro (ou arquivo) chamado `preview.js` com o seguinte conteúdo:
+Após efetuar esta alteração, uma vez mais dentro da pasta (ou diretório) `.storybook`, crie um novo ficheiro (ou arquivo) chamado `preview.js` com o seguinte conteúdo:
 
 ```javascript
 // .storybook/preview.js

--- a/content/intro-to-storybook/vue/pt/using-addons.md
+++ b/content/intro-to-storybook/vue/pt/using-addons.md
@@ -41,7 +41,7 @@ Registe o Knobs no ficheiro `.storybook/main.js`.
 
 module.exports = {
   stories: ['../src/components/**/*.stories.js'],
-  addons: ['@storybook/addon-actions', '@storybook/addon-links', '@storybook/addon-knobs'],
+  addons: ['@storybook/addon-actions', '@storybook/addon-knobs', '@storybook/addon-links'],
 };
 ```
 
@@ -93,39 +93,13 @@ export const Default = () => ({
   },
   methods: actionsData,
 });
-// pinned task state
-export const Pinned = () => ({
-  components: { Task },
-  template: taskTemplate,
-  props: {
-    task: {
-      default: {
-        ...taskData,
-        state: 'TASK_PINNED',
-      },
-    },
-  },
-  methods: actionsData,
-});
-// archived task state
-export const Archived = () => ({
-  components: { Task },
-  template: taskTemplate,
-  props: {
-    task: {
-      default: {
-        ...taskData,
-        state: 'TASK_ARCHIVED',
-      },
-    },
-  },
-  methods: actionsData,
-});
+
+// same as before
 ```
 
 Agora um novo item denominado "Knobs" deverá surgir próximo do "Action Logger" no painel inferior da aplicação.
 
-Tal documentado [aqui](https://github.com/storybooks/storybook/tree/master/addons/knobs#object), este tipo aceita uma "etiqueta" e um objeto padrão como parâmetros.
+Tal como documentado [aqui](https://github.com/storybooks/storybook/tree/master/addons/knobs#object), este tipo aceita uma "etiqueta" e um objeto padrão como parâmetros.
 A etiqueta é constante e irá aparecer no painel de extras á esquerda do campo de texto. O objeto fornecido será representado como um blob JSON que pode ser editado. Desde que seja submetido JSON válido, o componente irá ajustar-se com base na informação fornecida ao objeto!
 
 ## Os extras aumentam a esfera de ação do teu Storybook
@@ -169,54 +143,17 @@ Vamos então adicionar uma estória para o caso da ocorrência de um texto grand
 
 const longTitle = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not!`;
 
-// default task state
-export const Default = () => ({
-  components: { Task },
-  template: taskTemplate,
-  props: {
-    task: {
-      default: object('task', { ...taskData }),
-    },
-  },
-  methods: actionsData,
-});
-// pinned task state
-export const Pinned = () => ({
-  components: { Task },
-  template: taskTemplate,
-  props: {
-    task: {
-      default: {
-        ...taskData,
-        state: 'TASK_PINNED',
-      },
-    },
-  },
-  methods: actionsData,
-});
-// archived task state
-export const Archived = () => ({
-  components: { Task },
-  template: taskTemplate,
-  props: {
-    task: {
-      default: {
-        ...taskData,
-        state: 'TASK_ARCHIVED',
-      },
-    },
-  },
-  methods: actionsData,
-});
+// same as before
+
 export const LongTitle = () => ({
   components: { Task },
   template: taskTemplate,
   props: {
     task: {
-      default: {
+      default: () => ({
         ...taskData,
         title: longTitle,
-      },
+      }),
     },
   },
   methods: actionsData,


### PR DESCRIPTION
With this pr the issue #153 is addressed in it's both variants. The initial cause for the issue and what was brough to the attention with the [following comment](https://github.com/chromaui/learnstorybook.com/issues/153#issuecomment-584207942)

What was done:

Going by Framework
- React
    - Conclusion
  Both english and portuguese versions include a mention to the discord channel and blog for better discoverability.
    - Data 
    In both english and portuguese versions the reference to package json when installing redux was removed. Expanded the ending note with a mention to run the tests with the flag that is introduced in the end of the get-started section.
   - Deploy
      shortened and with that simplified the exporting as a static app section, GitHub section was reworded to match the existing versions. As they abide by the same convention. Removed lingering presences of the `.storybook-static` folder, the portuguese translation follows suit.
   - Get Started
     Added some wording to address the issue that kickstarted this whole endeavour. The portuguese translation follows suit.
   - Screen
     Updated `app.js` code snippet to match the current one. The portuguese translation follows suit.
   - Simple Component
      Unified the whole code snippets to a single approach. Updated the `.storybook/main.js` code snippet to it's most accurate one. The portuguese translation was updated to match the current one.
   - Test
      Moved chromatic instalation reference to a development dependency per convention. The portuguese translation follows suit.
    - Using Addons
       Moved knobs to a development dependency and updated `.storybook/main.js` to the most accurate one. Once again the portuguese translation was adjusted to match version 5.3 and these changes.
   - Some of the translations, more specifically: es, zh-cn, zh-tw were changed to include a note mentioning that the translation is not accurate. The wording is the equivalent to the one used in the angular version i mentioned in the issue that is currently addressing this. A side note, i used google translator to address both chinese translations, probably the wording might be a bit off and if is, i appologize for that. But i decided to have something there to avoid misleading people as the translation is no longer accurate.
   - Create addons
      - The entire section was reworder to match the current state of Storybook. The code snippets aswell. The pt translation follows suit.

- Vue
  - Get Started
     I did a bit of research and the same approach can be taken with this framework as for React. I added a note mentioning that the reader can alternatively use npm if he's willing to do so. The portuguese translation also covers this.
  - Simple Component
     Fixed some missing factory functions in some code snippets that were brought to the attention in another pr. Removed the Vue reference when dealing with Stateless components. This in order to make the sentence more simple. The reader already knows he's in a Vue related tutorial, no need to insist on it and keep him engaged. The portuguese translation is also updated.
  - Using Addons
     The code snippets were cut down to match the React Version. This was something that i overlooked. And there's no need on having a big code snippet when the intention is to keep the reader's focus on the important item. The portuguese translation is updated aswell.
   - Conclusion
      The same items were introduced here as in the React version in both the english version and portuguese translations.
    - Composite Component
        The portuguese translation code snippets were updated to match the original version.
     - Data
         Code snippets were updated to match the current english version.
     - Deploy
         There is some minor rewording that was made in the portuguese translation


I'd like to bring to the attention of @IvanSotelo as you spearheaded the spanish translation this pr. More specifically the Vue edition. If this goes through if you don't mind adjust accordingly. From the top of my head, the only items of concern are the Get started section, conclusion and using addons. 

Also @renet @jonathanherdt for their fantastic job on translating the React Version of the tutorial. If both of you are up for it, when this pr goes through it would awesome if you both coordinated and make the adjustments to the German translation. 
Also @Robin-Hoodie, @ghengeveld, more specifically @Robin-Hoodie as you spearheaded the Dutch translation, once and if this pr goes through if you're ok with it it would be awesome if you could make the adjustments to the Dutch translation. @ndelangen i'm aware that you're extremely busy working on Storybook but when and if the translation goes through it would be awesome if you once again proof read it. Sounds good to all of you?

Feel free to provide feedback