### PR TITLE
Replace deprecated SplashScreen functions on get-started.md

### DIFF
--- a/content/intro-to-storybook/react-native/en/get-started.md
+++ b/content/intro-to-storybook/react-native/en/get-started.md
@@ -258,7 +258,7 @@ Next the assets need to be loaded into the app, for that we're going to update `
 // hooks/useCachedResources.js
 async function loadResourcesAndDataAsync() {
   try {
-    SplashScreen.preventAutoHide();
+    SplashScreen.preventAutoHideAsync();
 
     // Load our initial navigation state
     setInitialNavigationState(await getInitialState());
@@ -277,7 +277,7 @@ async function loadResourcesAndDataAsync() {
     console.warn(e);
   } finally {
     setLoadingComplete(true);
-    SplashScreen.hide();
+    SplashScreen.hideAsync();
   }
 }
 ```


### PR DESCRIPTION
Replace deprecated functions: `SplashScreen.preventAutoHide`, `SplashScreen.hide`

Ref: https://docs.expo.io/versions/v37.0.0/sdk/splash-screen/#api