### PR TITLE
WIP: feature to update the site based on #275

### DIFF
--- a/content/design-systems-for-developers/index.md
+++ b/content/design-systems-for-developers/index.md
@@ -64,6 +64,21 @@ contributors:
     },
   ]
 twitterShareText: "I’m learning about building design systems! They're great for scaling frontend code on large teams."
+guideInformation: [
+  {
+    framework: 'react',
+    currentGuideVersion: [
+       {
+         language: 'en',
+         version: 5.3
+       },
+       {
+         language: 'pt',
+         version: 5.3
+       },
+    ]
+  }
+]
 ---
 
 <h2>What you'll build</h2>

--- a/content/intro-to-storybook/angular/es/get-started.md
+++ b/content/intro-to-storybook/angular/es/get-started.md
@@ -5,8 +5,8 @@ description: 'Configurar Angular Storybook en tu entorno de desarrollo'
 commit: 0818d47
 ---
 
-<div class="aside"><p>
-¡Esta traducción está desactualizada! Ayúdenos a mejorarlo haciendo clic en el enlace en la parte inferior de la página. No solo el equipo te lo agradece, sino toda la comunidad.</p></div>
+<!-- <div class="aside"><p>
+¡Esta traducción está desactualizada! Ayúdenos a mejorarlo haciendo clic en el enlace en la parte inferior de la página. No solo el equipo te lo agradece, sino toda la comunidad.</p></div> -->
 
 Storybook se ejecuta en conjunto con tu aplicación en modo desarrollo. Te ayuda a crear componentes de interfaz gráfica aislados de la lógica y el contexto de tu aplicación. Esta edición de Aprende Storybook es para Angular.
 

--- a/content/intro-to-storybook/angular/pt/get-started.md
+++ b/content/intro-to-storybook/angular/pt/get-started.md
@@ -4,7 +4,7 @@ tocTitle: 'Introdução'
 description: 'Configuração do Angular Storybook no ambiente de desenvolvimento'
 ---
 
-<div class="aside"><p>Esta tradução está desatualizada! Ajuda-nos a melhorá-la clicando no link no fim da página. Não somente a equipa agradece, mas toda a comunidade.</p></div>
+<!-- <div class="aside"><p>Esta tradução está desatualizada! Ajuda-nos a melhorá-la clicando no link no fim da página. Não somente a equipa agradece, mas toda a comunidade.</p></div> -->
 
 Storybook funciona em paralelo á aplicação em modo de desenvolvimento.
 Ajuda na construção de componentes de interface de utilizador isolados de qualquer lógica e contexto da aplicação.

--- a/content/intro-to-storybook/index.md
+++ b/content/intro-to-storybook/index.md
@@ -66,6 +66,117 @@ contributors:
     },
   ]
 twitterShareText: 'I’m learning Storybook! It’s a great dev tool for UI components.'
+guideInformation: [
+  {
+     framework: 'react',
+     currentGuideVersion: [
+       {
+         language: 'de',
+         version: 5.2
+       },
+       {
+         language: 'en',
+         version: 5.3
+       },
+       {
+         language: 'es',
+         version: 5.2
+       },
+       {
+         language: 'nl',
+         version: 5.2
+       },
+       {
+         language: 'pt',
+         version: 5.3
+       },
+       {
+         language: 'zh-CN',
+         version: 5.2
+       },
+       {
+         language: 'zh-TW',
+         version: 5.2
+       },
+     ]
+  },
+  {
+     framework: 'react-native',
+     currentGuideVersion: [
+       {
+         language: 'en',
+         version: 5.3
+       },
+       {
+         language: 'es',
+         version: 5.3
+       },
+     ]
+  },
+  {
+     framework: 'vue',
+     currentGuideVersion: [
+       {
+         language: 'en',
+         version: 5.3
+       },
+       {
+         language: 'es',
+         version: 5.3
+       },
+       {
+         language: 'pt',
+         version: 5.3
+       }
+     ]
+  },
+  {
+     framework: 'angular',
+     currentGuideVersion: [
+       {
+         language: 'en',
+         version: 5.3
+       },
+       {
+         language: 'es',
+         version: 5.2
+       },
+       {
+         language: 'pt',
+         version: 5.2
+       }
+     ]
+  },
+  {
+     framework: 'svelte',
+     currentGuideVersion: [
+        {
+         language: 'en',
+         version: 5.3
+       }
+     ]
+  },
+  {
+     framework: 'ember',
+     currentGuideVersion: []
+  },
+  {
+     framework: 'html',
+     currentGuideVersion: []
+  },
+  {
+     framework: 'marko',
+     currentGuideVersion: []
+  },
+  {
+     framework: 'mithril',
+     currentGuideVersion: []
+  },
+  {
+     framework: 'riot',
+     currentGuideVersion: []
+  },
+]
 ---
 
 <h2>What you'll build</h2>

