### PR TITLE
storybook.test.js causes test to fail (angular)

### DIFF
--- a/content/intro-to-storybook/angular/en/simple-component.md
+++ b/content/intro-to-storybook/angular/en/simple-component.md
@@ -265,10 +265,10 @@ With the [Storyshots addon](https://github.com/storybooks/storybook/tree/master/
 npm install -D @storybook/addon-storyshots
 ```
 
-Then create the `src/storybook.test.js` file with the following in it:
+Then create the `src/storybook.test.ts` file with the following in it:
 
 ```typescript
-// src/storybook.test.js
+// src/storybook.test.ts
 import initStoryshots from '@storybook/addon-storyshots';
 
 initStoryshots();


### PR DESCRIPTION
If storybook.test is a JS file, you will get the following error:

 FAIL  src/storybook.test.js
  ● Test suite failed to run
    Jest encountered an unexpected token
   ...
SyntaxError: Cannot use import statement outside a module

Saving the file as .ts (which is nice anyways in an angular project)