### PR TITLE
Chore: (intro to storybook) restructure create addons section

### DIFF
--- a/content/intro-to-storybook/angular/en/creating-addons.md
+++ b/content/intro-to-storybook/angular/en/creating-addons.md
@@ -1,6 +1,6 @@
 ---
-title: 'Creating addons'
-tocTitle: 'Creating addons'
+title: 'Bonus: Create an addon'
+tocTitle: 'Bonus: Creating addons'
 description: 'Learn how to build your own addons that will super charge your development'
 ---
 

--- a/content/intro-to-storybook/angular/en/using-addons.md
+++ b/content/intro-to-storybook/angular/en/using-addons.md
@@ -165,8 +165,4 @@ If we are using [visual regression testing](/angular/en/test/), we will also be 
 
 Don't forget to merge your changes with git!
 
-<!-- this is commented based on the restructuring that was introduced with pr 341. Once 6.0 lands this needs to be added back based on controls.-->
-<!--
-## Sharing Addons With The Team
-
-Knobs is a great way to get non-developers playing with your components and stories. However, it can be difficult for them to run the storybook on their local machine. That's why deploying your storybook to an online location can be really helpful. In the next chapter we'll do just that! -->
+<div class="aside"><p>As we've seen, Knobs is a great way to get non-developers playing with your components and stories. However, there are many more ways you can customize Storybook to fit your workflow with addons. In the <a href="/intro-to-storybook/react/en/creating-addons">create addons bonus chapter</a> we'll teach you that, by creating a addon that will help you supercharge your development workflow.</p></div>

--- a/content/intro-to-storybook/angular/en/using-addons.md
+++ b/content/intro-to-storybook/angular/en/using-addons.md
@@ -165,6 +165,8 @@ If we are using [visual regression testing](/angular/en/test/), we will also be 
 
 Don't forget to merge your changes with git!
 
+<!-- this is commented based on the restructuring that was introduced with pr 341. Once 6.0 lands this needs to be added back based on controls.-->
+<!--
 ## Sharing Addons With The Team
 
-Knobs is a great way to get non-developers playing with your components and stories. However, it can be difficult for them to run the storybook on their local machine. That's why deploying your storybook to an online location can be really helpful. In the next chapter we'll do just that!
+Knobs is a great way to get non-developers playing with your components and stories. However, it can be difficult for them to run the storybook on their local machine. That's why deploying your storybook to an online location can be really helpful. In the next chapter we'll do just that! -->

--- a/content/intro-to-storybook/angular/pt/creating-addons.md
+++ b/content/intro-to-storybook/angular/pt/creating-addons.md
@@ -1,6 +1,6 @@
 ---
-title: 'Criação de extras'
-tocTitle: 'Criação de extras'
+title: 'Bonus: Criar um extra'
+tocTitle: 'Bonus: Criação de extras'
 description: 'Aprende a criar os teus próprios extras que irão impulsionar o teu desenvolvimento'
 ---
 

--- a/content/intro-to-storybook/angular/pt/using-addons.md
+++ b/content/intro-to-storybook/angular/pt/using-addons.md
@@ -167,6 +167,8 @@ Tais casos extremos considerados obscuros têm tendência a ser esquecidos!
 
 Não esquecer de fundir as alterações com o git!
 
-## Partilha de extras com a equipa
+<!-- this is commented based on the restructuring that was introduced with pr 341. Once 6.0 lands this needs to be added back based on controls.-->
 
-Knobs é uma forma fantástica de forma a permitir que elementos não programadores brinquem com os componentes e estórias. No entanto, pode ser difícil para estes executarem o Storybook nos seus ambientes locais. É por isso que uma implementação online pode ajudar em muito. No próximo capitulo iremos fazer exatamente isso!
+<!-- ## Partilha de extras com a equipa
+
+Knobs é uma forma fantástica de forma a permitir que elementos não programadores brinquem com os componentes e estórias. No entanto, pode ser difícil para estes executarem o Storybook nos seus ambientes locais. É por isso que uma implementação online pode ajudar em muito. No próximo capitulo iremos fazer exatamente isso! -->

