### PR TITLE
Correct grammar in section title and body

### DIFF
--- a/content/intro-to-storybook/react/en/deploy.md
+++ b/content/intro-to-storybook/react/en/deploy.md
@@ -18,9 +18,9 @@ To deploy Storybook we first need to export it as a static web app. This functio
 
 Now when you build Storybook via `yarn build-storybook`, it will output a static Storybook in the `storybook-static` directory.
 
-## Continuous deploy
+## Continuous deployment
 
-We want to share the latest version of components whenever we push code. To do this we need to continuous deploy Storybook. We’ll rely on GitHub and Netlify to deploy our static site. We’re using the Netlify free plan.
+We want to share the latest version of components whenever we push code. To do this we need to continuously deploy Storybook. We’ll rely on GitHub and Netlify to deploy our static site. We’re using the Netlify free plan.
 
 ### GitHub
 


### PR DESCRIPTION
Change in heading

continuous deploy --> continuous deployment
Although deploy is the verb form, the adjective "continuous" is the point of emphasis, thus it dictates the structure of the phrase. Thus, the noun, deployment, should follow.

Change in body

continuous deploy --> continuously deploy
In this context, the "deploy" action takes centre stage, thus it dictates that the adverbial form, continuously, precede it.