### PR TITLE
WIP adds links to the content and a toc tree

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -26,7 +26,22 @@ module.exports = {
         path: `${__dirname}/content/`,
       },
     },
-    `gatsby-transformer-remark`,
+    {
+      resolve: `gatsby-transformer-remark`,
+      options: {
+        plugins: [
+          {
+            resolve: `gatsby-remark-autolink-headers`,
+            options: {
+              offsetY: 104,
+              icon: `<svg aria-hidden="true" height="20" version="1.1" viewBox="0 0 16 16" width="20"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>`,
+              removeAccents: true,
+              isIconAfterHeader: true,
+            },
+          },
+        ],
+      },
+    },
     `gatsby-plugin-styled-components`,
     `gatsby-plugin-sitemap`,
     {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gatsby-plugin-segment-js": "^3.0.1",
     "gatsby-plugin-sitemap": "^2.1.0",
     "gatsby-plugin-styled-components": "^3.0.7",
+    "gatsby-remark-autolink-headers": "^2.2.0",
     "gatsby-source-filesystem": "^2.0.37",
     "gatsby-transformer-remark": "^2.3.12",
     "lodash": "^4.17.11",

--- a/src/components/screens/ChapterScreen/Sidebar.stories.js
+++ b/src/components/screens/ChapterScreen/Sidebar.stories.js
@@ -5,8 +5,21 @@ import Sidebar from './Sidebar';
 const currentPageSlug = '/slug-1';
 
 const entries = [
-  { slug: currentPageSlug, title: 'Chapter 1' },
-  { slug: '/slug-2', title: 'Chapter 2' },
+  {
+    slug: currentPageSlug,
+    title: 'Chapter 1',
+    chapterNavItems: [
+      {
+        chapterNavText: 'Setup',
+        chapterNavLink: '/intro-to-storybook/react/en/get-started/#setup-react-storybook',
+      },
+      {
+        chapterNavText: 'Reuse CSS',
+        chapterNavLink: '/intro-to-storybook/react/en/get-started/#reuse-css',
+      },
+    ],
+  },
+  { slug: '/slug-2', title: 'Chapter 2', chapterNavItems: [] },
 ];
 
 storiesOf('Screens|ChapterScreen/Sidebar', module)

--- a/src/components/screens/ChapterScreen/TableOfContents.js
+++ b/src/components/screens/ChapterScreen/TableOfContents.js
@@ -70,16 +70,38 @@ const ListItem = styled.li`
   }
 `;
 
+// nav list
+
+
+
+// temporarly disabled the eslint rules (they will be back soon)
+
+// eslint-disable-next-line react/prop-types
+const NavItems = ({ headings, ...rest }) => (
+  <List {...rest}>
+    {/* eslint-disable-next-line react/prop-types */}
+    {headings.map(item => {
+      return (
+        <ListItem isActive>
+          <GatsbyLink to={item.chapterNavLink} tertiary>
+            {item.chapterNavText}
+          </GatsbyLink>
+        </ListItem>
+      );
+    })}
+  </List>
+);
+
 const TableOfContents = ({ currentPageSlug, entries, ...rest }) => (
   <List {...rest}>
     {entries.map(entry => {
       const isActive = currentPageSlug === entry.slug;
-
       return (
         <ListItem key={entry.slug} isActive={isActive}>
           <GatsbyLink to={entry.slug} tertiary={!isActive}>
             {entry.title}
           </GatsbyLink>
+          {isActive && <NavItems {...rest} headings={entry.chapterNavItems} />}
         </ListItem>
       );
     })}
@@ -92,6 +114,12 @@ TableOfContents.propTypes = {
     PropTypes.shape({
       slug: PropTypes.string.isRequired,
       title: PropTypes.string.isRequired,
+      chapterNavItems: PropTypes.arrayOf(
+        PropTypes.shape({
+          chapterNavText: PropTypes.string,
+          chapterNavLink: PropTypes.string,
+        })
+      ).isRequired,
     }).isRequired
   ).isRequired,
 };

--- a/src/components/screens/ChapterScreen/TableOfContents.stories.js
+++ b/src/components/screens/ChapterScreen/TableOfContents.stories.js
@@ -5,8 +5,21 @@ import TableOfContents from './TableOfContents';
 const currentPageSlug = '/slug-1';
 
 const entries = [
-  { slug: currentPageSlug, title: 'Chapter 1' },
-  { slug: '/slug-2', title: 'Chapter 2' },
+  {
+    slug: currentPageSlug,
+    title: 'Chapter 1',
+    chapterNavItems: [
+      {
+        chapterNavText: 'Setup',
+        chapterNavLink: '/intro-to-storybook/react/en/get-started/#setup-react-storybook',
+      },
+      {
+        chapterNavText: 'Reuse CSS',
+        chapterNavLink: '/intro-to-storybook/react/en/get-started/#reuse-css',
+      },
+    ],
+  },
+  { slug: '/slug-2', title: 'Chapter 2', chapterNavItems: [] },
 ];
 
 storiesOf('Screens|ChapterScreen/TableOfContents', module)

--- a/src/components/screens/ChapterScreen/index.js
+++ b/src/components/screens/ChapterScreen/index.js
@@ -167,6 +167,7 @@ Chapter.propTypes = {
               title: PropTypes.string,
               description: PropTypes.string,
             }).isRequired,