--- a/content/intro-to-storybook/react/es/get-started.md
+++ b/content/intro-to-storybook/react/es/get-started.md
@@ -5,10 +5,8 @@ description: 'Configurar React Storybook en tu entorno de desarrollo'
 commit: ebe2ae2
 ---
 
-
-<div class="aside"><p>
-¡Esta traducción está desactualizada! Ayúdenos a mejorarlo haciendo clic en el enlace en la parte inferior de la página. No solo el equipo te lo agradece, sino toda la comunidad.</p></div>
-
+<!-- <div class="aside"><p>
+¡Esta traducción está desactualizada! Ayúdenos a mejorarlo haciendo clic en el enlace en la parte inferior de la página. No solo el equipo te lo agradece, sino toda la comunidad.</p></div> -->
 
 Storybook se ejecuta junto con tu aplicación en modo desarrollo. Te ayuda a crear componentes de UI aislados de la lógica y el contexto de tu aplicación. Esta edición de Aprende Storybook es para React; existe una edición para [Angular](/angular/es/get-started) y para Vue vendrá pronto.
 

--- a/content/intro-to-storybook/react/zh-CN/get-started.md
+++ b/content/intro-to-storybook/react/zh-CN/get-started.md
@@ -5,12 +5,11 @@ description: '在你的开发环境下, 设置 React Storybook '
 commit: ebe2ae2
 ---
 
-<div class="aside">
+<!-- <div class="aside">
 <p>
   此翻译未更新！您可以通过单击页面底部的链接来帮助我们改进它，不仅团队会感激它，而且整个社区都会感激不尽
 </p>
-</div>
-
+</div> -->
 
 Storybook 是在开发模式下 与 您的应用程序一起运行的. 它可以帮助您构建 UI 组件,并与 应用程序的 业务逻辑和上下文 隔离开来. 本期"学习 Storybook"适用于 **React**; `Vue和Angular`版本即将推出.
 

--- a/content/intro-to-storybook/react/zh-TW/get-started.md
+++ b/content/intro-to-storybook/react/zh-TW/get-started.md
@@ -5,9 +5,10 @@ description: '在你的開發環境下, 設定 React Storybook '
 commit: ebe2ae2
 ---
 
-<div class="aside"><p>
+<!-- <div class="aside"><p>
 此翻譯尚未更新！您可以通過單擊頁面底部的鏈接來幫助我們改進它，不僅團隊會感激它，而且整個社區也會感激不盡。
-</p></div>
+</p></div> -->
+
 Storybook 是在開發模式下 與 您的應用程式一起執行的. 它可以幫助您構建 UI 元件,並與 應用程式的 業務邏輯和上下文 隔離開來. 本期"學習 Storybook"適用於 **React**; `Vue和Angular`版本即將推出.
 
 ![Storybook and your app](/intro-to-storybook/storybook-relationship.jpg)

--- a/content/visual-testing-handbook/index.md
+++ b/content/visual-testing-handbook/index.md
@@ -26,6 +26,17 @@ authors:
     },
   ]
 contributors: []