--- a/content/intro-to-storybook/index.md
+++ b/content/intro-to-storybook/index.md
@@ -17,9 +17,9 @@ toc:
     'deploy',
     'test',
     'using-addons',
-    'creating-addons',
     'conclusion',
     'contribute',
+    'creating-addons',
   ]
 coverImagePath: '/guide-cover/intro.svg'
 thumbImagePath: '/guide-thumb/intro.svg'

--- a/content/intro-to-storybook/react-native/en/using-addons.md
+++ b/content/intro-to-storybook/react-native/en/using-addons.md
@@ -37,7 +37,6 @@ yarn add -D @storybook/addon-knobs @storybook/addon-ondevice-knobs
 Register Knobs in your `storybook/addons.js` file.
 
 ```javascript
-
 // storybook/addons.js
 import '@storybook/addon-actions/register';
 import '@storybook/addon-knobs/register';
@@ -67,7 +66,6 @@ Let's use the object knob type in the `Task` component.
 First, import the `withKnobs` decorator and the `object` knob type to `Task.stories.js`:
 
 ```javascript
-
 // components/Task.stories.js
 import React from 'react';
 import { storiesOf } from '@storybook/react';
@@ -78,7 +76,6 @@ import { withKnobs, object } from '@storybook/addon-knobs';
 Next, within the stories of `Task`, pass `withKnobs` as a parameter to the `addDecorator()` function:
 
 ```javascript
-
 // components/Task.stories.js
 storiesOf('Task', module)
   .addDecorator(withKnobs)
@@ -88,7 +85,6 @@ storiesOf('Task', module)
 Lastly, integrate the `object` knob type within the "default" story:
 
 ```javascript
-
 // components/Task.stories.js
 storiesOf('Task', module)
   .addDecorator(withKnobs)
@@ -114,7 +110,6 @@ Additionally, with easy access to editing passed data to a component, QA Enginee
 Thanks to quickly being able to try different inputs to a component we can find and fix such problems with relative ease! Let's fix the issue with overflowing by adding a style to `Task.js`:
 
 ```javascript
-
 // components/Task.js
 // This is the input for our task title. It was changed to a simple text contrary to textinput,
 // to illustrate how to see what's intended
@@ -138,7 +133,6 @@ Of course we can always reproduce this problem by entering the same input into t
 Let's add a story for the long text case in Task.stories.js:
 
 ```javascript
-
 // components/Task.stories.js
 const longTitle = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not!`;
 
@@ -153,11 +147,13 @@ Now we've added the story, we can reproduce this edge-case with ease whenever we
 
 ![Here it is in Storybook.](/intro-to-storybook/addon-knobs-demo-edge-case-in-storybook.png)
 
-
 ### Merge Changes
 
 Don't forget to merge your changes with git!
 
-## Sharing Addons With The Team
+<!-- this is commented based on the restructuring that was introduced with pr 341. Once 6.0 lands this needs to be added back based on controls.-->
+
+<!-- ## Sharing Addons With The Team
 
 Knobs is a great way to get non-developers playing with your components and stories. However, it can be difficult for them to run the storybook on their local machine. That's why deploying your storybook to an online location can be really helpful. In the next chapter we'll do just that!
+ -->

--- a/content/intro-to-storybook/react-native/es/using-addons.md
+++ b/content/intro-to-storybook/react-native/es/using-addons.md
@@ -37,7 +37,6 @@ yarn add -D @storybook/addon-knobs @storybook/addon-ondevice-knobs
 Registra Knobs en tu archivo `storybook/addons.js`.
 
 ```javascript
-
 // storybook/addons.js
 import '@storybook/addon-actions/register';
 import '@storybook/addon-knobs/register';
@@ -47,7 +46,6 @@ import '@storybook/addon-links/register';
 Y tambien en `storybook/rn-addons.js`.
 
 ```javascript
-
 // storybook/rn-addons.js
 import '@storybook/addon-ondevice-actions/register';
 import '@storybook/addon-ondevice-knobs/register';
@@ -68,7 +66,6 @@ Usemos el tipo de knob de objeto en el componente `Task`.
 Primero, importe el decorador `withKnobs` y el tipo de knob `object` a `Task.stories.js`:
 
 ```javascript
