### PR TITLE
Update to correct vue-cli presets

### DIFF
--- a/content/intro-to-storybook/vue/en/get-started.md
+++ b/content/intro-to-storybook/vue/en/get-started.md
@@ -15,7 +15,7 @@ We’ll need to follow a few steps to get the build process set up in your envir
 
 ```bash
 # Create our application, using a preset that contains jest:
-npx -p @vue/cli vue create taskbox --preset hichroma/vue-preset-learnstorybook 
+npx -p @vue/cli vue create taskbox --preset chromaui/vue-preset-learnstorybook 
 
 cd taskbox
 


### PR DESCRIPTION
The preset repository `hichroma/vue-preset-learnstorybook` could not be found on github the correct repository for the preset is seen in the commit.