+guideInformation: [
+  {
+    framework: 'react',
+    currentGuideVersion: [
+       {
+         language: 'en',
+         version: 5.3
+       }
+    ]
+  }
+]
 ---
 
 <h2>What you'll build</h2>

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,6 +10,7 @@ module.exports = {
     siteUrl: permalink,
     githubUrl: 'https://github.com/chromaui/learnstorybook.com',
     contributeUrl: 'https://github.com/chromaui/learnstorybook.com/#contribute',
+    currentStorybookVersion: 5.3,
   },
   plugins: [
     {

--- a/src/components/screens/ChapterScreen/ChapterLinks.js
+++ b/src/components/screens/ChapterScreen/ChapterLinks.js
@@ -61,13 +61,19 @@ const buildTwitterUrl = (guide, text) =>
     text
   )}&tw_p=tweetbutton&url=https%3A%2F%2Flearnstorybook.com%2F${guide}&via=chromaui`;
 
-const ChapterLinks = ({ codeGithubUrl, commit, guide, twitterShareText }) => {
+const ChapterLinks = ({
+  codeGithubUrl,
+  commit,
+  guide,
+  twitterShareText,
+  twitterLinkDisplayText,
+  gitLinkDisplayText,
+}) => {
   const withCommitLink = !isNil(codeGithubUrl) && !isNil(commit);
 
   if (!withCommitLink && !twitterShareText) {
     return null;
   }
-
   return (
     <BoxLinksWrapper withMultiple={withCommitLink}>
       {withCommitLink && (
@@ -76,7 +82,9 @@ const ChapterLinks = ({ codeGithubUrl, commit, guide, twitterShareText }) => {
             <BoxLinkIcon icon="repository" />
 
             <BoxLinkMessage>
-              Keep your code in sync with this chapter. View {commit} on GitHub.
+             {/*  Keep your code in sync with this chapter. View {commit} on GitHub. */}
+
+              {gitLinkDisplayText}
             </BoxLinkMessage>
           </BoxLinkContent>
         </BoxLink>
@@ -88,7 +96,8 @@ const ChapterLinks = ({ codeGithubUrl, commit, guide, twitterShareText }) => {
             <BoxLinkIcon icon="twitter" />
 
             <BoxLinkMessage>
-              Is this free guide helping you? Tweet to give kudos and help other devs find it.
+              {/* Is this free guide helping you? Tweet to give kudos and help other devs find it. */}
+              {twitterLinkDisplayText}
             </BoxLinkMessage>
           </BoxLinkContent>
         </BoxLink>
@@ -102,12 +111,16 @@ ChapterLinks.propTypes = {
   commit: PropTypes.string,
   guide: PropTypes.string.isRequired,
   twitterShareText: PropTypes.string,
+  twitterLinkDisplayText: PropTypes.string,
+  gitLinkDisplayText: PropTypes.string,
 };
 
 ChapterLinks.defaultProps = {
   codeGithubUrl: null,
   commit: null,
   twitterShareText: null,
+  twitterLinkDisplayText: null,
+  gitLinkDisplayText: null,
 };
 
 export default ChapterLinks;

--- a/src/components/screens/ChapterScreen/ChapterLinks.js
+++ b/src/components/screens/ChapterScreen/ChapterLinks.js
@@ -82,7 +82,7 @@ const ChapterLinks = ({
             <BoxLinkIcon icon="repository" />
 
             <BoxLinkMessage>
-             {/*  Keep your code in sync with this chapter. View {commit} on GitHub. */}
+              {/*  Keep your code in sync with this chapter. View {commit} on GitHub. */}
 
               {gitLinkDisplayText}
             </BoxLinkMessage>

--- a/src/components/screens/ChapterScreen/ChapterLinks.stories.js
+++ b/src/components/screens/ChapterScreen/ChapterLinks.stories.js
@@ -4,8 +4,35 @@ import ChapterLinks from './ChapterLinks';
 
 const guide = 'guide';
 
+const defaultLinkText = {
+  twitterLinkDisplayText:
+    'Is this free guide helping you? Tweet to give kudos and help other devs find it.',
+  gitLinkDisplayText: 'Keep your code in sync with this chapter. View on GitHub the commit AAAAAA',
+};
+const translatedLinkText = {
+  twitterLinkDisplayText:
+    'Este guia gratuito está a ajudar-te? Tweeta para elogiar e ajudar outros programadores a descobri-lo',
+  gitLinkDisplayText:
+    'Mantém o teu código sincronizado com este capítulo. Vê no GitHub o commit AAAAAA',
+};
+
 storiesOf('Screens|ChapterScreen/ChapterLinks', module)
   .add('with commit', () => (
-    <ChapterLinks codeGithubUrl="https://github.com" commit="AAAAAA" guide={guide} />
+    <ChapterLinks
+      codeGithubUrl="https://github.com"
+      commit="AAAAAA"
+      guide={guide}
+      twitterLinkDisplayText={defaultLinkText.twitterLinkDisplayText}
+      gitLinkDisplayText={defaultLinkText.gitLinkDisplayText}
+    />
   ))
-  .add('without commit', () => <ChapterLinks guide={guide} />);
+  .add('without commit', () => <ChapterLinks guide={guide} />)
+  .add('with commit in another language', () => (
+    <ChapterLinks
+      codeGithubUrl="https://github.com"
+      commit="AAAAAA"
+      guide={guide}
+      twitterLinkDisplayText={translatedLinkText.twitterLinkDisplayText}
+      gitLinkDisplayText={translatedLinkText.gitLinkDisplayText}
+    />
+  ));

--- a/src/components/screens/ChapterScreen/GithubLink.js
+++ b/src/components/screens/ChapterScreen/GithubLink.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Link, styles } from '@storybook/design-system';
+import { fetchGitHubTextInfo } from '../../../lib/getTranslationInformation';
 
 const { typography } = styles;
 
@@ -15,19 +16,23 @@ const LinkWrapper = styled(Link)`
   font-size: ${typography.size.s2}px;
 `;
 
-const GithubLink = ({ githubFileUrl }) => (
-  <GithubLinkWrapper>
-    <LinkWrapper tertiary href={githubFileUrl} target="_blank" rel="noopener">
-      <span role="img" aria-label="write">
-        ✍️
-      </span>{' '}
-      Edit on GitHub – PRs welcome!
-    </LinkWrapper>
-  </GithubLinkWrapper>
-);
+const GithubLink = ({ githubFileUrl, githubDisplayText }) => {
+  return (
+    <GithubLinkWrapper>
+      <LinkWrapper tertiary href={githubFileUrl} target="_blank" rel="noopener">
+        <span role="img" aria-label="write">
+          ✍️
+        </span>{' '}
+        {/* Edit on GitHub – PRs welcome! */}
+        {githubDisplayText}
+      </LinkWrapper>
+    </GithubLinkWrapper>
+  );
+};
 
 GithubLink.propTypes = {
   githubFileUrl: PropTypes.string.isRequired,
+  githubDisplayText: PropTypes.string.isRequired,
 };
 
 export default GithubLink;

--- a/src/components/screens/ChapterScreen/GithubLink.js
+++ b/src/components/screens/ChapterScreen/GithubLink.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Link, styles } from '@storybook/design-system';
-import { fetchGitHubTextInfo } from '../../../lib/getTranslationInformation';
 
 const { typography } = styles;
 

--- a/src/components/screens/ChapterScreen/LanguageMenu/index.stories.js
+++ b/src/components/screens/ChapterScreen/LanguageMenu/index.stories.js
@@ -211,7 +211,7 @@ storiesOf('Screens|ChapterScreen/LanguageMenu', module)
       }}
     />
   ))
-  .add('w all frameworks, 2 translations',()=>(
+  .add('w all frameworks, 2 translations', () => (
     <LanguageMenu
       {...sharedProps}
       framework="react"

--- a/src/components/screens/ChapterScreen/TranslationUpdated.js
+++ b/src/components/screens/ChapterScreen/TranslationUpdated.js
@@ -30,7 +30,7 @@ const TranslationUpdated = ({ currentLanguage, currentTranslations, storybookVer
 };
 TranslationUpdated.defaultProps = {
   currentTranslations: [],
-}
+};
 TranslationUpdated.propTypes = {
   storybookVersion: PropTypes.number.isRequired,
   currentLanguage: PropTypes.string.isRequired,

--- a/src/components/screens/ChapterScreen/TranslationUpdated.js
+++ b/src/components/screens/ChapterScreen/TranslationUpdated.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { styles } from '@storybook/design-system';
+import { fetchTutorialNotUpdatedText } from '../../../lib/getTranslationInformation';
+
+const { spacing, color, typography } = styles;
+
+const TranslationWrapper = styled.div`
+  font-size: ${typography.size.s3}px;
+  color: ${color.darker};
+  background: #f8fafc;
+  border-radius: ${spacing.borderRadius.small}px;
+  padding: 20px;
+  margin: ${spacing.padding.small}px 0px;
+`;
+
+const TranslationUpdated = ({ currentLanguage, currentTranslations, storybookVersion }) => {
+  const getGuideVersionByLanguage = currentTranslations.findIndex(
+    guideLanguage => guideLanguage.language === currentLanguage
+  );
+  const translationNotUpdated = fetchTutorialNotUpdatedText(currentLanguage);
+  if (
+    getGuideVersionByLanguage < 0 ||
+    currentTranslations[getGuideVersionByLanguage].version >= storybookVersion
+  ) {
+    return null;
+  }
+  return <TranslationWrapper>{translationNotUpdated}</TranslationWrapper>;
+};
+TranslationUpdated.defaultProps = {
+  currentTranslations: [],
+}
+TranslationUpdated.propTypes = {
+  storybookVersion: PropTypes.number.isRequired,
+  currentLanguage: PropTypes.string.isRequired,
+  currentTranslations: PropTypes.arrayOf(
+    PropTypes.shape({
+      language: PropTypes.string,
+      version: PropTypes.number,
+    }).isRequired
+  ),
+};
+export default TranslationUpdated;

--- a/src/components/screens/ChapterScreen/TranslationUpdated.stories.js
+++ b/src/components/screens/ChapterScreen/TranslationUpdated.stories.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import TranslationUpdated from './TranslationUpdated';
+
+const defaultLanguage = 'en';
+const translatedLanguage = 'es';
+const defaultStorybookVersion = 5.3;
+const translationData = [
+  {
+    language: 'de',
+    version: 5.2,
+  },
+  {
+    language: 'en',
+    version: 5.3,
+  },
+  {
+    language: 'es',
+    version: 5.2,
+  },
+  {
+    language: 'nl',
+    version: 5.2,
+  },
+  {
+    language: 'pt',
+    version: 5.3,
+  },
+  {
+    language: 'zh-CN',
+    version: 5.2,
+  },
+  {
+    language: 'zh-TW',
+    version: 5.2,
+  },
+];
+storiesOf('Screens|ChapterScreen/TranslationUpdated', module)
+  .addParameters({ component: TranslationUpdated })
+  .add('default', () => (
+    <TranslationUpdated
+      currentLanguage={defaultLanguage}
+      currentTranslations={translationData}
+      storybookVersion={defaultStorybookVersion}
+    />
+  ))
+  .add('translation not updated', () => (
+    <TranslationUpdated
+      currentLanguage={translatedLanguage}
+      currentTranslations={translationData}
+      storybookVersion={defaultStorybookVersion}
+    />
+  ));

--- a/src/components/screens/ChapterScreen/index.js
+++ b/src/components/screens/ChapterScreen/index.js
@@ -63,13 +63,7 @@ const Chapter = ({
       fields: { framework, guide, language, slug, chapter, permalink },
     },
     currentGuide: {
-      frontmatter: {
-        codeGithubUrl,
-        title: currentGuideTitle,
-        toc,
-        twitterShareText,
-        guideInformation,
-      },
+      frontmatter: { codeGithubUrl, title: currentGuideTitle, toc, guideInformation },
     },
     site: { siteMetadata },
     tocPages,

--- a/src/components/screens/ChapterScreen/index.stories.js
+++ b/src/components/screens/ChapterScreen/index.stories.js
@@ -26,6 +26,17 @@ const props = {
         languages: ['en'],
         title: 'Guide Title',
         toc: ['chapter-1', 'chapter-2'],
+        guideInformation: [
+          {
+            framework: 'react',
+            currentGuideVersion: [
+              {
+                language: 'en',
+                version: 5.3,
+              },
+            ],
+          },
+        ],
       },
     },
     site: {
@@ -34,6 +45,7 @@ const props = {
         contributeUrl: 'https://github.com',
         permalink: 'https://learnstorybook.com',
         title: 'Learn Storybook',
+        currentStorybookVersion: 5.3,
       },
     },
     tocPages: {
@@ -99,6 +111,42 @@ const props = {
   },
 };
 
+const translatedProps = {
+  data: {
+    ...props.data,
+    currentPage: {
+      ...props.data.currentPage,
+      fields: {
+        chapter: 'chapter-1',
+        framework: 'react',
+        guide: 'sample-guide',
+        language: 'es',
+        permalink: 'https://learnstorybook.com/sample-guide',
+        slug: '/chapter-slug',
+      },
+    },
+    currentGuide: {
+      frontmatter: {
+        codeGithubUrl: 'https://github.com',
+        languages: ['es'],
+        title: 'Guide Title',
+        toc: ['chapter-1', 'chapter-2'],
+        guideInformation: [
+          {
+            framework: 'react',
+            currentGuideVersion: [
+              {
+                language: 'es',
+                version: 5.2,
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
+};
 storiesOf('Screens|ChapterScreen/index', module)
   .addParameters({ component: Chapter })
-  .add('default', () => <Chapter {...props} />);
+  .add('default', () => <Chapter {...props} />)
+  .add('without outdated version', () => <Chapter {...translatedProps} />);

--- a/src/lib/getTranslationInformation.js
+++ b/src/lib/getTranslationInformation.js
@@ -1,0 +1,66 @@
+import EnglishLanguageMap from './locales/en';
+import PortugueseLanguageMap from './locales/pt';
+import SpanishLanguageMap from './locales/es';
+import NetherLandsLanguageMap from './locales/nl';
+import GermanLanguageMap from './locales/de';
+import SimplifiedChineseLanguageMap from './locales/zh-CN';
+import TraditionalChineseLanguageMap from './locales/zh-TW';
+import FrenchLanguageMap from './locales/fr';
+import ItalianLanguageMap from './locales/it';
+
+const translationMap = {
+  en: {
+    ...EnglishLanguageMap,
+  },
+  pt: {
+    ...PortugueseLanguageMap,
+  },
+  es: {
+    ...SpanishLanguageMap,
+  },
+  nl: {
+    ...NetherLandsLanguageMap,
+  },
+  de: {
+    ...GermanLanguageMap,
+  },
+  'zh-CN': {
+    ...SimplifiedChineseLanguageMap,
+  },
+  'zh-TW': {
+    ...TraditionalChineseLanguageMap,
+  },
+  fr: {
+    ...FrenchLanguageMap,
+  },
+  it: {
+    ...ItalianLanguageMap,
+  },
+};
+/**
+ *  function to fetch the necessary text for displaying the not current tutorial version
+ * @param {String} language will retrieve the necessary information based on the language supplied
+ * @returns {Object} with the necessary text to be added to the tutorial
+ */
+export const fetchTutorialNotUpdatedText = language => {
+  return translationMap[language]
+    ? translationMap[language].guidenotupdated
+    : translationMap.en.guidenotupdated;
+};
+/**
+ *  function to fetch the necessary text for displaying the twitter information
+ * @param {String} language will retrieve the necessary information based on the language supplied
+ * @returns {Object} with the necessary text to be added to the tutorial
+ */
+export const fetchTwitterTextInfo = language => {
+  return translationMap[language] ? translationMap[language].twitter : translationMap.en.twitter;
+};
+
+/**
+ *  function to fetch the necessary text for displaying the github information
+ * @param {String} language will retrieve the necessary information based on the language supplied
+ * @returns {Object} with the necessary text to be added to the tutorial
+ */
+export const fetchGitHubTextInfo = language => {
+  return translationMap[language] ? translationMap[language].github : translationMap.en.github;
+};

--- a/src/lib/locales/de.js
+++ b/src/lib/locales/de.js
@@ -1,0 +1,21 @@
+const GermanLanguageMap = {
+  twitter: {
+    displaytext:
+      'Hilft Ihnen dieser kostenlose Leitfaden? Tweet, um ein Lob zu geben und anderen Entwicklern zu helfen, es zu finden.',
+    'intro-to-storybook':
+      'Ich lerne Storybook! Es ist ein großartiges Entwicklungswerkzeug für UI-Komponenten.',
+    'design-systems-for-developers':
+      'Ich lerne über Gebäudeentwurfssysteme! Sie eignen sich hervorragend zum Skalieren von Frontend-Code in großen Teams.',
+    'visual-testing-handbook':
+      'In Kürze lernen Sie, wie Sie Workflows und bewährte Verfahren für branchenübliche Tests anwenden.',
+  },
+  github: {
+    displaytext: 'Halten Sie Ihren Code mit diesem Kapitel synchron.',
+    committext: 'Zeigen Sie auf GitHub das folgende Commit an',
+    prtext: 'Auf GitHub bearbeiten - PRs willkommen!',
+  },
+  guidenotupdated:
+    'Diese Übersetzung wird nicht aktualisiert! Sie können uns helfen, es zu verbessern, indem Sie auf den Link unten auf der Seite klicken. Nicht nur das Team wird es zu schätzen wissen, sondern auch die gesamte Community.',
+};
+
+export default GermanLanguageMap;

--- a/src/lib/locales/en.js
+++ b/src/lib/locales/en.js
@@ -1,0 +1,17 @@
+const EnglishLanguageMap = {
+  twitter: {
+    displaytext: 'Is this free guide helping you? Tweet to give kudos and help other devs find it.',
+    'intro-to-storybook': 'I’m learning Storybook! It’s a great dev tool for UI components.',
+    'design-systems-for-developers': `I’m learning about building design systems! They're great for scaling frontend code on large teams.`,
+    'visual-testing-handbook': `Soon you'll learn how to apply industry grade testing workflows and good practices.`,
+  },
+  github: {
+    displaytext: 'Keep your code in sync with this chapter.',
+    committext: 'View on GitHub the commit',
+    prtext: 'Edit on GitHub – PRs welcome!',
+  },
+  guidenotupdated:
+    'This translation is not updated! You can help us improve it by clicking the link at the bottom of the page, not only the team will appreciate it but also the entire community.',
+};
+
+export default EnglishLanguageMap;

