### PR TITLE
Small fix on how the command options cli text is shown

### DIFF
--- a/content/intro-to-storybook/angular/en/test.md
+++ b/content/intro-to-storybook/angular/en/test.md
@@ -55,7 +55,7 @@ $ git commit -m "taskbox UI"
 Add the package as a dependency.
 
 ```bash
-npm install -D storybook-chromatic
+npm install -D chromatic
 ```
 
 One fantastic thing about this addon is that it will use Git history to keep track of your UI components.
@@ -76,7 +76,7 @@ npx chromatic --project-token=<project-token>
 ```
 
 <div class="aside">
-If your Storybook has a custom build script you may have to [add options](https://www.chromatic.com/docs/setup#command-options) to this command.
+If your Storybook has a custom build script you may have to <a href="https://www.chromatic.com/docs/setup#command-options">add options </a> to this command.
 </div>
 
 Once the first test is complete, we have test baselines for each story. In other words, screenshots of each story known to be “good”. Future changes to those stories will be compared to the baselines.

--- a/content/intro-to-storybook/angular/es/test.md
+++ b/content/intro-to-storybook/angular/es/test.md
@@ -94,6 +94,8 @@ Ejecuta el comando de prueba en la línea de comandos para configurar las prueba
 npx chromatic --project-token=<project-token>
 ```
 
+<div class="aside"> Si su Storybook tiene un script de compilación personalizado, es posible que deba <a href="https://www.chromatic.com/docs/setup#command-options"> agregar opciones </a> a este comando. </div>
+
 Una vez el primer test esté completo, tenemos punto de referencia de prueba para cada historia. En otras palabras, capturas de cada historia que son las "correctas". Cualquier cambio a estas historias será comparado contra dichos puntos de referencia.
 
 ![Chromatic baselines](/intro-to-storybook/chromatic-baselines.png)

--- a/content/intro-to-storybook/angular/pt/test.md
+++ b/content/intro-to-storybook/angular/pt/test.md
@@ -53,7 +53,7 @@ $ git commit -m "taskbox UI"
 Adiciona-se o pacote como dependência.
 
 ```bash
-npm install -D storybook-chromatic
+npm install -D chromatic
 ```
 
 Um aspeto fantástico acerca deste extra é que recorre á Git history para se manter a par dos componentes de interface de utilizador.
@@ -72,6 +72,8 @@ Execute o comando de testes na consola de forma a configurar os testes visuais d
 ```bash
 npx chromatic --project-token=<project-token>
 ```
+
+<div class="aside"> Se o seu Storybook tiver um script de compilação personalizado, poderá ter que <a href="https://www.chromatic.com/docs/setup#command-options">adicionar opções</a> a este comando.</div>
 
 Assim que o primeiro teste estiver concluído, é obtida a base de testes para cada estória. Por outras palavras, uma captura de cada estória considerada "boa". Alterações futuras a estas estórias, irão ser comparadas com esta base.
 

--- a/content/intro-to-storybook/react/en/test.md
+++ b/content/intro-to-storybook/react/en/test.md
@@ -74,7 +74,7 @@ npx chromatic --project-token=<project-token>
 ```
 
 <div class="aside">
-If your Storybook has a custom build script you may have to [add options](https://www.chromatic.com/docs/setup#command-options) to this command.
+If your Storybook has a custom build script you may have to <a href="https://www.chromatic.com/docs/setup#command-options">add options</a> to this command.
 </div>
 
 Once the first test is complete, we have test baselines for each story. In other words, screenshots of each story known to be “good”. Future changes to those stories will be compared to the baselines.

--- a/content/intro-to-storybook/react/es/test.md
+++ b/content/intro-to-storybook/react/es/test.md
@@ -95,6 +95,8 @@ Ejecuta el comando de prueba en la línea de comandos para configurar las prueba
 npx chromatic --project-token=<project-token>
 ```
 
+<div class="aside"> Si su Storybook tiene un script de compilación personalizado, es posible que deba <a href="https://www.chromatic.com/docs/setup#command-options"> agregar opciones </a> a este comando. </div>
+
 Una vez el primer test esté completo, tenemos líneas base de prueba para cada historia. En otras palabras, capturas de cada historia que ya se conocen como "buenas". Los futuros cambios a estas historias serán comparados con estás lineas base.
 
 ![Chromatic baselines](/intro-to-storybook/chromatic-baselines.png)

