### PR TITLE
Chore: (intro to storybook): Updated english version of the tutorial per latest Storybook and Expo versions

### DIFF
--- a/content/intro-to-storybook/react-native/en/composite-component.md
+++ b/content/intro-to-storybook/react-native/en/composite-component.md
@@ -23,9 +23,9 @@ A composite component isn’t much different than the basic components it contai
 Start with a rough implementation of the `TaskList`. You’ll need to import the `Task` component from earlier and pass in the attributes and actions as inputs.
 
 ```javascript
-// components/TaskList.js
 
-import React from 'react';
+// components/TaskList.js
+import * as React from 'react';
 import Task from './Task';
 import { FlatList, Text, SafeAreaView } from 'react-native';
 import { styles } from "../constants/globalStyles";
@@ -68,8 +68,9 @@ export default TaskList;
 Next create `Tasklist`’s test states in the story file.
 
 ```javascript
+
 // components/TaskList.stories.js
-import React from 'react';
+import * as React from 'react';
 import { View } from 'react-native';
 import { styles } from '../constants/globalStyles';
 import { storiesOf } from '@storybook/react-native';
@@ -110,7 +111,8 @@ Don't forget that this story also needs to be added to `storybook/index.js` so t
 Change the `configure()` method to the following:
 
 ```javascript
-// import stories
+
+// storybook/config.js
 configure(() => {
   require('../components/Task.stories.js');
   require('../components/TaskList.stories.js');
@@ -135,11 +137,11 @@ For the loading edge case, we're going to create a new component that will displ
 Create a new file called `LoadingRow.js` with the following content:
 
 ```javascript
-// components/LoadingRow.js
 
+// components/LoadingRow.js
 import React, { useState, useEffect } from 'react';
 import { Animated, Text, View, Easing, SafeAreaView } from 'react-native';
