### PR TITLE
Chore: minor rewording on intro to storybook react native version

### DIFF
--- a/content/intro-to-storybook/react-native/en/get-started.md
+++ b/content/intro-to-storybook/react-native/en/get-started.md
@@ -252,7 +252,7 @@ svn export https://github.com/chromaui/learnstorybook-code/branches/master/publi
 svn export https://github.com/google/fonts/trunk/ofl/nunitosans assets/font
 ```
 
-Next the assets need to be loaded into the app, for that we're going to update `useCachedResources.js` to the following:
+Next the assets need to be loaded into the app, for that we're going to update `hooks/useCachedResources.js` to the following:
 
 ```javascript
 // hooks/useCachedResources.js

--- a/content/intro-to-storybook/react-native/en/screen.md
+++ b/content/intro-to-storybook/react-native/en/screen.md
@@ -60,7 +60,7 @@ Then we create a container which grabs the data for `PureInboxScreen` in `screen
 // screens/InboxScreen.js
 import * as React from 'react';
 import { connect } from 'react-redux';
-import PureInboxScreen from './PureInboxScreen';
+import PureInboxScreen from '../components/PureInboxScreen';
 
 const InboxScreen = ({ error }) => {
   return <PureInboxScreen error={error} />;
@@ -87,8 +87,6 @@ export default function HomeScreen() {
   );
 }
 ```
-
-<div class="aside"><p>After this change, App-test that was setup by expo will probably break, you can bypass this by deleting the appropriate file in the __tests__ folder or adjust your test accordingly.</p></div>
 
 However, where things get interesting is in rendering the story in Storybook.
 

--- a/content/intro-to-storybook/react-native/es/get-started.md
+++ b/content/intro-to-storybook/react-native/es/get-started.md
@@ -20,7 +20,6 @@ Antes de sumergirse en el tutorial, tenga en cuenta las siguientes consideracion
 
 - A lo largo de este tutorial, se utilizará <code>yarn</code>. Si desea utilizar npm, seleccione la opción adecuada durante el proceso de inicialización de la aplicación y reemplace todos los comandos posteriores con npm.
 
-
 Con eso fuera del camino, ejecutemos los siguientes comandos:
 
 ```bash
@@ -66,7 +65,7 @@ jest.mock('global', () => ({
 }));
 ```
 
-Actualice el campo `jest` en` package.json`:
+Actualice el campo `jest` en`package.json`:
 
 ```json
 "jest": {
@@ -232,6 +231,7 @@ export const styles = StyleSheet.create({
   },
 });
 ```
+
 </details>
 
 ![Taskbox UI](/intro-to-storybook/ss-browserchrome-taskbox-learnstorybook.png)
@@ -250,10 +250,11 @@ Para que coincida con el diseño previsto, deberá descargar los directorios de 
 svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/icon assets/icon
 svn export <https://github.com/google/fonts/trunk/ofl/nunitosans> assets/font
 ```
-A continuación, los recursos deben cargarse en la aplicación, para eso vamos a actualizar `App.js` a lo siguiente:
+
+A continuación, los recursos deben cargarse en la aplicación, para eso vamos a actualizar `hooks/useCachedResources.js` a lo siguiente:
 
 ```javascript
-// App.js
+// hooks/useCachedResources.js
 async function loadResourcesAndDataAsync() {
   try {
     SplashScreen.preventAutoHide();
@@ -270,7 +271,6 @@ async function loadResourcesAndDataAsync() {
       'NunitoSans-Italic': require('./assets/font/NunitoSans-Italic.ttf'),
       NunitoSans: require('./assets/font/NunitoSans-Regular.ttf'),
     });
-
   } catch (e) {
     // We might want to provide this error information to an error reporting service
     console.warn(e);

--- a/content/intro-to-storybook/react-native/es/screen.md
+++ b/content/intro-to-storybook/react-native/es/screen.md
@@ -60,7 +60,7 @@ Luego, podemos crear un contenedor, que nuevamente toma los datos para `PureInbo
 // screens/InboxScreen.js
 import * as React from 'react';
 import { connect } from 'react-redux';
-import PureInboxScreen from './PureInboxScreen';
+import PureInboxScreen from '../components/PureInboxScreen';
 
 const InboxScreen = ({ error }) => {
   return <PureInboxScreen error={error} />;
@@ -87,8 +87,6 @@ export default function HomeScreen() {
   );
 }
 ```
-
-<div class="aside"><p>Después de este cambio, la prueba de aplicación que configuró expo probablemente se romperá, puede omitir esto eliminando el archivo apropiado en la carpeta __tests__ o ajustar su prueba en consecuencia.</p></div>
 
 Sin embargo, al intentar mostrar nuestro componente "contenedor" dentro de Storybook las cosas se ponen interesantes.
 


### PR DESCRIPTION
This pr follows up on #327 that was merged recently. 

The get started chapter was updated so that both the snippet and text match. 

In the screen chapter the aside mentioning the "App-test" was removed as of the current state of the template the folder/file no longer exist. 

In the screen section the snippet was updated to fix the correct import of the component.

The spanish translation was updated aswell to reflect these changes.


