### PR TITLE
Import component for typescript

### DIFF
--- a/content/intro-to-storybook/react/en/using-addons.md
+++ b/content/intro-to-storybook/react/en/using-addons.md
@@ -73,15 +73,10 @@ import { action } from '@storybook/addon-actions';
 import { withKnobs, object } from '@storybook/addon-knobs/react';
 ```
 
-If using typescript
-
-```typescript
-// src/components/Task.stories.tsx
-
-import React from 'react';
-import { action } from '@storybook/addon-actions';
-import { withKnobs, object } from '@storybook/addon-knobs';
-```
+<div class="aside">
+  If you're using TypeScript, you'll need to make a small adjustment to the imports.
+  You'll need to use <code>import { withKnobs, object } from '@storybook/addon-knobs'</code> instead.
+</div>
 
 Next, within the `default` export of `Task.stories.js` file, add `withKnobs` to the `decorators` key:
 

--- a/content/intro-to-storybook/react/en/using-addons.md
+++ b/content/intro-to-storybook/react/en/using-addons.md
@@ -73,6 +73,16 @@ import { action } from '@storybook/addon-actions';
 import { withKnobs, object } from '@storybook/addon-knobs/react';
 ```
 
+If using typescript
+
+```typescript
+// src/components/Task.stories.tsx
+
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import { withKnobs, object } from '@storybook/addon-knobs';
+```
+
 Next, within the `default` export of `Task.stories.js` file, add `withKnobs` to the `decorators` key:
 
 ```javascript


### PR DESCRIPTION
Import location for typescript is different, which is not specified anywhere in document, as mentioned [here](https://github.com/storybookjs/storybook/issues/8817#issue-522091331), I have added a snippet for typescript explicitly.