--- a/src/lib/locales/es.js
+++ b/src/lib/locales/es.js
@@ -1,0 +1,21 @@
+const SpanishLanguageMap = {
+  twitter: {
+    displaytext:
+      '¿Te está ayudando este guía gratuito? Tuitea para felicitar y ayudar a otros desarrolladores a encontrarlo.',
+    'intro-to-storybook':
+      '¡Estoy aprendiendo Storybook! Es una gran herramienta de desarrollo para componentes de la interfaz de usuario.',
+    'design-systems-for-developers':
+      '¡Estoy aprendiendo sobre la construcción de sistemas de diseño! Son excelentes para escalar código de interfaz en equipos grandes.',
+    'visual-testing-handbook':
+      'Pronto aprenderá cómo aplicar flujos de trabajo de prueba de grado industrial y buenas prácticas.',
+  },
+  github: {
+    displaytext: 'Mantenga su código sincronizado con este capítulo.',
+    committext: 'Ve en GitHub el commit',
+    prtext: 'Editar en GitHub - PRs son bienvenidos !',
+  },
+  guidenotupdated:
+    '¡Esta traducción no está actualizada! Puede ayudarnos a mejorarlo haciendo clic en el enlace en la parte inferior de la página, no solo el equipo lo apreciará, sino también toda la comunidad.',
+};
+
+export default SpanishLanguageMap;

