### PR TITLE
Update official addons page link in using addons chapter

### DIFF
--- a/content/intro-to-storybook/angular/en/using-addons.md
+++ b/content/intro-to-storybook/angular/en/using-addons.md
@@ -10,7 +10,7 @@ everybody in your team. If you've been following along with this tutorial linear
 <div class="aside">
 <strong>Looking for a list of potential addons?</strong>
 <br/>
-😍 You can see the list of officially-supported and strongly-supported community addons <a href="https://storybook.js.org/addons/addon-gallery/">here</a>.
+😍 You can see the list of officially-supported and strongly-supported community addons <a href="https://storybook.js.org/addons">here</a>.
 </div>
 
 We could write forever about configuring and using addons for all of your particular use-cases. For now, let's work towards integrating one of the most popular addons within Storybook's ecosystem: [knobs](https://github.com/storybooks/storybook/tree/master/addons/knobs).

--- a/content/intro-to-storybook/angular/pt/using-addons.md
+++ b/content/intro-to-storybook/angular/pt/using-addons.md
@@ -9,7 +9,7 @@ Storybook possui um sistema robusto de [extras](https://storybook.js.org/addons/
 <div class="aside">
     <strong>Á procura de uma lista de extras?</strong>
     <br/>
-    😍 A lista de extras oficiais e da comunidade pode ser consultada <a href="https://storybook.js.org/addons/addon-gallery/">aqui</a>.
+    😍 A lista de extras oficiais e da comunidade pode ser consultada <a href="https://storybook.js.org/addons">aqui</a>.
 </div>
 
 Poderíamos ficar aqui eternamente a discutir como configurar e usar os extras para todos os casos. Por enquanto, vamos focar-nos em integrar um dos extras mais populares no ecossistema Storybook: [knobs](https://github.com/storybooks/storybook/tree/master/addons/knobs).

--- a/content/intro-to-storybook/react-native/en/using-addons.md
+++ b/content/intro-to-storybook/react-native/en/using-addons.md
@@ -10,7 +10,7 @@ everybody in your team.
 <div class="aside">
 <strong>Looking for a list of potential addons?</strong>
 <br/>
-😍 You can see the list of officially-supported and strongly-supported community addons <a href="https://storybook.js.org/addons/addon-gallery/">here</a>.
+😍 You can see the list of officially-supported and strongly-supported community addons <a href="https://storybook.js.org/addons">here</a>.
 </div>
 
 We could write forever about configuring and using addons for all of your particular use-cases. For now, let's work towards integrating one of the most popular addons within Storybook's ecosystem: [knobs](https://github.com/storybooks/storybook/tree/master/addons/knobs).

--- a/content/intro-to-storybook/react-native/es/using-addons.md
+++ b/content/intro-to-storybook/react-native/es/using-addons.md
@@ -10,7 +10,7 @@ todos en tu equipo.
 <div class = "aside">
     <strong> ¿Busca una lista de posibles complementos? </strong>
     <br/>
-    😍 Puede ver la lista de complementos de la comunidad con respaldo oficial y con un fuerte respaldo <a href="https://storybook.js.org/addons/addon-gallery/"> aquí </a>.
+    😍 Puede ver la lista de complementos de la comunidad con respaldo oficial y con un fuerte respaldo <a href="https://storybook.js.org/addons"> aquí </a>.
 </div>
 
 Podríamos escribir para siempre sobre la configuración y el uso de complementos para todos sus casos de uso particulares. Por ahora, trabajemos para integrar uno de los complementos más populares dentro del ecosistema de Storybook: [knobs](https://github.com/storybooks/storybook/tree/master/addons/knobs).

--- a/content/intro-to-storybook/react/de/using-addons.md
+++ b/content/intro-to-storybook/react/de/using-addons.md
@@ -10,7 +10,7 @@ Storybook rühmt sich eines robuten [Addon-Systems](https://storybook.js.org/add
 <div class="aside">
 <strong>Auf der Suche nach einer Liste verfügbarer Addons?</strong>
 <br/>
-😍 <a href="https://storybook.js.org/addons/addon-gallery/">Hier</a> findest du die Liste offiziell unterstützter und von der Community aktiv unterstützer Addons.
+😍 <a href="https://storybook.js.org/addons">Hier</a> findest du die Liste offiziell unterstützter und von der Community aktiv unterstützer Addons.
 </div>
 
 Wir könnten unendlich viel über die Verwendung von Addons für all deine speziellen Anwendungsfälle schreiben. Fürs Erste, lass uns auf die Integration eines der am weitesten verbreiteten Addons innerhalb des Storybook-Ökosystems hinarbeiten: [knobs](https://github.com/storybooks/storybook/tree/master/addons/knobs).

--- a/content/intro-to-storybook/react/en/using-addons.md
+++ b/content/intro-to-storybook/react/en/using-addons.md
@@ -11,7 +11,7 @@ everybody in your team. If you've been following along with this tutorial linear
 <div class="aside">
 <strong>Looking for a list of potential addons?</strong>
 <br/>
-😍 You can see the list of officially-supported and strongly-supported community addons <a href="https://storybook.js.org/addons/addon-gallery/">here</a>.
+😍 You can see the list of officially-supported and strongly-supported community addons <a href="https://storybook.js.org/addons">here</a>.
 </div>
 
 We could write forever about configuring and using addons for all of your particular use-cases. For now, let's work towards integrating one of the most popular addons within Storybook's ecosystem: [knobs](https://github.com/storybooks/storybook/tree/master/addons/knobs).

--- a/content/intro-to-storybook/react/nl/using-addons.md
+++ b/content/intro-to-storybook/react/nl/using-addons.md
@@ -10,7 +10,7 @@ Storybook beschikt over een robuust systeem van [add-ons](https://storybook.js.o
 <div class="aside">
 <strong> Op zoek naar een lijst met mogelijke add-ons? </strong>
 <br/>
-😍 Je kunt de lijst met officieel ondersteunde en goede community-add-ons <a href="https://storybook.js.org/addons/addon-gallery/">hier bekijken</a>.
+😍 Je kunt de lijst met officieel ondersteunde en goede community-add-ons <a href="https://storybook.js.org/addons">hier bekijken</a>.
 </div>
 
 We zouden nog veel kunnen schrijven over het configureren en gebruiken van add-ons voor al je specifieke use-cases. Laten we nu werken aan de integratie van een van de meest populaire add-ons in het ecosysteem van Storybook: [knobs](https://github.com/storybooks/storybook/tree/master/addons/knobs).

--- a/content/intro-to-storybook/react/pt/using-addons.md
+++ b/content/intro-to-storybook/react/pt/using-addons.md
@@ -10,7 +10,7 @@ Storybook possui um sistema robusto de [extras](https://storybook.js.org/addons/
 <div class="aside">
     <strong>Á procura de uma lista de extras?</strong>
     <br/>
-    😍 A lista de extras oficiais e da comunidade pode ser consultada <a href="https://storybook.js.org/addons/addon-gallery/">aqui</a>.
+    😍 A lista de extras oficiais e da comunidade pode ser consultada <a href="https://storybook.js.org/addons">aqui</a>.
 </div>
 
 Poderíamos ficar aqui eternamente a discutir como configurar e usar os extras para todos os casos. Por enquanto, vamos focar-nos em integrar um dos extras mais populares no ecossistema Storybook: [knobs](https://github.com/storybooks/storybook/tree/master/addons/knobs).

--- a/content/intro-to-storybook/svelte/en/using-addons.md
+++ b/content/intro-to-storybook/svelte/en/using-addons.md
@@ -10,7 +10,7 @@ everybody in your team. If you've been following along with this tutorial linear
 <div class="aside">
 <strong>Looking for a list of potential addons?</strong>
 <br/>
-😍 You can see the list of officially-supported and strongly-supported community addons <a href="https://storybook.js.org/addons/addon-gallery/">here</a>.
+😍 You can see the list of officially-supported and strongly-supported community addons <a href="https://storybook.js.org/addons">here</a>.
 </div>
 
 We could write forever about configuring and using addons for all of your particular use-cases. For now, let's work towards integrating one of the most popular addons within Storybook's ecosystem: [knobs](https://github.com/storybooks/storybook/tree/master/addons/knobs).

--- a/content/intro-to-storybook/svelte/es/using-addons.md
+++ b/content/intro-to-storybook/svelte/es/using-addons.md
@@ -10,7 +10,7 @@ todos en tu equipo. Si ha seguido este tutorial linealmente, hasta ahora hemos h
 <div class="aside">
   <strong>¿Busca una lista de posibles complementos?</strong>
   <br/>
-  😍 Puede ver la lista de complementos de la comunidad con respaldo oficial y con un fuerte respaldo <a href="https://storybook.js.org/addons/addon-gallery/"> aquí </a>.
+  😍 Puede ver la lista de complementos de la comunidad con respaldo oficial y con un fuerte respaldo <a href="https://storybook.js.org/addons"> aquí </a>.
 </div>
 
 Podríamos escribir para siempre sobre la configuración y el uso de complementos para todos sus casos de uso particulares. Por ahora, trabajemos para integrar uno de los complementos más populares dentro del ecosistema de Storybook: [knobs](https://github.com/storybooks/storybook/tree/master/addons/knobs).

--- a/content/intro-to-storybook/vue/en/using-addons.md
+++ b/content/intro-to-storybook/vue/en/using-addons.md
@@ -10,7 +10,7 @@ everybody in your team. If you've been following along with this tutorial linear
 <div class="aside">
 <strong>Looking for a list of potential addons?</strong>
 <br/>
-😍 You can see the list of officially-supported and strongly-supported community addons <a href="https://storybook.js.org/addons/addon-gallery/">here</a>.
+😍 You can see the list of officially-supported and strongly-supported community addons <a href="https://storybook.js.org/addons">here</a>.
 </div>
 
 We could write forever about configuring and using addons for all of your particular use-cases. For now, let's work towards integrating one of the most popular addons within Storybook's ecosystem: [knobs](https://github.com/storybooks/storybook/tree/master/addons/knobs).

--- a/content/intro-to-storybook/vue/es/using-addons.md
+++ b/content/intro-to-storybook/vue/es/using-addons.md
@@ -10,7 +10,7 @@ todos en tu equipo. Si ha seguido este tutorial linealmente, hasta ahora hemos h
 <div class = "aside">
     <strong> ¿Busca una lista de posibles complementos? </strong>
     <br/>
-    😍 Puede ver la lista de complementos de la comunidad con respaldo oficial y con un fuerte respaldo <a href="https://storybook.js.org/addons/addon-gallery/"> aquí </a>.
+    😍 Puede ver la lista de complementos de la comunidad con respaldo oficial y con un fuerte respaldo <a href="https://storybook.js.org/addons"> aquí </a>.
 </div>
 
 Podríamos escribir para siempre sobre la configuración y el uso de complementos para todos sus casos de uso particulares. Por ahora, trabajemos para integrar uno de los complementos más populares dentro del ecosistema de Storybook: [knobs](https://github.com/storybooks/storybook/tree/master/addons/knobs).

--- a/content/intro-to-storybook/vue/pt/using-addons.md
+++ b/content/intro-to-storybook/vue/pt/using-addons.md
@@ -10,7 +10,7 @@ Storybook possui um sistema robusto de [extras](https://storybook.js.org/addons/
 <div class="aside">
     <strong>Á procura de uma lista de extras?</strong>
     <br/>
-    😍 A lista de extras oficiais e da comunidade pode ser consultada <a href="https://storybook.js.org/addons/addon-gallery/">aqui</a>.
+    😍 A lista de extras oficiais e da comunidade pode ser consultada <a href="https://storybook.js.org/addons">aqui</a>.
 </div>
 
 Poderíamos ficar aqui eternamente a discutir como configurar e usar os extras para todos os casos. Por enquanto, vamos focar-nos em integrar um dos extras mais populares no ecossistema Storybook: [knobs](https://github.com/storybooks/storybook/tree/master/addons/knobs).


### PR DESCRIPTION
The link is present in the using addons chapter
Link: https://www.learnstorybook.com/intro-to-storybook/react/en/using-addons/