### PR TITLE
Added missing step of connecting app to Redux

### DIFF
--- a/content/intro-to-storybook/react/en/data.md
+++ b/content/intro-to-storybook/react/en/data.md
@@ -77,7 +77,7 @@ const defaultTasks = [
 export default createStore(reducer, { tasks: defaultTasks });
 ```
 
-After that, we need to update our `src/App.js` to be able to connect our React components to the Redux store. The <Provider /> makes the Redux store available to any nested components that have been wrapped in the connect() function.
+In our top-level app component (src/App.js) we can wire the store into our component hierarchy fairly easily:
 ```javascript
 import React, { Component } from 'react';
 import { Provider } from 'react-redux';

--- a/content/intro-to-storybook/react/en/data.md
+++ b/content/intro-to-storybook/react/en/data.md
@@ -79,20 +79,17 @@ export default createStore(reducer, { tasks: defaultTasks });
 
 In our top-level app component (src/App.js) we can wire the store into our component hierarchy fairly easily:
 ```javascript
-import React, { Component } from 'react';
+import React from 'react';
 import { Provider } from 'react-redux';
 import store from './lib/redux';
-
 import TaskList from './components/TaskList';
 
-class App extends Component {
-  render() {
-    return (
-      <Provider store={store}>
-        <TaskList />
-      </Provider>
-    );
-  }
+function App() {
+  return (
+    <Provider store={store}>
+       <TaskList />
+    </Provider>
+  );
 }
 
 export default App;

--- a/content/intro-to-storybook/react/en/data.md
+++ b/content/intro-to-storybook/react/en/data.md
@@ -77,6 +77,27 @@ const defaultTasks = [
 export default createStore(reducer, { tasks: defaultTasks });
 ```
 
+After that, we need to update our `src/App.js` to be able to connect our React components to the Redux store. The <Provider /> makes the Redux store available to any nested components that have been wrapped in the connect() function.
+```javascript
+import React, { Component } from 'react';
+import { Provider } from 'react-redux';
+import store from './lib/redux';
+
+import TaskList from './components/TaskList';
+
+class App extends Component {
+  render() {
+    return (
+      <Provider store={store}>
+        <TaskList />
+      </Provider>
+    );
+  }
+}
+
+export default App;
+```
+
 Then we’ll update the default export from the `TaskList` component to connect to the Redux store and render the tasks we are interested in:
 
 ```javascript


### PR DESCRIPTION
In the guide, the step of adding the provider in order to be able to use connect() is missing.