--- a/src/lib/locales/fr.js
+++ b/src/lib/locales/fr.js
@@ -1,0 +1,16 @@
+const FrenchLanguageMap = {
+  twitter: {
+    displaytext: `Ce guide gratuit vous aide-t-il? Tweetez pour donner des félicitations et aider d'autres développeurs à le trouver.`,
+    'intro-to-storybook': `J'apprends Storybook! C'est un excellent outil de développement pour les composants de l'interface utilisateur.`,
+    'design-systems-for-developers': `J'apprends à construire des systèmes de conception! Ils sont parfaits pour mettre à niveau le code frontend sur de grandes équipes.`,
+    'visual-testing-handbook': `Bientôt, vous apprendrez comment appliquer des workflows de test de niveau industriel et de bonnes pratiques.`,
+  },
+  github: {
+    displaytext: 'Modifier sur GitHub - PR bienvenus!',
+    committext: 'Gardez votre code synchronisé avec ce chapitre',
+    prtext: 'Voir sur GitHub le commit suivant',
+  },
+  guidenotupdated: `Cette traduction n'est pas mise à jour! Vous pouvez nous aider à l'améliorer en cliquant sur le lien en bas de la page, non seulement l'équipe l'appréciera mais aussi toute la communauté.`,
+};
+
+export default FrenchLanguageMap;