-
 // components/Task.stories.js
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
@@ -89,7 +86,6 @@ storiesOf('Task', module)
 Por último, integre el tipo de knob `object` dentro de la historia "predeterminada":
 
 ```javascript
-
 // components/Task.stories.js
 storiesOf('Task', module)
   .addDecorator(withKnobs)
@@ -115,7 +111,6 @@ Además, con un fácil acceso para editar los datos pasados ​​a un component
 ¡Gracias a poder probar rápidamente diferentes entradas a un componente, podemos encontrar y solucionar estos problemas con relativa facilidad! Arreglemos el problema de desbordamiento agregando un estilo a `Task.js`:
 
 ```javascript
-
 // components/Task.js
 // This is the input for our task title. It was changed to a simple text contrary to textinput,
 // to illustrate how to see what's intended
@@ -139,7 +134,6 @@ Por supuesto, siempre podemos reproducir este problema ingresando la misma entra
 Agreguemos una historia para el caso de texto largo en `Task.stories.js`:
 
 ```javascript
-
 // components/Task.stories.js
 const longTitle = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not`;
 
@@ -158,6 +152,9 @@ Ahora que hemos agregado la historia, podemos reproducir este caso extremo con f
 
 ¡No olvides fusionar tus cambios con git!
 
-## Compartir complementos con el equipo
+<!-- this is commented based on the restructuring that was introduced with pr 341. Once 6.0 lands this needs to be added back based on controls.-->
+
+<!-- ## Compartir complementos con el equipo
 
 Knobs es una excelente manera de hacer que los no desarrolladores jueguen con sus componentes e historias. Sin embargo, puede ser difícil para ellos ejecutar Storybook en su máquina local. Es por eso que implementar storybook en una ubicación en línea puede ser realmente útil. ¡En el próximo capítulo haremos exactamente eso!
+ -->

--- a/content/intro-to-storybook/react/de/creating-addons.md
+++ b/content/intro-to-storybook/react/de/creating-addons.md
@@ -1,6 +1,6 @@
 ---
-title: 'Addons erstellen'
-tocTitle: 'Addons erstellen'
+title: 'Bonus: Erstelle ein Addon'
+tocTitle: 'Bonus: Addons erstellen'
 description: 'Lerne, eigene Addons zu bauen, die deine Entwicklung beschleunigen'
 commit: 'bebba5d'
 ---

--- a/content/intro-to-storybook/react/de/using-addons.md
+++ b/content/intro-to-storybook/react/de/using-addons.md
@@ -147,6 +147,9 @@ Sofern wir [visuelle Regressions-Tests](/react/de/test/) verwenden, werden wir n
 
 Vergiss nicht, deine Änderungen in Git zu mergen!
 
+<!-- this is commented based on the restructuring that was introduced with pr 341. Once 6.0 lands this needs to be added back based on controls.-->
+
+<!--
 ## Addons mit dem Team teilen
 
-Knobs ist eine schöne Möglichkeit für Nicht-Entwickler mit deinen Komponenten und Stories herumzuspielen. Es könnte ihnen aber Schwierigkeiten bereiten, das Storybook auf ihren lokalen Rechnern zu starten. Aus diesem Grund kann es hilfreich sein, dein Storybook online zu deployen. Im nächsten Kapitel machen wir genau das!
+Knobs ist eine schöne Möglichkeit für Nicht-Entwickler mit deinen Komponenten und Stories herumzuspielen. Es könnte ihnen aber Schwierigkeiten bereiten, das Storybook auf ihren lokalen Rechnern zu starten. Aus diesem Grund kann es hilfreich sein, dein Storybook online zu deployen. Im nächsten Kapitel machen wir genau das! -->

--- a/content/intro-to-storybook/react/en/creating-addons.md
+++ b/content/intro-to-storybook/react/en/creating-addons.md
@@ -1,11 +1,11 @@
 ---
