### PR TITLE
stop exporting taskData and actionsData

### DIFF
--- a/content/intro-to-storybook/react/en/simple-component.md
+++ b/content/intro-to-storybook/react/en/simple-component.md
@@ -59,14 +59,14 @@ export default {
   excludeStories: /.*Data$/,
 };
 
-export const taskData = {
+const taskData = {
   id: '1',
   title: 'Test Task',
   state: 'TASK_INBOX',
   updatedAt: new Date(2018, 0, 1, 9, 0),
 };
 
-export const actionsData = {
+const actionsData = {
   onPinTask: action('onPinTask'),
   onArchiveTask: action('onArchiveTask'),
 };


### PR DESCRIPTION
When these 2 item export in storyshots it takes as 2 stories and break the tests.

By the way, what is the real reason to export like this?