--- a/src/lib/locales/it.js
+++ b/src/lib/locales/it.js
@@ -1,0 +1,17 @@
+const ItalianLanguageMap = {
+  twitter: {
+    displaytext:
+      'Questa guida gratuita ti sta aiutando? Tweet per dare complimenti e aiutare gli altri sviluppatori a trovarlo.',
+    'intro-to-storybook': `Sto imparando il Storybook! È un ottimo strumento di sviluppo per i componenti dell'interfaccia utente.`,
+    'design-systems-for-developers': `Sto imparando a costruire sistemi di progettazione! Sono fantastici per ridimensionare il codice frontend in team di grandi dimensioni.`,
+    'visual-testing-handbook': `Presto imparerai come applicare flussi di lavoro di test di livello industriale e buone pratiche.`,
+  },
+  github: {
+    displaytext: 'Mantieni il codice sincronizzato con questo capitolo',
+    committext: 'Visualizza su GitHub il seguente commit',
+    prtext: 'Modifica su GitHub - Le PR sono benvenute!',
+  },
+  guidenotupdated: `Questa traduzione non è aggiornata! Puoi aiutarci a migliorarlo facendo clic sul link in fondo alla pagina, non solo il team lo apprezzerà, ma anche l'intera comunità.`,
+};
+
+export default ItalianLanguageMap;