-import { styles } from '../globalStyles';
+import { styles } from '../constants/globalStyles';
 
 const GlowView = props => {
   const [glowAnim] = useState(new Animated.Value(0));
@@ -184,9 +186,9 @@ export default LoadingRow;
 And update `TaskList.js` to the following:
 
 ```javascript
-// src/components/TaskList.js
 
-import React from 'react';
+// src/components/TaskList.js
+import * as React from 'react';
 import Task from './Task';
 import PercolateIcons from '../constants/Percolate';
 import LoadingRow from './LoadingRow';
@@ -256,9 +258,9 @@ Note the position of the pinned item in the list. We want the pinned item to ren
 As the component grows, so too do input requirements. Define the prop requirements of `TaskList`. Because `Task` is a child component, make sure to provide data in the right shape to render it. To save time and headache, reuse the propTypes you defined in `Task` earlier.
 
 ```javascript
-// src/components/TaskList.js
 
-import React from 'react';
+// src/components/TaskList.js
+import * as React from 'react';
 import PropTypes from 'prop-types';
 
 import Task from './Task';
@@ -298,19 +300,20 @@ In our case, we want our `TaskList` to render any pinned tasks **before** unpinn
 
 So, to avoid this problem, we can use Jest to render the story to the DOM and run some DOM querying code to verify salient features of the output.
 
-Create a test file called `__tests__/TaskList.test.js`. Here, we’ll build out our tests that make assertions about the output.
+Create a test file called `components/__tests__/TaskList.test.js`. Here, we’ll build out our tests that make assertions about the output.
 
 ```javascript
-// __tests__/TaskList.test.js
-import React from 'react';
-import renderer from 'react-test-renderer';
-import TaskList from '../components/TaskList';
-import { withPinnedTasks } from '../components/TaskList.stories';
-import Task from '../components/Task';
+
+// components/__tests__/TaskList.test.js
+import * as React from 'react';
+import {create} from 'react-test-renderer';
+import TaskList from '../TaskList'
+import { withPinnedTasks } from '../TaskList.stories';
+import Task from '../Task';
 describe('TaskList', () => {
   it('renders pinned tasks at the start of the list', () => {
     const events = { onPinTask: jest.fn(), onArchiveTask: jest.fn() };
-    const tree = renderer.create(<TaskList tasks={withPinnedTasks} {...events} />);
+    const tree = create(<TaskList tasks={withPinnedTasks} {...events} />);
     const rootElement = tree.root;
     const listofTasks = rootElement.findAllByType(Task);
     expect(listofTasks[0].props.task.title).toBe('Task 6 (pinned)');
@@ -322,4 +325,4 @@ describe('TaskList', () => {
 
 Note that we’ve been able to reuse the `withPinnedTasks` list of tasks in both story and unit test; in this way we can continue to leverage an existing resource (the examples that represent interesting configurations of a component) in many ways.
 
-Notice as well that this test is quite brittle. It's possible that as the project matures, and the exact implementation of the `Task` changes --perhaps using a different styling prop or a `Text` rather than an `TextInput`--the test will fail, and need to be updated. This is not necessarily a problem, but rather an indication to be careful about liberally using unit tests for UI. They're not easy to maintain. Instead rely on visual, snapshot, and visual regression (see [testing chapter](/intro-to-storybook/react-native/en/test/)) tests where possible.
+Notice as well that this test is quite brittle. It's possible that as the project matures, and the exact implementation of the `Task` changes --perhaps using a different styling prop or a `Text` rather than an `TextInput`--the test will fail, and need to be updated. This is not necessarily a problem, but rather an indication to be careful about liberally using unit tests for UI. They're not easy to maintain. Instead rely on visual, snapshot tests where possible.

--- a/content/intro-to-storybook/react-native/en/conclusion.md
+++ b/content/intro-to-storybook/react-native/en/conclusion.md
@@ -9,7 +9,7 @@ Congratulations! You created your first UI in Storybook. Along the way you learn
 <br/>
 [🌎 **Deployed Storybook**](https://clever-banach-415c03.netlify.com/)
 
-Storybook is a powerful tool for React, Vue, and Angular. It has a thriving developer community and a wealth of addons. This introduction scratches the surface of what’s possible. We’re confident that once you adopt Storybook, you’ll be impressed by how productive it is to build durable UIs.
+Storybook is a powerful tool for React, Vue, Angular, Svelte and many others frameworks. It has a thriving developer community and a wealth of addons. This introduction scratches the surface of what’s possible. We’re confident that once you adopt Storybook, you’ll be impressed by how productive it is to build durable UIs.
 
 ## Learn more
 

--- a/content/intro-to-storybook/react-native/en/conclusion.md
+++ b/content/intro-to-storybook/react-native/en/conclusion.md
@@ -21,6 +21,10 @@ Want to dive deeper? Here are helpful resources.
 
 - [**Visual Testing Handbook**](https://www.chromaticqa.com/book/visual-testing-handbook) dives deep into using Storybook to visual test components. Free 31-page ebook.
 
+- [**Storybook Discord chat**](https://discord.gg/UUt2PJb) puts you in contact with the Storybook community. Get and give help to other Storybook users.
+
+- [**Storybook blog**](https://medium.com/storybookjs) showcases the latest releases and features to streamline your UI development workflow.
+
 ## Who made LearnStorybook.com?
 
 The text, code, and production were contributed by [Chroma](http://blog.hichroma.com/). The tutorial was inspired by Chroma’s popular [GraphQL + React tutorial series](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858).

--- a/content/intro-to-storybook/react-native/en/data.md
+++ b/content/intro-to-storybook/react-native/en/data.md
@@ -23,6 +23,7 @@ yarn add react-redux redux
 First we’ll construct a simple Redux store that responds to actions that change the state of tasks, in a file called `lib/redux.js` (intentionally kept simple):
 
 ```javascript
+
 // lib/redux.js
 
 // A simple redux store/actions/reducer implementation.
@@ -81,7 +82,9 @@ Then we'll update our `TaskList` to read data out of the store. First let's move
 In `components/PureTaskList.js`:
 
 ```javascript
-import React from 'react';
+
+//components/PureTaskList.js
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import Task from './Task';
 import PercolateIcons from '../constants/Percolate';
@@ -110,7 +113,9 @@ export default PureTaskList;
 In `components/TaskList.js`:
 
 ```javascript
-import React from 'react';
+
+// components/TaskList.js
+import * as React from 'react';
 import PureTaskList from './PureTaskList';
 import { connect } from 'react-redux';
 import { archiveTask, pinTask } from '../lib/redux';
@@ -137,9 +142,9 @@ export default connect(
 The reason to keep the presentational version of the `TaskList` separate is because it is easier to test and isolate. As it doesn't rely on the presence of a store it is much easier to deal with from a testing perspective. Let's rename `components/TaskList.stories.js` into `components/PureTaskList.stories.js`, and ensure our stories use the presentational version:
 
 ```javascript
-// components/PureTaskList.stories.js
 
-import React from 'react';
+// components/PureTaskList.stories.js
+import * as React from 'react';
 import { View } from 'react-native';
 import { styles } from '../constants/globalStyles';
 import { storiesOf } from '@storybook/react-native';
@@ -178,22 +183,22 @@ storiesOf('PureTaskList', module)
 
 Similarly, we need to use `PureTaskList` in our Jest test:
 
-```js
-// __tests__/TaskList.test.js
-import React from 'react';
-import renderer from 'react-test-renderer';
-import PureTaskList from '../components/PureTaskList';
-import { withPinnedTasks } from '../components/PureTaskList.stories';
-import Task from '../components/Task';
-describe('TaskList',()=>{
-    it('renders pinned tasks at the start of the list',()=>{
-        const events = { onPinTask: jest.fn(), onArchiveTask: jest.fn() };
-        const tree = renderer.create(<PureTaskList tasks={withPinnedTasks} {...events} />)
-        const rootElement= tree.root;
-        const listofTasks= rootElement.findAllByType(Task)
-        expect(listofTasks[0].props.task.title).toBe("Task 6 (pinned)")
-    })
-})
+```javascript
+
+// components/__tests__/TaskList.test.js
+import * as React from 'react';
+import {create} from 'react-test-renderer';
+import PureTaskList from '../PureTaskList';
+import { withPinnedTasks } from '../PureTaskList.stories';
+import Task from '../Task';
+describe('TaskList', () => {
+  it('renders pinned tasks at the start of the list', () => {
+    const events = { onPinTask: jest.fn(), onArchiveTask: jest.fn() };
+    const tree = create(<PureTaskList tasks={withPinnedTasks} {...events} />);
+    const rootElement = tree.root;
+    const listofTasks = rootElement.findAllByType(Task);
+    expect(listofTasks[0].props.task.title).toBe('Task 6 (pinned)');
+  });
 });
 ```
 

--- a/content/intro-to-storybook/react-native/en/data.md
+++ b/content/intro-to-storybook/react-native/en/data.md
@@ -14,7 +14,7 @@ Our `TaskList` component as currently written is “presentational” (see [this
 
 This example uses [Redux](https://redux.js.org/), the most popular React library for storing data, to build a simple data model for our app. However, the pattern used here applies just as well to other data management libraries like [Apollo](https://www.apollographql.com/client/) and [MobX](https://mobx.js.org/).
 
-Add some new dependencies on `package.json` with:
+Add the necessary dependencies to your project with:
 
 ```bash
 yarn add react-redux redux

--- a/content/intro-to-storybook/react-native/en/get-started.md
+++ b/content/intro-to-storybook/react-native/en/get-started.md
@@ -4,13 +4,13 @@ tocTitle: 'Get started'
 description: 'Setup Storybook in your development environment'
 ---
 
-Storybook runs alongside your app in development mode. It helps you build UI components isolated from the business logic and context of your app. This edition of Learn Storybook is for React Native; other editions exist for [Vue](/vue/en/get-started) and [Angular](/angular/en/get-started) and [React](/react/en/get-started).
+Storybook runs alongside your app in development mode. It helps you build UI components isolated from the business logic and context of your app. This edition of Learn Storybook is for React Native; other editions exist for [React](/react/en/get-started), [Vue](/vue/en/get-started), [Angular](/angular/en/get-started) and [Svelte](/svelte/en/get-started).
 
 ![Storybook and your app](/intro-to-storybook/storybook-relationship.jpg)
 
 ## Setup React Native Storybook
 
-We’ll need to follow a few steps to get the build process set up in your environment. To start with, we want to use [Expo](https://expo.io/tools) to setup our build system, and enable [Storybook](https://storybook.js.org/) and [Jest](https://facebook.github.io/jest/) testing in our created app. 
+We’ll need to follow a few steps to get the build process set up in your environment. To start with, we want to use [Expo](https://expo.io/tools) to setup our build system, and enable [Storybook](https://storybook.js.org/) and [Jest](https://facebook.github.io/jest/) testing in our created app.
 
 Before diving into the tutorial, take into account the following considerations:
 
@@ -18,8 +18,7 @@ Before diving into the tutorial, take into account the following considerations:
 
 - You'll need a working simulator or a physical device correctly setup to maximize your experience, [react-native docs](https://facebook.github.io/react-native/docs/getting-started) has more detailed instructions on how to achieve this.
 
-- Throughout this tutorial, yarn will be used. Should you want to use npm, select the appropriate option during when you're initializing the app and replace all subsequent commands with npm.
-
+- Throughout this tutorial, <code>yarn</code> will be used. Should you want to use <code>npm</code>, select the appropriate option when you're initializing the app and replace all subsequent commands with npm.
 
 With that out of the way, let’s run the following commands:
 
@@ -49,6 +48,7 @@ yarn add -D @storybook/addon-ondevice-actions
 Change `storybook/rn-addons.js` to the following:
 
 ```javascript
+// storybook/rn-addons.js
 import '@storybook/addon-ondevice-actions/register';
 ```
 
@@ -71,7 +71,7 @@ Update the `jest` field in `package.json`:
 "jest": {
     "preset": "jest-expo",
     "transformIgnorePatterns": [
-      "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|sentry-expo|native-base)"
+      "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base)"
     ],
     "setupFilesAfterEnv": [
       "<rootDir>/__mocks__/globalMock.js"
@@ -100,7 +100,11 @@ Depending on what part of the app you’re working on, you may want to run one o
 
 Taskbox reuses design elements from the GraphQL and React Tutorial [example app](https://blog.hichroma.com/graphql-react-tutorial-part-1-6-d0691af25858), so we won’t need to write CSS in this tutorial. Contrary to the other tutorials, we wont copy over the compiled CSS, as React Native handles styling in a whole different way, but instead create a new file `constants/globalStyles.js` and add the following:
 
+<details>
+  <summary>Click to expand and see the full file contents</summary>
+
 ```javascript
+// /constants/globalStyles.js
 import { StyleSheet } from 'react-native';
 export const styles = StyleSheet.create({
   container: {
@@ -228,6 +232,8 @@ export const styles = StyleSheet.create({
 });
 ```
 
+</details>
+
 ![Taskbox UI](/intro-to-storybook/ss-browserchrome-taskbox-learnstorybook.png)
 
 <div class="aside">
@@ -236,39 +242,43 @@ If you want to modify the styling, the source LESS files are provided in the Git
 
 ## Add assets
 
-Add the font and icon directories by downloading them to your computer and dropping them into your repository.
+To match the intended design, you'll need to download both the font and icon directories and place them inside the `assets` folder.
+
+<div class="aside">
+<p>We’ve used <code>svn</code> (Subversion) to easily download a folder of files from GitHub. If you don’t have subversion installed or want to just do it manually, you can grab the icons folder directly <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a> and the font <a href="https://github.com/google/fonts/tree/master/ofl/nunitosans">here</a>.</p></div>
 
 ```bash
 svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/icon assets/icon
-svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/font assets/font
+svn export https://github.com/google/fonts/trunk/ofl/nunitosans assets/font
 ```
-
-<div class="aside">
-<p>We’ve used <code>svn</code> (Subversion) to easily download a folder of files from GitHub. If you don’t have subversion installed or want to just do it manually, you can grab the folders directly <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.</p></div>
 
 Next the assets need to be loaded into the app, for that we're going to update `App.js` to the following:
 
 ```javascript
 // App.js
+async function loadResourcesAndDataAsync() {
+  try {
+    SplashScreen.preventAutoHide();
 
-async function loadResourcesAsync() {
-  await Promise.all([
-    Asset.loadAsync([
-      require('./assets/images/robot-dev.png'),
-      require('./assets/images/robot-prod.png'),
-    ]),
-    Font.loadAsync({
-      // This is the font that we are using for our tab bar
+    // Load our initial navigation state
+    setInitialNavigationState(await getInitialState());
+
+    // Load fonts
+    await Font.loadAsync({
       ...Ionicons.font,
-      // We include SpaceMono because we use it in HomeScreen.js. Feel free to
-      // remove this if you are not using it in your app
       'space-mono': require('./assets/fonts/SpaceMono-Regular.ttf'),
-      'percolate': require('./assets/icon/percolate.ttf'),
+      percolate: require('./assets/icon/percolate.ttf'),
       'NunitoSans-Bold': require('./assets/font/NunitoSans-Bold.ttf'),
       'NunitoSans-Italic': require('./assets/font/NunitoSans-Italic.ttf'),
-      'NunitoSans': require('./assets/font/NunitoSans-Regular.ttf'),
-    }),
-  ]);
+      NunitoSans: require('./assets/font/NunitoSans-Regular.ttf'),
+    });
+  } catch (e) {
+    // We might want to provide this error information to an error reporting service
+    console.warn(e);
+  } finally {
+    setLoadingComplete(true);
+    SplashScreen.hide();
+  }
 }
 ```
 
@@ -276,7 +286,11 @@ In order to use the icons from the `percolate` font safely and correctly in Reac
 
 Create a new file `/constants/Percolate.js` with the following:
 
+<details>
+  <summary>Click to expand and see the full file contents</summary>
+
 ```javascript
+// constants/Percolate.js
 /**
  * PercolateIcons icon set component.
  * Usage: <PercolateIcons name="icon-name" size={20} color="#4F8EF7" />
@@ -284,135 +298,135 @@ Create a new file `/constants/Percolate.js` with the following:
 
 import { createIconSet } from '@expo/vector-icons';
 const glyphMap = {
-  'graphql': 59658,
-  'redux': 59656,
-  'grid': 59657,
-  'redirect': 59655,
-  'grow': 59651,
-  'lightning': 59652,
+  graphql: 59658,
+  redux: 59656,
+  grid: 59657,
+  redirect: 59655,
+  grow: 59651,
+  lightning: 59652,
   'request-change': 59653,
-  'transfer': 59654,
-  'calendar': 59650,
-  'sidebar': 59648,
-  'tablet': 59649,
-  'atmosphere': 58993,
-  'browser': 58994,
-  'database': 58995,
+  transfer: 59654,
+  calendar: 59650,
+  sidebar: 59648,
+  tablet: 59649,
+  atmosphere: 58993,
+  browser: 58994,
+  database: 58995,
   'expand-alt': 58996,
-  'mobile': 58997,
-  'watch': 58998,
-  'home': 58880,
+  mobile: 58997,
+  watch: 58998,
+  home: 58880,
   'user-alt': 58881,
-  'user': 58882,
+  user: 58882,
   'user-add': 58883,
-  'users': 58884,
-  'profile': 58885,
-  'bookmark': 58886,
+  users: 58884,
+  profile: 58885,
+  bookmark: 58886,
   'bookmark-hollow': 58887,
-  'star': 58888,
+  star: 58888,
   'star-hollow': 58889,
-  'circle': 58890,
+  circle: 58890,
   'circle-hollow': 58891,
-  'heart': 58892,
+  heart: 58892,
   'heart-hollow': 58893,
   'face-happy': 58894,
   'face-sad': 58895,
   'face-neutral': 58896,
-  'lock': 58897,
-  'unlock': 58898,
-  'key': 58899,
+  lock: 58897,
+  unlock: 58898,
+  key: 58899,
   'arrow-left-alt': 58900,
   'arrow-right-alt': 58901,
-  'sync': 58902,
-  'reply': 58903,
-  'expand': 58904,
+  sync: 58902,
+  reply: 58903,
+  expand: 58904,
   'arrow-left': 58905,
   'arrow-up': 58906,
   'arrow-down': 58907,
   'arrow-right': 58908,
   'chevron-down': 58909,
-  'back': 58910,
-  'download': 58911,
-  'upload': 58912,
-  'proceed': 58913,
-  'info': 58914,
-  'question': 58915,
-  'alert': 58916,
-  'edit': 58917,
-  'paintbrush': 58918,
-  'close': 58919,
-  'trash': 58920,
-  'cross': 58921,
-  'delete': 58922,
-  'power': 58923,
-  'add': 58924,
-  'plus': 58925,
-  'document': 58926,
+  back: 58910,
+  download: 58911,
+  upload: 58912,
+  proceed: 58913,
+  info: 58914,
+  question: 58915,
+  alert: 58916,
+  edit: 58917,
+  paintbrush: 58918,
+  close: 58919,
+  trash: 58920,
+  cross: 58921,
+  delete: 58922,
+  power: 58923,
+  add: 58924,
+  plus: 58925,
+  document: 58926,
   'graph-line': 58927,
   'doc-chart': 58928,
   'doc-list': 58929,
-  'category': 58930,
-  'copy': 58931,
-  'book': 58932,
-  'certificate': 58934,
-  'print': 58935,
+  category: 58930,
+  copy: 58931,
+  book: 58932,
+  certificate: 58934,
+  print: 58935,
   'list-unordered': 58936,
   'graph-bar': 58937,
-  'menu': 58938,
-  'filter': 58939,
-  'ellipsis': 58940,
-  'cog': 58941,
-  'wrench': 58942,
-  'nut': 58943,
-  'camera': 58944,
-  'eye': 58945,
-  'photo': 58946,
-  'video': 58947,
-  'speaker': 58948,
-  'phone': 58949,
-  'flag': 58950,
-  'pin': 58951,
-  'compass': 58952,
-  'globe': 58953,
-  'location': 58954,
-  'search': 58955,
-  'timer': 58956,
-  'time': 58957,
-  'dashboard': 58958,
-  'hourglass': 58959,
-  'play': 58960,
-  'stop': 58961,
-  'email': 58962,
-  'comment': 58963,
-  'link': 58964,
-  'paperclip': 58965,
-  'box': 58966,
-  'structure': 58967,
-  'commit': 58968,
-  'cpu': 58969,
-  'memory': 58970,
-  'outbox': 58971,
-  'share': 58972,
-  'button': 58973,
-  'check': 58974,
-  'form': 58975,
-  'admin': 58976,
-  'paragraph': 58977,
-  'bell': 58978,
-  'rss': 58979,
-  'basket': 58980,
-  'credit': 58981,
-  'support': 58982,
-  'shield': 58983,
-  'beaker': 58984,
-  'google': 58985,
-  'gdrive': 58986,
-  'youtube': 58987,
-  'facebook': 58988,
+  menu: 58938,
+  filter: 58939,
+  ellipsis: 58940,
+  cog: 58941,
+  wrench: 58942,
+  nut: 58943,
+  camera: 58944,
+  eye: 58945,
+  photo: 58946,
+  video: 58947,
+  speaker: 58948,
+  phone: 58949,
+  flag: 58950,
+  pin: 58951,
+  compass: 58952,
+  globe: 58953,
+  location: 58954,
+  search: 58955,
+  timer: 58956,
+  time: 58957,
+  dashboard: 58958,
+  hourglass: 58959,
+  play: 58960,
+  stop: 58961,
+  email: 58962,
+  comment: 58963,
+  link: 58964,
+  paperclip: 58965,
+  box: 58966,
+  structure: 58967,
+  commit: 58968,
+  cpu: 58969,
+  memory: 58970,
+  outbox: 58971,
+  share: 58972,
+  button: 58973,
+  check: 58974,
+  form: 58975,
+  admin: 58976,
+  paragraph: 58977,
+  bell: 58978,
+  rss: 58979,
+  basket: 58980,
+  credit: 58981,
+  support: 58982,
+  shield: 58983,
+  beaker: 58984,
+  google: 58985,
+  gdrive: 58986,
+  youtube: 58987,
+  facebook: 58988,
   'thumbs-up': 58989,
-  'twitter': 58990,
-  'github': 58991,
-  'meteor': 58992,
+  twitter: 58990,
+  github: 58991,
+  meteor: 58992,
 };
 
 const iconSet = createIconSet(glyphMap, 'percolate');
@@ -426,82 +440,89 @@ export const ToolbarAndroid = iconSet.ToolbarAndroid;
 export const getImageSource = iconSet.getImageSource;
 ```
 
-In order to see Storybook in React Native we're going to update `screens\SettingsScreen.js` to the following:
+</details>
+
+In order to see Storybook in React Native we're going to update `screens/LinksScreen.js` to the following:
 
 ```javascript
-import React from 'react';
-import StorybookUIRoot from '../storybook/';
-export default function SettingsScreen() {
+// screens/LinksScreen.js
+import * as React from 'react';
+import StorybookUIRoot from '../storybook';
+
+export default function LinksScreen() {
   return <StorybookUIRoot />;
 }
-
-SettingsScreen.navigationOptions = {
-  title: 'Storybook',
-};
 ```
 
-And finally `navigation\MainTabNavigator.js` to the following:
+And finally `navigation/BottomTabNavigator.js` to the following:
 
 ```javascript
-import React from 'react';
-import { Platform } from 'react-native';
-import { createStackNavigator, createBottomTabNavigator } from 'react-navigation';
+// navigation/BottomTabNavigator.js
+import * as React from 'react';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import TabBarIcon from '../components/TabBarIcon';
 import HomeScreen from '../screens/HomeScreen';
-import SettingsScreen from '../screens/SettingsScreen';
+import LinksScreen from '../screens/LinksScreen';
 
-const config = Platform.select({
-  web: { headerMode: 'screen' },
-  default: {},
-});
+const BottomTab = createBottomTabNavigator();
+const INITIAL_ROUTE_NAME = 'Home';
 
-const HomeStack = createStackNavigator(
-  {
-    Home: HomeScreen,
-  },
-  config
-);
+export default function BottomTabNavigator({ navigation, route }) {
+  navigation.setOptions({ headerTitle: getHeaderTitle(route) });
+  return (
+    <BottomTab.Navigator initialRouteName={INITIAL_ROUTE_NAME}>
+      <BottomTab.Screen
+        name="Taskbox"
+        component={HomeScreen}
+        options={{
+          title: 'Taskbox',
+          tabBarIcon: ({ focused }) => <TabBarIcon focused={focused} name="md-code-working" />,
+        }}
+      />
+      <BottomTab.Screen
+        name="Links"
+        component={LinksScreen}
+        options={{
+          title: 'Storybook',
+          tabBarIcon: ({ focused }) => <TabBarIcon focused={focused} name="md-book" />,
+        }}
+      />
+    </BottomTab.Navigator>
+  );
+}
 
-HomeStack.navigationOptions = {
-  tabBarLabel: 'Home',
-  tabBarIcon: ({ focused }) => (
-    <TabBarIcon
-      focused={focused}
-      name={
-        Platform.OS === 'ios'
-          ? `ios-information-circle${focused ? '' : '-outline'}`
-          : 'md-information-circle'
-      }
-    />
-  ),
-};
+function getHeaderTitle(route) {
+  const routeName = route.state?.routes[route.state.index]?.name ?? INITIAL_ROUTE_NAME;
 
-HomeStack.path = '';
-
-const SettingsStack = createStackNavigator(
-  {
-    Settings: SettingsScreen,
-  },
-  config
-);
-
-SettingsStack.navigationOptions = {
-  tabBarLabel: 'Storybook',
-  tabBarIcon: ({ focused }) => (
-    <TabBarIcon focused={focused} name={Platform.OS === 'ios' ? 'ios-options' : 'md-options'} />
-  ),
-};
-
-SettingsStack.path = '';
-
-const tabNavigator = createBottomTabNavigator({
-  HomeStack,
-  SettingsStack,
-});
-
-tabNavigator.path = '';
-
-export default tabNavigator;
+  switch (routeName) {
+    case 'Home':
+      return 'How to get started';
+    case 'Links':
+      return 'Your Storybook';
+  }
+}
 ```
+
+And finally, we'll need to make a small change to our Storybook configuration. As we're using Expo to build our app, we can safely remove some items from the configuration as they are not required. Turning the file contents into the following:
+
+```javascript
+// /storybook/index.js
+import { getStorybookUI, configure } from '@storybook/react-native';
+
+import './rn-addons';
+
+// import stories
+configure(() => {
+  require('./stories');
+}, module);
+
+const StorybookUIRoot = getStorybookUI({
+  asyncStorage: null,
+});
+
+export default StorybookUIRoot;
+```
+
+<div class="aside"><p>We're adding the <code>asyncStorage:null</code> due to the fact that starting with React Native 0.59 Async Storage was deprecated. Should you need to use it in your own app, you'll have to add it manually by installing <code>@react-native-community/async-storage</code> package and adjust the code above accordingly. You can read more about how to setup Storybook with Async Storage in <a href="https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#react-native-async-storage">here</a>. As the tutorial will not use any of the features of Async Storage, we can safely add this element to Storybook configuration.</p></div>
 
 After adding styling and assets, the app will render a bit strangely. That’s OK. We aren’t working on the app right now. We’re starting off with building our first component!

--- a/content/intro-to-storybook/react-native/en/screen.md
+++ b/content/intro-to-storybook/react-native/en/screen.md
@@ -13,8 +13,9 @@ In this chapter we continue to increase the sophistication by combining componen
 As our app is very simple, the screen we’ll build is pretty trivial, simply wrapping the `TaskList` component (which supplies its own data via Redux) in some layout and pulling a top-level `error` field out of redux (let's assume we'll set that field if we have some problem connecting to our server). Create `PureInboxScreen.js` in your `components` folder:
 
 ```javascript
+
 // components/PureInboxScreen.js
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import PercolateIcons from '../constants/Percolate';
 import TaskList from './TaskList';
@@ -57,7 +58,9 @@ export default PureInboxScreen;
 Then we create a container which grabs the data for `PureInboxScreen` in `screens/InboxScreen.js`
 
 ```javascript
-import React from 'react';
+
+// screens/InboxScreen.js
+import * as React from 'react';
 import { connect } from 'react-redux';
 import PureInboxScreen from './PureInboxScreen';
 
@@ -71,20 +74,20 @@ export default connect(({ error }) => ({ error }))(InboxScreen);
 We also change the `HomeScreen` component to render the `InboxScreen` (eventually we would use a more complex structure to choose the correct screen, but let's not worry about that here):
 
 ```javascript
-// screens/HomeScreen.js
 
-import React, { Component } from 'react';
-import { Provider } from 'react-redux';
-import store from './lib/redux';
+// screens/HomeScreen.js
+import * as React from "react";
+import { Provider } from "react-redux";
+import store from "../lib/redux";
 
 import InboxScreen from "./InboxScreen";
 
 export default function HomeScreen() {
-  return(
+  return (
     <Provider store={store}>
-      <InboxScreen/>
+      <InboxScreen />
     </Provider>
-  )
+  );
 }
 ```
 
@@ -99,9 +102,9 @@ When placing the `TaskList` into Storybook, we were able to dodge this issue by 
 However, for the `PureInboxScreen` we have a problem because although the `PureInboxScreen` itself is presentational, its child, the `TaskList`, is not. In a sense the `PureInboxScreen` has been polluted by “container-ness”. So when we setup our stories in `PureInboxScreen.stories.js`:
 
 ```javascript
-// components/PureInboxScreen.stories.js
 
-import React from 'react';
+// components/PureInboxScreen.stories.js
+import * as React from 'react';
 import { storiesOf } from '@storybook/react-native';
 import PureInboxScreen from './PureInboxScreen';
 
@@ -127,9 +130,9 @@ As an aside, passing data down the hierarchy is a legitimate approach, especiall
 The good news is that it is easy to supply a Redux store to the `PureInboxScreen` in a story! We can just use a mocked version of the Redux store provided in a decorator:
 
 ```javascript
-// components/PureInboxScreen.stories.js
 
-import React from 'react';
+// components/PureInboxScreen.stories.js
+import * as React from 'react';
 import { storiesOf } from '@storybook/react-native';
 import { action } from '@storybook/addon-actions';
 import { Provider } from 'react-redux';

--- a/content/intro-to-storybook/react-native/en/simple-component.md
+++ b/content/intro-to-storybook/react-native/en/simple-component.md
@@ -26,11 +26,12 @@ First, let’s create the task component and its accompanying story file: `compo
 We’ll begin with a basic implementation of the `Task`, simply taking in the attributes we know we’ll need and the two actions you can take on a task (to move it between lists):
 
 ```javascript
-// /components/Task.js
-import React from 'react';
+
+// components/Task.js
+import * as React from 'react';
 import { TextInput, SafeAreaView } from 'react-native';
 import { styles } from '../constants/globalStyles';
-
+ 
 export default function Task({ task: { id, title, state }, onArchiveTask, onPinTask }) {
   return (
     <SafeAreaView style={styles.listitem}>
@@ -45,10 +46,11 @@ Above, we render straightforward markup for `Task` based on the existing HTML st
 Below we build out Task’s three test states in the story file:
 
 ```javascript
+
 // components/Task.stories.js
-import React from 'react';
+import * as React from 'react';
 import { View } from 'react-native';
-import { styles } from '../globalStyles';
+import { styles } from '../constants/globalStyles';
 import { storiesOf } from '@storybook/react-native';
 import { action } from '@storybook/addon-actions';
 import Task from './Task';
@@ -85,7 +87,7 @@ As we need to pass the same set of actions to all permutations of our component,
 
 Another nice thing about bundling the `actions` that a component needs is that you can `export` them and use them in stories for components that reuse this component, as we'll see later.
 
-To define our stories, we call `add()` once for each of our test states to generate a story. The action story is a function that returns a rendered element (i.e. a component class with a set of props) in a given state---exactly like a React [Stateless Functional Component](https://reactjs.org/docs/components-and-props.html).
+To define our stories, we call `add()` once for each of our test states to generate a story. The action story is a function that returns a rendered element (i.e. a component class with a set of props) in a given state---exactly like a [Stateless Functional Component](https://reactjs.org/docs/components-and-props.html).
 
 When creating a story we use a base task (`task`) to build out the shape of the task the component expects. This is typically modelled from what the true data looks like. Again, `export`-ing this shape will enable us to reuse it in later stories, as we'll see.
 
@@ -95,9 +97,10 @@ When creating a story we use a base task (`task`) to build out the shape of the 
 
 ## Config
 
-We also have to make one small change to the Storybook configuration setup (`storybook/index.js`) so it notices our `.stories.js` files. By default Storybook looks for stories in a `/stories` directory; this tutorial uses a naming scheme that is similar to the `.test.js` naming scheme favoured by CRA or Vue CLI for automated tests.
+We also have to make one small change to the Storybook configuration setup (`storybook/index.js`) so it notices our recently created stories.
 
 ```javascript
+
 // storybook/config.js
 import { getStorybookUI, configure } from '@storybook/react-native';
 
@@ -108,10 +111,9 @@ configure(() => {
   require('../components/Task.stories.js');
 }, module);
 
-
-// Refer to https://github.com/storybookjs/storybook/tree/master/app/react-native#start-command-parameters
-// To find allowed options for getStorybookUI
-const StorybookUIRoot = getStorybookUI({});
+const StorybookUIRoot = getStorybookUI({
+  asyncStorage:null
+});
 
 
 export default StorybookUIRoot;
@@ -126,8 +128,6 @@ Once we’ve done this, restarting the Storybook server should yield test cases 
   />
 </video>
 
-Alternatively you can use [react-native-storybook-loader](https://github.com/elderfo/react-native-storybook-loader) to handle loading all of the stories at once, the use of the this third party package will not be covered in this tutorial for brevity purposes.
-
 ## Build out the states
 
 Now we have Storybook setup, styles imported, and test cases built out, we can quickly start the work of implementing the HTML of the component to match the design.
@@ -135,12 +135,12 @@ Now we have Storybook setup, styles imported, and test cases built out, we can q
 The component is still basic at the moment. First write the code that achieves the design without going into too much detail:
 
 ```javascript
-// components/Task.js
 
-import React from 'react';
+// components/Task.js
+import * as React from 'react';
 import { TextInput, SafeAreaView, View, TouchableOpacity } from 'react-native';
-import { styles } from '../globalStyles';
-import PercolateIcons from '../Percolate';
+import { styles } from '../constants/globalStyles';
+import PercolateIcons from '../constants/Percolate';
 
 export default function Task({ task: { id, title, state }, onArchiveTask, onPinTask }) {
   return (
@@ -188,9 +188,9 @@ The additional markup from above combined with the styling we created earlier yi
 It’s best practice to use `propTypes` in React to specify the shape of data that a component expects. Not only is it self documenting, it also helps catch problems early.
 
 ```javascript
-// src/components/Task.js
 
-import React from 'react';
+// src/components/Task.js
+import * as React from 'react';
 import PropTypes from 'prop-types';
 
 export default function Task({ task: { id, title, state }, onArchiveTask, onPinTask }) {
@@ -235,13 +235,14 @@ Make sure your components render data that doesn't change, so that your snapshot
 With the [Storyshots addon](https://github.com/storybooks/storybook/tree/master/addons/storyshots) a snapshot test is created for each of the stories. Use it by adding a development dependency on the package:
 
 ```bash
-yarn add --dev @storybook/addon-storyshots
+yarn add -D @storybook/addon-storyshots
 ```
 
-Then create an `__tests__/storybook.test.js` file with the following:
+Then create an `components/__tests__/storybook.test.js` file with the following:
 
 ```javascript
-// __tests__/storybook.test.js
+
+// components/__tests__/storybook.test.js
 import initStoryshots from '@storybook/addon-storyshots';
 initStoryshots();
 ```

--- a/content/intro-to-storybook/react-native/en/using-addons.md
+++ b/content/intro-to-storybook/react-native/en/using-addons.md
@@ -5,7 +5,7 @@ description: 'Learn how to integrate and use addons using a popular example'
 ---
 
 Storybook boasts a robust system of [addons](https://storybook.js.org/addons/introduction/) with which you can enhance the developer experience for
-everybody in your team. If you've been following along with this tutorial linearly, we have referenced multiple addons so far, and you will have already implemented one in the [Testing chapter](/react/en/test/).
+everybody in your team.
 
 <div class="aside">
 <strong>Looking for a list of potential addons?</strong>
@@ -37,8 +37,8 @@ yarn add -D @storybook/addon-knobs @storybook/addon-ondevice-knobs
 Register Knobs in your `storybook/addons.js` file.
 
 ```javascript
-// storybook/addons.js
 
+// storybook/addons.js
 import '@storybook/addon-actions/register';
 import '@storybook/addon-knobs/register';
 import '@storybook/addon-links/register';
@@ -67,8 +67,8 @@ Let's use the object knob type in the `Task` component.
 First, import the `withKnobs` decorator and the `object` knob type to `Task.stories.js`:
 
 ```javascript
-// src/components/Task.stories.js
 
+// components/Task.stories.js
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
@@ -78,8 +78,8 @@ import { withKnobs, object } from '@storybook/addon-knobs';
 Next, within the stories of `Task`, pass `withKnobs` as a parameter to the `addDecorator()` function:
 
 ```javascript
-// src/components/Task.stories.js
 
+// components/Task.stories.js
 storiesOf('Task', module)
   .addDecorator(withKnobs)
   .add(/*...*/);
@@ -88,13 +88,11 @@ storiesOf('Task', module)
 Lastly, integrate the `object` knob type within the "default" story:
 
 ```javascript
-// src/components/Task.stories.js
 
+// components/Task.stories.js
 storiesOf('Task', module)
   .addDecorator(withKnobs)
-  .add('default', () => {
-    return <Task task={object('task', { ...task })} {...actions} />;
-  })
+  .add('default', () => <Task task={object('task', { ...task })} {...actions} />)
   .add('pinned', () => <Task task={{ ...task, state: 'TASK_PINNED' }} {...actions} />)
   .add('archived', () => <Task task={{ ...task, state: 'TASK_ARCHIVED' }} {...actions} />);
 ```
@@ -116,8 +114,8 @@ Additionally, with easy access to editing passed data to a component, QA Enginee
 Thanks to quickly being able to try different inputs to a component we can find and fix such problems with relative ease! Let's fix the issue with overflowing by adding a style to `Task.js`:
 
 ```javascript
-// components/Task.js
 
+// components/Task.js
 // This is the input for our task title. It was changed to a simple text contrary to textinput,
 // to illustrate how to see what's intended
 <Text
@@ -140,9 +138,9 @@ Of course we can always reproduce this problem by entering the same input into t
 Let's add a story for the long text case in Task.stories.js:
 
 ```javascript
-// components/Task.stories.js
 
-const longTitle = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not`;
+// components/Task.stories.js
+const longTitle = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not!`;
 
 storiesOf('Task', module)
   .add('default', () => <Task task={task} {...actions} />)
@@ -155,7 +153,6 @@ Now we've added the story, we can reproduce this edge-case with ease whenever we
 
 ![Here it is in Storybook.](/intro-to-storybook/addon-knobs-demo-edge-case-in-storybook.png)
 
-If we are using [visual regression testing](/react/en/test/), we will also be informed if we ever break our ellipsizing solution. Such obscure edge-cases are always liable to be forgotten!
 
 ### Merge Changes
 


### PR DESCRIPTION
This pr updates the intro to storybook react native version to the latest Storybook and Expo versions.

# What was done

Going by section:

- get started
   - svelte link added.
   - Minor rewording on some parts.
   - Code snippets updated
   - Collapsed both globalstyles and percolate references to keep focus on the tutorial as they are big code snippets. Should the reader need to see the contents, he/she just needs to click the element
   - Assets section was rewritten as the existing one lacks to mention that the nunito font needs to be grabbed from another source. As throughout the tutorial it makes a extensive usage of it. I originally forgot to check it.
   - Added a reference to Async Storage as it seems that is deprecated and the reader needs to add it manually and linked to the migration guide. I went with the usage of null as per documentation it's used basically to keep track of the last story and to keep the tutorial flowing adding it it would seem as a bit of a distraction.
- simple component
   - minor rewording and code snippets adjustments and file locations updated per new Expo file/folder structure.

- composite component
  - same logic used here as the one for the simple component section. Some minor changes per file/folder structure of Expo. Removed a lingering reference to the test chapter as it does not exist.

- data section
  - minor tweaks to the code snippets

- screen section
  - minor tweaks to the code snippets

- using addons
  - minor tweaks to the code snippets.
   - the last of the test section mention was removed. It slipped and for that i'm sorry.


- conclusion
   - added discord and the Storybook blog reference as to align to the remainder of the documentation. As per the react /vue pr that was introduced shortly.



The code used is present [here](https://github.com/jonniebigodes/intro-storybook-updated-rn)

@IvanSotelo sorry for this to take so long to be made into a pr. Some work was necessary and also i was hoping for a fix on the Expo template and it didn't come. I commented on the issue introducing a change to the said template and i'm hoping that they agree and i can make the pr to address it. 

But for now it seems that when the reader is going through the `get-started` section he/she will encounter a error when the `test` command is issued. This is not a issue with the documentation, but with the underlying framework, i left out the proposed change to keep the flow of the document going. 

When you can go through this and adjust your translation accordingly, i'll take a look as soon as you update your pr and then probably these 2 can be merged almost immediately.

Once again i'm sorry for not creating the pr sooner.

Feel free to provide feedback