-title: 'Creating addons'
-tocTitle: 'Creating addons'
+title: 'Bonus: Create an addon'
+tocTitle: 'Bonus: Creating addons'
 description: 'Learn how to build your own addons that will super charge your development'
 commit: 'bebba5d'
 ---
 
-Throughout this tutorial we were introduced to one of the key features of Storybook, its robust system of [addons](https://storybook.js.org/addons/introduction/), which can be used to enhance not only yours but also your team's developer experience and workflows.
+Earlier, we introduced a key Storybook feature: the robust [addons](https://storybook.js.org/addons/introduction/) ecosystem. Addons are used to enhance your developer experience and workflows.
 
 In this bonus chapter, we're going to take a look on how we create our own addon. You might think that writing it can be a daunting task, but actually it's not, we just need to take a couple of steps to get started and we can start writing it.
 

--- a/content/intro-to-storybook/react/en/creating-addons.md
+++ b/content/intro-to-storybook/react/en/creating-addons.md
@@ -5,9 +5,9 @@ description: 'Learn how to build your own addons that will super charge your dev
 commit: 'bebba5d'
 ---
 
-In the previous chapter we were introduced to one of the key features of Storybook, its robust system of [addons](https://storybook.js.org/addons/introduction/), which can be used to enhance not only yours but also your team's developer experience and workflows.
+Throughout this tutorial we were introduced to one of the key features of Storybook, its robust system of [addons](https://storybook.js.org/addons/introduction/), which can be used to enhance not only yours but also your team's developer experience and workflows.
 
-In this chapter we're going to take a look on how we create our own addon. You might think that writing it can be a daunting task, but actually it's not, we just need to take a couple of steps to get started and we can start writing it.
+In this bonus chapter, we're going to take a look on how we create our own addon. You might think that writing it can be a daunting task, but actually it's not, we just need to take a couple of steps to get started and we can start writing it.
 
 But first thing is first, let's first scope out what our addon will do.
 
@@ -40,7 +40,7 @@ export default {
 
 We've outlined what our addon will do, it's time to start working on it.
 
-In the root of your project folder, create a new file called `.babelrc` with the following inside:
+In the root folder of your project, create a new file called `.babelrc` with the following inside:
 
 ```json
 {
@@ -89,7 +89,7 @@ addons.register('my/design-addon', () => {
 });
 ```
 
-This is the a typical boilerplate code to get started and going over what the code is doing:
+This is the typical boilerplate code to get you started. Going over what the code is doing:
 
 - We're registering a new addon in our Storybook.
 - Add a new UI element for our addon with some options (a title that will define our addon and the type of element used) and render it with some text for now.

--- a/content/intro-to-storybook/react/en/using-addons.md
+++ b/content/intro-to-storybook/react/en/using-addons.md
@@ -158,3 +158,5 @@ If we are using [visual regression testing](/react/en/test/), we will also be in
 ### Merge Changes
 
 Don't forget to merge your changes with git!
+
+<div class="aside"><p>As we've seen, Knobs is a great way to get non-developers playing with your components and stories. However, there are many more ways you can customize Storybook to fit your workflow with addons. In the <a href="/intro-to-storybook/react/en/creating-addons">create addons</a> bonus chapter we'll teach you that, by creating a addon that will help you supercharge your development workflow.</p></div>

--- a/content/intro-to-storybook/react/en/using-addons.md
+++ b/content/intro-to-storybook/react/en/using-addons.md
@@ -158,7 +158,3 @@ If we are using [visual regression testing](/react/en/test/), we will also be in
 ### Merge Changes
 
 Don't forget to merge your changes with git!
-
-## Creating your own addon
-
-As we've seen, Knobs is a great way to get non-developers playing with your components and stories. However, there are many more ways you can customize Storybook to fit your workflow with addons. In the next chapter, we'll guide you through creating an addon that shows your static design alongside your development.

--- a/content/intro-to-storybook/react/nl/creating-addons.md
+++ b/content/intro-to-storybook/react/nl/creating-addons.md
@@ -1,6 +1,6 @@
 ---
-title: 'Maken van addons'
-tocTitle: 'Maken van addons'
+title: 'Bonus: maak een addons'
+tocTitle: 'Bonus: Maken van addons'
 description: 'Leer hoe je je eigen add-ons kunt bouwen die je ontwikkeling boosten'
 commit: 'bebba5d'
 ---

--- a/content/intro-to-storybook/react/nl/using-addons.md
+++ b/content/intro-to-storybook/react/nl/using-addons.md
@@ -151,6 +151,7 @@ Als we [visuele regressietests](/react/en/test/) gebruiken, zullen we ook worden
 
 Vergeet niet je wijzigingen te mergen met git!
 
-## Addons delen met het team
+<!-- this is commented based on the restructuring that was introduced with pr 341. Once 6.0 lands this needs to be added back based on controls.-->
+<!-- ## Addons delen met het team
 
-Knobs is een geweldige manier om niet-developers met je componenten en stories te laten spelen. Het kan echter moeilijk zijn om het storybook op hun lokale computer uit te voeren. Daarom kan het handig zijn om je storybook naar een online locatie te deployen. In het volgende hoofdstuk zullen we precies dat doen!
+Knobs is een geweldige manier om niet-developers met je componenten en stories te laten spelen. Het kan echter moeilijk zijn om het storybook op hun lokale computer uit te voeren. Daarom kan het handig zijn om je storybook naar een online locatie te deployen. In het volgende hoofdstuk zullen we precies dat doen! -->

--- a/content/intro-to-storybook/react/pt/creating-addons.md
+++ b/content/intro-to-storybook/react/pt/creating-addons.md
@@ -1,6 +1,6 @@
 ---
-title: 'Criação de extras'
-tocTitle: 'Criação de extras'
+title: 'Bonus: Criar um extra'
+tocTitle: 'Bonus: Criação de extras'
 description: 'Aprende a criar os teus próprios extras que irão impulsionar o teu desenvolvimento'
 commit: 'bebba5d'
 ---

--- a/content/intro-to-storybook/react/pt/using-addons.md
+++ b/content/intro-to-storybook/react/pt/using-addons.md
@@ -158,6 +158,8 @@ Tais casos extremos considerados obscuros têm tendência a ser esquecidos!
 
 Não esquecer de fundir as alterações com o git!
 
-## Partilha de extras com a equipa
+<!-- this is commented based on the restructuring that was introduced with pr 341. Once 6.0 lands this needs to be added back based on controls.-->
 
-Knobs é uma forma fantástica de forma a permitir que elementos não programadores brinquem com os componentes e estórias. No entanto, pode ser difícil para estes executarem o Storybook nos seus ambientes locais. É por isso que uma implementação online pode ajudar em muito. No próximo capitulo iremos fazer exatamente isso!!
+<!-- ## Partilha de extras com a equipa
+
+Knobs é uma forma fantástica de forma a permitir que elementos não programadores brinquem com os componentes e estórias. No entanto, pode ser difícil para estes executarem o Storybook nos seus ambientes locais. É por isso que uma implementação online pode ajudar em muito. No próximo capitulo iremos fazer exatamente isso!! -->

--- a/content/intro-to-storybook/svelte/en/creating-addons.md
+++ b/content/intro-to-storybook/svelte/en/creating-addons.md
@@ -1,6 +1,6 @@
 ---
-title: 'Creating addons'
-tocTitle: 'Creating addons'
+title: 'Bonus: Create an addon'
+tocTitle: 'Bonus: Creating addons'
 description: 'Learn how to build your own addons that will super charge your development'
 ---
 

--- a/content/intro-to-storybook/svelte/en/using-addons.md
+++ b/content/intro-to-storybook/svelte/en/using-addons.md
@@ -160,9 +160,4 @@ If we are using [visual regression testing](/svelte/en/test/), we will also be i
 
 Don't forget to merge your changes with git!
 
-<!-- this is commented based on the restructuring that was introduced with pr 341. Once 6.0 lands this needs to be added back based on controls.-->
-<!--
-## Sharing Addons With The Team
-
-Knobs is a great way to get non-developers playing with your components and stories. However, it can be difficult for them to run the storybook on their local machine. That's why deploying your storybook to an online location can be really helpful. In the next chapter we'll do just that!
- -->
+<div class="aside"><p>As we've seen, Knobs is a great way to get non-developers playing with your components and stories. However, there are many more ways you can customize Storybook to fit your workflow with addons. In the <a href="/intro-to-storybook/react/en/creating-addons">create addons</a> bonus chapter we'll teach you that, by creating a addon that will help you supercharge your development workflow.</p></div>

--- a/content/intro-to-storybook/svelte/en/using-addons.md
+++ b/content/intro-to-storybook/svelte/en/using-addons.md
@@ -160,6 +160,9 @@ If we are using [visual regression testing](/svelte/en/test/), we will also be i
 
 Don't forget to merge your changes with git!
 
+<!-- this is commented based on the restructuring that was introduced with pr 341. Once 6.0 lands this needs to be added back based on controls.-->
+<!--
 ## Sharing Addons With The Team
 
 Knobs is a great way to get non-developers playing with your components and stories. However, it can be difficult for them to run the storybook on their local machine. That's why deploying your storybook to an online location can be really helpful. In the next chapter we'll do just that!
+ -->

--- a/content/intro-to-storybook/svelte/es/creating-addons.md
+++ b/content/intro-to-storybook/svelte/es/creating-addons.md
@@ -1,6 +1,6 @@
 ---
-title: 'Creando complementos'
-tocTitle: 'Creando complementos'
+title: 'Bonificación: Crear un complemento'
+tocTitle: 'Bonificación: Creando complementos'
 description: 'Aprende a construir tus propios complementos que cargarán tu desarrollo'
 ---
 
@@ -16,9 +16,9 @@ Para este ejemplo, supongamos que nuestro equipo tiene algunos recursos de dise�
 
 Tenemos nuestro objetivo, ahora definamos qué características admitirá nuestro complemento:
 
--   Mostrar el elemento de diseño en un panel
--   Imágenes de soporte, pero también urls para incrustar
--   Debe admitir múltiples recursos, en caso de que haya múltiples versiones o temas
+- Mostrar el elemento de diseño en un panel
+- Imágenes de soporte, pero también urls para incrustar
+- Debe admitir múltiples recursos, en caso de que haya múltiples versiones o temas
 
 La forma en que adjuntaremos la lista de recursos a las historias es a través de [parámetros](https://storybook.js.org/docs/configurations/options-parameter/), que es una opción de Storybook que nos permite inyectar parámetros personalizados para nuestras historias. La forma de usarlo es bastante similar a cómo usamos un decorador en capítulos anteriores.
 
@@ -39,7 +39,7 @@ export default {
 
 ## Configuración
 
-Hemos esbozado lo que hará nuestro complemento, es hora de configurar nuestro entorno de desarrollo local. 
+Hemos esbozado lo que hará nuestro complemento, es hora de configurar nuestro entorno de desarrollo local.
 
 Comenzaremos agregando un paquete adicional a nuestro proyecto. Más específicamente `@babel/preset-react`, este paquete nos permitirá usar el código React dentro de nuestra aplicación Svelte sin ningún problema.
 
@@ -104,7 +104,6 @@ Este es un código de un boilerplate típico para comenzar y repasar lo que est�
 - Agregue un nuevo elemento de interfaz de usuario para nuestro complemento con algunas opciones (un título que definirá nuestro complemento y el tipo de elemento utilizado) y renderícelo con algo de texto por ahora.
 
 Comenzando Storybook en este punto, aún no podremos ver el complemento. Como hicimos anteriormente con el complemento Knobs, necesitamos registrar el nuestro en el archivo `.storybook/main.js`. Simplemente agregue lo siguiente a la lista de `complementos` ya existente:
-
 
 ```js
 // .storybook/main.js
@@ -198,7 +197,7 @@ Tenga en cuenta que estamos usando el [useParameter](https://storybook.js.org/do
 
 Hemos conectado todas las piezas necesarias. Pero, ¿cómo podemos ver si realmente funciona y muestra algo?
 
-Para hacerlo, haremos un pequeño cambio en el archivo `task.stories.js` y agregaremos la opción[parameters](<https://storybook.js.org/docs/configurations/options-parameter/#per-story-options>).
+Para hacerlo, haremos un pequeño cambio en el archivo `task.stories.js` y agregaremos la opción[parameters](https://storybook.js.org/docs/configurations/options-parameter/#per-story-options).
 
 ```javascript
 // src/components/task.stories.js

--- a/content/intro-to-storybook/svelte/es/using-addons.md
+++ b/content/intro-to-storybook/svelte/es/using-addons.md
@@ -160,6 +160,9 @@ Si estamos utilizando [pruebas de regresión visual](/svelte/es/test/), también
 
 ¡No olvides fusionar tus cambios con git!
 
-## Compartir complementos con el equipo
+<!-- this is commented based on the restructuring that was introduced with pr 341. Once 6.0 lands this needs to be added back based on controls.-->
+
+<!-- ## Compartir complementos con el equipo
 
 Knobs es una excelente manera de hacer que los no desarrolladores jueguen con sus componentes e historias. Sin embargo, puede ser difícil para ellos ejecutar Storybook en su máquina local. Es por eso que implementar storybook en una ubicación en línea puede ser realmente útil. ¡En el próximo capítulo haremos exactamente eso!
+ -->

--- a/content/intro-to-storybook/vue/en/using-addons.md
+++ b/content/intro-to-storybook/vue/en/using-addons.md
@@ -168,6 +168,8 @@ If we are using [visual regression testing](/vue/en/test/), we will also be info
 
 Don't forget to merge your changes with git!
 
-## Sharing Addons With The Team
+<!-- this is commented based on the restructuring that was introduced with pr 341. Once 6.0 lands this needs to be added back based on controls.-->
 
-Knobs is a great way to get non-developers playing with your components and stories. However, it can be difficult for them to run the Storybook on their local machine. That's why deploying your storybook to an online location can be really helpful. In the next chapter we'll do just that!
+<!-- ## Sharing Addons With The Team
+
+Knobs is a great way to get non-developers playing with your components and stories. However, it can be difficult for them to run the Storybook on their local machine. That's why deploying your storybook to an online location can be really helpful. In the next chapter we'll do just that! -->

--- a/content/intro-to-storybook/vue/es/using-addons.md
+++ b/content/intro-to-storybook/vue/es/using-addons.md
@@ -168,6 +168,9 @@ Si estamos utilizando [pruebas de regresión visual](/vue/es/test/), también se
 
 ¡No olvides fusionar tus cambios con git!
 
-## Compartir complementos con el equipo
+<!-- this is commented based on the restructuring that was introduced with pr 341. Once 6.0 lands this needs to be added back based on controls.-->
+
+<!-- ## Compartir complementos con el equipo
 
 Knobs es una excelente manera de hacer que los no desarrolladores jueguen con sus componentes e historias. Sin embargo, puede ser difícil para ellos ejecutar Storybook en su máquina local. Es por eso que implementar storybook en una ubicación en línea puede ser realmente útil. ¡En el próximo capítulo haremos exactamente eso!
+ -->

--- a/content/intro-to-storybook/vue/pt/using-addons.md
+++ b/content/intro-to-storybook/vue/pt/using-addons.md
@@ -171,6 +171,9 @@ Tais casos extremos considerados obscuros têm tendência a ser esquecidos!
 
 Não esquecer de fundir as alterações com o git!
 
+<!-- this is commented based on the restructuring that was introduced with pr 341. Once 6.0 lands this needs to be added back based on controls.-->
+<!--
 ## Partilha de extras com a equipa
 
 Knobs é uma forma fantástica de forma a permitir que elementos não programadores brinquem com os componentes e estórias. No entanto, pode ser difícil para estes executarem o Storybook nos seus ambientes locais. É por isso que uma implementação online pode ajudar em muito. No próximo capitulo iremos fazer exatamente isso!
+ -->


### PR DESCRIPTION
With this pr the intro to storybook create addons section was moved in the toc list.

What was done:
- Applied some minor wording and fixed some typos.
- Fixed the using addons section, by commenting out (for now), the last section as it was introducing issues, due to the fact that #341 was just merged. 


Feel free to provide feedback