--- a/src/lib/locales/nl.js
+++ b/src/lib/locales/nl.js
@@ -1,0 +1,20 @@
+const NetherLandsLanguageMap = {
+  twitter: {
+    displaytext:
+      'Helpt deze gratis gids je? Tweet om een ​​pluim te geven en andere ontwikkelaars te helpen het te vinden.',
+    'intro-to-storybook': 'Ik leer Storybook! Het is een geweldige dev-tool voor UI-componenten.',
+    'design-systems-for-developers':
+      'Ik leer over het ontwerpen van ontwerpsystemen! Ze zijn geweldig voor het schalen van frontend-code op grote teams.',
+    'visual-testing-handbook':
+      'Binnenkort leert u hoe u testworkflows en goede praktijken van industriële kwaliteit toepast.',
+  },
+  github: {
+    displaytext: 'Houd uw code synchroon met dit hoofdstuk',
+    committext: 'Bekijk op GitHub de volgende commit',
+    prtext: 'Bewerken op GitHub - PR welkom!',
+  },
+  guidenotupdated:
+    'Deze vertaling is niet bijgewerkt! Je kunt ons helpen het te verbeteren door op de link onderaan de pagina te klikken, niet alleen het team zal het waarderen, maar ook de hele community.',
+};
+
+export default NetherLandsLanguageMap;

