### PR TITLE
Reflect the change from Expo 37 on get-started.md

### DIFF
--- a/content/intro-to-storybook/react-native/en/get-started.md
+++ b/content/intro-to-storybook/react-native/en/get-started.md
@@ -260,9 +260,6 @@ async function loadResourcesAndDataAsync() {
   try {
     SplashScreen.preventAutoHide();
 
-    // Load our initial navigation state
-    setInitialNavigationState(await getInitialState());
-
     // Load fonts
     await Font.loadAsync({
       ...Ionicons.font,


### PR DESCRIPTION
Remove setInitialNavigationState as Expo 37 updated.

I believe the line has been removed in Expo 37 or earlier.

Ref: https://github.com/expo/expo/blob/master/templates/expo-template-tabs/hooks/useCachedResources.ts