--- a/content/intro-to-storybook/react/nl/test.md
+++ b/content/intro-to-storybook/react/nl/test.md
@@ -92,7 +92,7 @@ npx chromatic --project-token=<project-token>
 ```
 
 <div class="aside">
-Als je Storybook een afwijkend build script heeft dan moet je mogelijk [opties toevoegen](https://www.chromatic.com/docs/setup#command-options) aan dit commando.
+Als je Storybook een afwijkend build script heeft dan moet je mogelijk <a href="https://www.chromatic.com/docs/setup#command-options">opties toevoegen </a> aan dit commando.
 </div>
 
 Zodra de eerste test is voltooid, hebben we test baselines voor elke story. Met andere woorden, screenshots van elke story die bekend staan als "goed". Toekomstige wijzigingen in die stories zullen worden vergeleken met de baselines.

--- a/content/intro-to-storybook/react/pt/test.md
+++ b/content/intro-to-storybook/react/pt/test.md
@@ -74,6 +74,8 @@ Execute o comando de testes na consola de forma a configurar os testes visuais d
 npx chromatic --project-token=<project-token>
 ```
 
+<div class="aside"> Se o seu Storybook tiver um script de compilação personalizado, poderá ter que <a href="https://www.chromatic.com/docs/setup#command-options">adicionar opções</a> a este comando. </div>
+
 Assim que o primeiro teste estiver concluído, é obtida a base de testes para cada estória. Por outras palavras, uma captura de cada estória considerada "boa". Alterações futuras a estas estórias, irão ser comparadas com esta base.
 
 ![Bases Chromatic](/intro-to-storybook/chromatic-baselines.png)

--- a/content/intro-to-storybook/svelte/en/test.md
+++ b/content/intro-to-storybook/svelte/en/test.md
@@ -89,7 +89,7 @@ Run the test command in the command line to setup visual regression tests for St
 ```
 
 <div class="aside">
-If your Storybook has a custom build script you may have to [add options](https://www.chromatic.com/docs/setup#command-options) to this command.
+If your Storybook has a custom build script you may have to <a href="https://www.chromatic.com/docs/setup#command-options">add options</a> to this command.
 </div>
 
 Once the first test is complete, we have test baselines for each story. In other words, screenshots of each story known to be “good”. Future changes to those stories will be compared to the baselines.

--- a/content/intro-to-storybook/vue/en/test.md
+++ b/content/intro-to-storybook/vue/en/test.md
@@ -74,7 +74,7 @@ npx chromatic --project-token=<project-token>
 ```
 
 <div class="aside">
-If your Storybook has a custom build script you may have to [add options](https://www.chromatic.com/docs/setup#command-options) to this command.
+If your Storybook has a custom build script you may have to <a href="https://www.chromatic.com/docs/setup#command-options"> add options </a> to this command.
 </div>
 
 Once the first test is complete, we have test baselines for each story. In other words, screenshots of each story known to be “good”. Future changes to those stories will be compared to the baselines.

--- a/content/intro-to-storybook/vue/es/test.md
+++ b/content/intro-to-storybook/vue/es/test.md
@@ -73,6 +73,8 @@ Ejecuta el comando de prueba en la línea de comandos para configurar las prueba
 npx chromatic --project-token=<project-token>
 ```
 
+<div class="aside"> Si su Storybook tiene un script de compilación personalizado, es posible que deba <a href="https://www.chromatic.com/docs/setup#command-options"> agregar opciones </a> a este comando. </div>
+
 Una vez el primer test esté completo, tenemos líneas base de prueba para cada historia. En otras palabras, capturas de cada historia que ya se conocen como "buenas". Los futuros cambios a estas historias serán comparados con estás lineas base.
 
 ![Chromatic baselines](/intro-to-storybook/chromatic-baselines.png)

--- a/content/intro-to-storybook/vue/pt/test.md
+++ b/content/intro-to-storybook/vue/pt/test.md
@@ -73,6 +73,8 @@ Execute o comando de testes na consola de forma a configurar os testes visuais d
 npx chromatic --project-token=<project-token>
 ```
 
+<div class="aside"> Se o seu Storybook tiver um script de compilação personalizado, poderá ter que <a href="https://www.chromatic.com/docs/setup#command-options">adicionar opções</a> a este comando. </div>
+
 Assim que o primeiro teste estiver concluído, é obtida a base de testes para cada estória. Por outras palavras, uma captura de cada estória considerada "boa". Alterações futuras a estas estórias, irão ser comparadas com esta base.
 
 ![Bases Chromatic](/intro-to-storybook/chromatic-baselines.png)


### PR DESCRIPTION
This small pr fixes how the text in the test section is displayed.

The current form is on a markdown way, but it should be shown as a html link as it's inside a div element.

Feel free to provide feedback.