### PR TITLE
Feature(site): adds redirects rules for both Svelte and React Native frameworks

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -5,7 +5,7 @@
 /angular/* /intro-to-storybook/angular/:splat 301
 /vue/* /intro-to-storybook/vue/:splat 301
 /svelte/* /intro-to-storybook/svelte/:splat 301
-/react-native/* intro-to-storybook/react-native/:splat 301
+/react-native/* /intro-to-storybook/react-native/:splat 301
 
 # Before frameworks and translations were added, chapters sat at the root
 /get-started /react/en/get-started 301

--- a/static/_redirects
+++ b/static/_redirects
@@ -4,6 +4,8 @@
 /react/* /intro-to-storybook/react/:splat 301
 /angular/* /intro-to-storybook/angular/:splat 301
 /vue/* /intro-to-storybook/vue/:splat 301
+/svelte/* /intro-to-storybook/svelte/:splat 301
+/react-native/* intro-to-storybook/react-native/:splat 301
 
 # Before frameworks and translations were added, chapters sat at the root
 /get-started /react/en/get-started 301


### PR DESCRIPTION
This pr introduces 2 new rules to the redirects file in order to fix the navigation issue mentioned in #285. More specifically regarding Svelte and React Native. It prevents 404 when the reader clicks a link that redirects to the tutorial version.

Feel free to provide feedback

