### PR TITLE
Chore: fix for issue 320

### DIFF
--- a/src/components/screens/ChapterScreen/LanguageMenu/FrameworkMenu.js
+++ b/src/components/screens/ChapterScreen/LanguageMenu/FrameworkMenu.js
@@ -88,6 +88,7 @@ const getChapterInOtherLanguage = (
   const chapterInOtherLanguage = translationPages.edges.find(
     ({ node: { fields } }) => fields.slug === expectedSlug
   );
+
   if (chapterInOtherLanguage) {
     return expectedSlug;
   }
@@ -95,9 +96,11 @@ const getChapterInOtherLanguage = (
   const firstInOtherLanguage = translationPages.edges.find(
     ({ node: { fields } }) => fields.slug === expectedFirstChapter
   );
+
   // if it exists returns the expected first chapter
   if (firstInOtherLanguage) {
-    return firstInOtherLanguage;
+    // return firstInOtherLanguage;
+    return expectedFirstChapter;
   }
   // returns the default first chapter(ie the english version of the tutorial, preventing a 404)
   return `/${guide}/${framework}/en/${firstChapter}/`;


### PR DESCRIPTION
This small pr addresses and possibly close #320 .

What was done:
- In `src\components\ChapterScreen\LanguageMenu\FrameworkMenu.js`, the check inside `getChapterInOtherLanguage` will return the full object instead of the actual link/slug required for the navigation. This small fix covers it, instead of returning the whole object it will return the get started chapter.

@kylesuss and @domyen i would like for you to add some feedback on this. 
Also @Darth-Knoppix can you check the deploy preview and see if it's ok on your end.

Feel free to provide feedback