### PR TITLE
fix: typo on test.md

### DIFF
--- a/content/intro-to-storybook/react/en/test.md
+++ b/content/intro-to-storybook/react/en/test.md
@@ -9,7 +9,7 @@ No Storybook tutorial would be complete without testing. Testing is essential to
 
 - **Visual tests** rely on developers to manually look at a component to verify it for correctness. They help us sanity check a component’s appearance as we build.
 - **Snapshot tests** with Storyshots capture a component’s rendered markup. They help us stay abreast of markup changes that cause rendering errors and warnings.
-- **Unit tests** with Jest verify that the output of a component remains the same given an fixed input. They’re great for testing the functional qualities of a component.
+- **Unit tests** with Jest verify that the output of a component remains the same given a fixed input. They’re great for testing the functional qualities of a component.
 
 ## “But does it look right?”
 


### PR DESCRIPTION
"fixed" starts with a non vowel sound, therefore its preceding article should be "a" instead of "an"