+            headings: PropTypes.arrayOf(PropTypes.shape({ value: PropTypes.string })).isRequired,
             fields: PropTypes.shape({
               slug: PropTypes.string.isRequired,
               framework: PropTypes.string,
@@ -262,6 +263,9 @@ export const query = graphql`
             slug
             framework
             chapter
+          }
+          headings {
+            value
           }
         }
       }

--- a/src/lib/tocEntries.js
+++ b/src/lib/tocEntries.js
@@ -7,12 +7,24 @@ export default function tocEntries(toc, pages) {
         return null;
       }
       const { tocTitle, title, description } = node.frontmatter;
-
+      const { headings } = node;
+      // needs better sanitizing strategy
+      const chapterNavItems = headings
+        ? headings.map(heading => {
+            return {
+              chapterNavText: heading.value,
+              chapterNavLink: `${node.fields.slug}#${heading.value
+                .replace(/\s/g, '-')
+                .toLowerCase()}`,
+            };
+          })
+        : [];
       return {
         chapter: node.fields.chapter,
         slug: node.fields.slug,
         title: tocTitle || title,
         description,
+        chapterNavItems,
       };
     })
     .filter(e => !!e);

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,6 +905,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.8.7":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
+  integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.4.4", "@babel/template@^7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.6.0.tgz#7f0159c7f5012230dad64cca42ec9bdb5c9536e6"
@@ -6833,6 +6840,17 @@ gatsby-react-router-scroll@^2.1.14:
     scroll-behavior "^0.9.10"
     warning "^3.0.0"
 
+gatsby-remark-autolink-headers@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-2.2.0.tgz#e716f9c24534b81d8463dbad96569e09129a9da7"
+  integrity sha512-JAb878rNBvQHB41z8Susu/jO0wWzy2orSlUn3tCrdqQBNBo7xsFpGuDxjfzY5S3U71GHALmeV7AiPMJYc61heg==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    github-slugger "^1.3.0"
+    lodash "^4.17.15"
+    mdast-util-to-string "^1.1.0"
+    unist-util-visit "^1.4.1"
+
 gatsby-source-filesystem@^2.0.37:
   version "2.1.33"
   resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.33.tgz#6a6e4a075be7af5db603acb695b9eabdc885985e"
@@ -7128,6 +7146,13 @@ github-slugger@^1.1.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.2.1.tgz#47e904e70bf2dccd0014748142d31126cfd49508"
   integrity sha512-SsZUjg/P03KPzQBt7OxJPasGw6NRO5uOgiZ5RGXVud5iSIZ0eNZeNp5rTwCxtavrRUa/A77j8mePVc5lEvk0KQ==
+  dependencies:
+    emoji-regex ">=6.0.0 <=6.1.1"
+
+github-slugger@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.3.0.tgz#9bd0a95c5efdfc46005e82a906ef8e2a059124c9"
+  integrity sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==
   dependencies:
     emoji-regex ">=6.0.0 <=6.1.1"
 
@@ -10072,6 +10097,11 @@ mdast-util-to-string@^1.0.2, mdast-util-to-string@^1.0.6:
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.0.6.tgz#7d85421021343b33de1552fc71cb8e5b4ae7536d"
   integrity sha512-868pp48gUPmZIhfKrLbaDneuzGiw3OTDjHc5M1kAepR2CWBJ+HpEsm252K4aXdiP5coVZaJPOqGtVU6Po8xnXg==
 
+mdast-util-to-string@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz#27055500103f51637bd07d01da01eb1967a43527"
+  integrity sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==
+
 mdast-util-toc@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mdast-util-toc/-/mdast-util-toc-2.1.0.tgz#82b6b218577bb0e67b23abf5c3f7ac73a4b5389f"
@@ -12970,6 +13000,11 @@ regenerator-runtime@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
+regenerator-runtime@^0.13.4:
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
+  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
 
 regenerator-transform@^0.14.0:
   version "0.14.1"


### PR DESCRIPTION
This pr is a WIP to add links to the documentation, more specifically to the headers.

What was done:

- Installed `gatsby-remark-autolink-headers`
- Configured it in `gatsby-config.js`
- Updated the query in `src\components\screens\ChapterScreen\index.js` to use the plugin
- Changed `src\lib\tocEntries` to generate the list of headers based on the data recieved.

What is not yet implemented:
- The urls are yet not fully "sanitized", i've checked and there's some cases with some special characters, more specifically `ç` in the portugues translations and also `ã` in the portuguese and spanish translations. The german as some issues aswell as for the `Ü` case.
- Styling needs to be addressed overall.


I've created a small figma( and pardon me for my lack of skills in it) in [here](https://www.figma.com/file/QVMQZDxH2bJL8yLlh4Ld3G/Concept_for_learnStorybook_link_headers?node-id=0%3A1). 

Even if it doesn't go through like this, i think that at least leaving the plugin `gatsby-remark-autolink-headers` would be a great addition for access to the documentation.

And if a custom svg can be added as the chevron for the links i think it would be a nice touch.

Feel free to provide feedback @domyen @tmeasday @kylesuss 