--- a/src/lib/locales/pt.js
+++ b/src/lib/locales/pt.js
@@ -1,0 +1,21 @@
+const PortugueseLanguageMap = {
+  twitter: {
+    displaytext:
+      'Este guia gratuito está a ajudar-te? Tweeta para elogiar e ajudar outros programadores a descobri-lo',
+    'intro-to-storybook':
+      'Estou a aprender Storybook! É uma ferramenta excelente para componentes de interface de utilizador.',
+    'design-systems-for-developers':
+      'Estou a aprender a construir sistemas de design! São fantásticos para dimensionar código frontend em equipas grandes.',
+    'visual-testing-handbook':
+      'Em breve irás aprender como aplicar metodologias aplicadas na indústria e boas práticas.',
+  },
+  github: {
+    displaytext: 'Mantém o teu código sincronizado com este capítulo.',
+    committext: 'Vê no GitHub o commit',
+    prtext: 'Edita no GitHub - Os Pull Requests são bem vindos',
+  },
+  guidenotupdated:
+    'Esta tradução está desatualizada! Ajuda-nos a melhorá-la clicando no link no fim da página. Não somente a equipa agradece, mas toda a comunidade.',
+};
+
+export default PortugueseLanguageMap;

--- a/src/lib/locales/zh-CN.js
+++ b/src/lib/locales/zh-CN.js
@@ -1,0 +1,17 @@
+const SimplifiedChineseLanguageMap = {
+  twitter: {
+    displaytext: '該免費指南對您有幫助嗎？鳴叫致以榮譽，並幫助其他開發者找到它。',
+    'intro-to-storybook': '我正在学习故事书！这是用于UI组件的出色开发工具。',
+    'design-systems-for-developers': `我正在学习建筑设计系统！它们非常适合在大型团队中扩展前端代码。`,
+    'visual-testing-handbook': `很快，您将学习如何应用行业级测试工作流程和良好实践。`,
+  },
+  github: {
+    displaytext: '使您的代码与本章保持同步。',
+    committext: '在GitHub上查看提交',
+    prtext: '在GitHub上编辑–欢迎PR！',
+  },
+  guidenotupdated:
+    '此翻譯未更新！您可以通過單擊頁面底部的鏈接來幫助我們改進它，不僅團隊會感激它，而且整個社區也會感激。',
+};
+
+export default SimplifiedChineseLanguageMap;

--- a/src/lib/locales/zh-TW.js
+++ b/src/lib/locales/zh-TW.js
@@ -1,0 +1,17 @@
+const TraditionalChineseLanguageMap = {
+  twitter: {
+    displaytext: '該免費指南對您有幫助嗎？鳴叫致以榮譽，並幫助其他開發者找到它。',
+    'intro-to-storybook': '我正在學習故事書！這是用於UI組件的出色開發工具。',
+    'design-systems-for-developers': `我正在學習建築設計系統！它們非常適合在大型團隊中擴展前端代碼。`,
+    'visual-testing-handbook': `很快，您將學習如何應用行業級測試工作流程和良好實踐。`,
+  },
+  github: {
+    displaytext: '使您的代碼與本章保持同步。',
+    committext: '在GitHub上查看提交',
+    prtext: '在GitHub上編輯–歡迎PR！',
+  },
+  guidenotupdated:
+    '此翻譯未更新！您可以通過單擊頁面底部的鏈接來幫助我們改進它，不僅團隊會感激它，而且整個社區也會感激。',
+};
+
+export default TraditionalChineseLanguageMap;


### PR DESCRIPTION
This pr addresses #275. Going to leave in the `DO NOT MERGE` label as this is a work in progress and depending on feedback it will move forward.

What was done:

- Inside `gatsby-config.js` a new element was added to contain the current Storybook version.
- Each tutorials `index.md` frontmatter was updated with a key to contain each individual framework/available language and the version of storybook used in it.
- Created the component to display the information per language if the tutorial is not correct. Probably some available languages, more specifically deutsch/dutch could be better worded.
- Also based on this i kickstarted a i18n approach to the site, for now some parts of the site are done, i'm currently making a inventory of what could be translated in terms of wording component wise. And also if `react-i18next` and other i18n play nice with both Storybook/Gatsby and with that offer a trully translated experience to the reader to his/hers native language, based on what is currently available in terms of content.
- Also updated some of the stories to reflect this change.


Feel free to provide feedback.