### PR TITLE
addon-knobs should be added as a devDependency.

### DIFF
--- a/content/intro-to-storybook/react/de/using-addons.md
+++ b/content/intro-to-storybook/react/de/using-addons.md
@@ -31,7 +31,7 @@ Knobs (Knöpfe) sind eine tolle Möglichkeit für Designer und Entwickler, um in
 Als Erstes müssen wir die nötigen Abhängigkeiten installieren.
 
 ```bash
-yarn add @storybook/addon-knobs
+yarn add -D @storybook/addon-knobs
 ```
 
 Registriere Knobs in deiner `.storybook/addons.js` Datei.

--- a/content/intro-to-storybook/react/nl/using-addons.md
+++ b/content/intro-to-storybook/react/nl/using-addons.md
@@ -31,7 +31,7 @@ Knobs is een geweldige bron voor designers en developers om te experimenteren en
 Eerst moeten we alle benodigde dependencies installeren.
 
 ```bash
-yarn add @storybook/addon-knobs
+yarn add -D @storybook/addon-knobs
 ```
 
 Registreer Knobs in je `.storybook/addons.js` bestand.


### PR DESCRIPTION
In the tutorial, `addon-knobs` is sometimes added to the project dependencies instead of the dev dependencies. I think it should, what do you think?