### PR TITLE
Chore: updates to the svelte snippets used in Intro to Storybook tutorial

### DIFF
--- a/content/intro-to-storybook/svelte/en/composite-component.md
+++ b/content/intro-to-storybook/svelte/en/composite-component.md
@@ -22,8 +22,8 @@ A composite component isn’t much different than the basic components it contai
 
 Start with a rough implementation of the `TaskList`. You’ll need to import the `Task` component from earlier and pass in the attributes and actions as inputs.
 
-```html
-<!--src/components/TaskList.svelte-->
+```svelte
+<!-- src/components/TaskList.svelte -->
 
 <script>
   import Task from './Task.svelte';
@@ -39,68 +39,68 @@ Start with a rough implementation of the `TaskList`. You’ll need to import the
 {/if}
 {#if emptyTasks}
   <div class="list-items">empty</div>
-{/if} 
+{/if}
 {#each tasks as task}
   <Task {task} on:onPinTask on:onArchiveTask />
 {/each}
 ```
 
-
 Next create `Tasklist`’s test states in the story file.
 
 ```javascript
 // src/components/TaskList.stories.js
-import TaskList from "./TaskList.svelte";
-import { taskData, actionsData } from "./Task.stories";
+
+import TaskList from './TaskList.svelte';
+import { taskData, actionsData } from './Task.stories';
 export default {
-  title: "TaskList",
-  excludeStories: /.*Data$/
+  title: 'TaskList',
+  excludeStories: /.*Data$/,
 };
 
 export const defaultTasksData = [
-  { ...taskData, id: "1", title: "Task 1" },
-  { ...taskData, id: "2", title: "Task 2" },
-  { ...taskData, id: "3", title: "Task 3" },
-  { ...taskData, id: "4", title: "Task 4" },
-  { ...taskData, id: "5", title: "Task 5" },
-  { ...taskData, id: "6", title: "Task 6" }
+  { ...taskData, id: '1', title: 'Task 1' },
+  { ...taskData, id: '2', title: 'Task 2' },
+  { ...taskData, id: '3', title: 'Task 3' },
+  { ...taskData, id: '4', title: 'Task 4' },
+  { ...taskData, id: '5', title: 'Task 5' },
+  { ...taskData, id: '6', title: 'Task 6' },
 ];
 export const withPinnedTasksData = [
   ...defaultTasksData.slice(0, 5),
-  { id: "6", title: "Task 6 (pinned)", state: "TASK_PINNED" }
+  { id: '6', title: 'Task 6 (pinned)', state: 'TASK_PINNED' },
 ];
 
 // default TaskList state
 export const Default = () => ({
   Component: TaskList,
-   props: {
-    tasks: defaultTasksData
+  props: {
+    tasks: defaultTasksData,
   },
   on: {
-    ...actionsData
-  }
+    ...actionsData,
+  },
 });
 // tasklist with pinned tasks
 export const WithPinnedTasks = () => ({
   Component: TaskList,
   props: {
-    tasks: withPinnedTasksData
+    tasks: withPinnedTasksData,
   },
   on: {
-    ...actionsData
-  }
+    ...actionsData,
+  },
 });
 // tasklist in loading state
 export const Loading = () => ({
   Component: TaskList,
   props: {
-    loading: true
+    loading: true,
   },
 });
 // tasklist no tasks
 export const Empty = () => ({
   Component: TaskList,
-}); 
+});
 ```
 
 `taskData` supplies the shape of a `Task` that we created and exported from the `Task.stories.js` file. Similarly, `actionsData` defines the actions (mocked callbacks) that a `Task` component expects, which the `TaskList` also needs.
@@ -122,8 +122,9 @@ For the loading edge case, we're going to create a new component that will displ
 
 Create a new file called `LoadingRow.svelte` and inside add the following markup:
 
-```html
-<!--src/components/LoadingRow.svelte-->
+```svelte
+<!-- src/components/LoadingRow.svelte -->
+
 <div class="loading-item">
   <span class="glow-checkbox" />
   <span class="glow-text">
@@ -136,8 +137,8 @@ Create a new file called `LoadingRow.svelte` and inside add the following markup
 
 And update `TaskList.svelte` to the following:
 
-```html
-<!--src/components/TaskList.svelte-->
+```svelte
+<!-- src/components/TaskList.svelte -->
 
 <script>
   import Task from './Task.svelte';
@@ -161,7 +162,7 @@ And update `TaskList.svelte` to the following:
   <LoadingRow />
   <LoadingRow />
 </div>
-{/if} 
+{/if}
 {#if tasks.length === 0 && !loading}
 <div class="list-items">
   <div class="wrapper-message">
@@ -170,7 +171,7 @@ And update `TaskList.svelte` to the following:
     <div class="subtitle-message">Sit back and relax</div>
   </div>
 </div>
-{/if} 
+{/if}
 {#each tasksInOrder as task}
   <Task {task} on:onPinTask on:onArchiveTask />
 {/each}
@@ -207,9 +208,10 @@ Create a test file called `src/components/TaskList.test.js`. Here, we’ll build
 
 ```javascript
 // src/components/TaskList.test.js
+
 import TaskList from './TaskList.svelte';
 import { render } from '@testing-library/svelte';
-import { withPinnedTasksData } from './TaskList.stories'
+import { withPinnedTasksData } from './TaskList.stories';
 test('TaskList ', async () => {
   const { container } = await render(TaskList, {
     props: {

--- a/content/intro-to-storybook/svelte/en/creating-addons.md
+++ b/content/intro-to-storybook/svelte/en/creating-addons.md
@@ -4,9 +4,9 @@ tocTitle: 'Bonus: Creating addons'
 description: 'Learn how to build your own addons that will super charge your development'
 ---
 
-In the previous chapter we were introduced to one of the key features of Storybook, its robust system of [addons](https://storybook.js.org/addons/introduction/), which can be used to enhance not only yours but also your team's developer experience and workflows.
+Earlier, we introduced a key Storybook feature: the robust [addons](https://storybook.js.org/addons/introduction/) ecosystem. Addons are used to enhance your developer experience and workflows.
 
-In this chapter we're going to take a look on how we create our own addon. You might think that writing it can be a daunting task, but actually it's not, we just need to take a couple of steps to get started and we can start writing it.
+In this bonus chapter, we're going to take a look on how we create our own addon. You might think that writing it can be a daunting task, but actually it's not, we just need to take a couple of steps to get started and we can start writing it.
 
 But first thing is first, let's first scope out what our addon will do.
 
@@ -23,6 +23,8 @@ We have our goal, now let's define what features our addon will support:
 The way we'll be attaching the list of assets to the stories is through [parameters](https://storybook.js.org/docs/configurations/options-parameter/), which is a Storybook option that allow us to inject custom parameters to our stories. The way to use it, it's quite similar on how we used a decorator in previous chapters.
 
 ```javascript
+// YourComponent.stories.js
+
 export default {
   title: 'Your component',
   decorators: [
@@ -69,7 +71,9 @@ The updated file should look like the following:
 }
 ```
 
-Finally inside your `.storybook` folder, create a new one called `design-addon` and inside it a new file called `register.js`.
+Making this change will allow us to use the correct presets and options for the addon we're about to develop.
+
+Afterwards, inside your `.storybook` folder, create a new one called `design-addon` and inside it a new file called `register.js`.
 
 And that's it! We're ready to start developing our addon.
 
@@ -81,6 +85,7 @@ Add the following to your recently created file:
 
 ```javascript
 //.storybook/design-addon/register.js
+
 import React from 'react';
 import { AddonPanel } from '@storybook/components';
 import { addons, types } from '@storybook/addons';
@@ -107,6 +112,7 @@ Starting Storybook at this point, we won't be able to see the addon just yet. Li
 
 ```js
 // .storybook/main.js
+
 module.exports = {
   stories: ['../src/components/**/*.stories.js'],
   addons: [
@@ -132,6 +138,7 @@ Make the following changes to the addon file:
 
 ```javascript
 //.storybook/design-addon/register.js
+
 import React, { Fragment } from 'react';
 /* same as before */
 import { useParameter } from '@storybook/api';
@@ -158,6 +165,7 @@ Your code should look like the following:
 
 ```javascript
 //.storybook/design-addon/register.js
+
 import React, { Fragment } from 'react';
 import { AddonPanel } from '@storybook/components';
 import { useParameter } from '@storybook/api';
@@ -201,6 +209,7 @@ To do so, we're going to make a small change to the `task.stories.js` file and a
 
 ```javascript
 // src/components/Task.stories.js
+
 export default {
   component: Task,
   title: 'Task',
@@ -228,6 +237,7 @@ At this stage we can see that the addon is working as it should, but now let's c
 
 ```javascript
 //.storybook/design-addon/register.js
+
 import React, { Fragment } from 'react';
 import { AddonPanel } from '@storybook/components';
 import { useParameter, useStorybookState } from '@storybook/api';
@@ -308,6 +318,7 @@ We need to adjust our imports for our needs:
 
 ```javascript
 //.storybook/design-addon/register.js
+
 import { useParameter, useStorybookState, useAddonState } from '@storybook/api';
 import { AddonPanel, ActionBar } from '@storybook/components';
 /* same as before */
@@ -317,6 +328,7 @@ And modify our `Content` component, so that we can change between assets:
 
 ```javascript
 //.storybook/design-addon/register.js
+
 const Content = () => {
   // story's parameter being retrieved here
   const results = useParameter('assets', []);
@@ -360,6 +372,7 @@ We've accomplished what we set out to do, which is to create a fully functioning
 
 ```javascript
 // .storybook/design-addon/register.js
+
 import React, { Fragment } from 'react';
 
 import { useParameter, useStorybookState, useAddonState } from '@storybook/api';

--- a/content/intro-to-storybook/svelte/en/data.md
+++ b/content/intro-to-storybook/svelte/en/data.md
@@ -55,7 +55,9 @@ Then we'll update our `TaskList` to read data out of the store. First let's move
 
 In `src/components/PureTaskList.svelte`:
 
-```html
+```svelte
+<!-- src/components/PureTaskList.svelte -->
+
 <!--This file moved from TaskList.svelte-->
 <script>
   import Task from './Task.svelte';
@@ -78,7 +80,7 @@ In `src/components/PureTaskList.svelte`:
   <LoadingRow />
   <LoadingRow />
 </div>
-{/if} 
+{/if}
 {#if noTasks && !loading}
 <div class="list-items">
   <div class="wrapper-message">
@@ -87,7 +89,7 @@ In `src/components/PureTaskList.svelte`:
     <div class="subtitle-message">Sit back and relax</div>
   </div>
 </div>
-{/if} 
+{/if}
 {#each tasksInOrder as task}
 <Task {task} on:onPinTask on:onArchiveTask />
 {/each}
@@ -95,7 +97,9 @@ In `src/components/PureTaskList.svelte`:
 
 In `src/components/TaskList.svelte`:
 
-```html
+```svelte
+<!-- src/components/TaskList.svelte -->
+
 <script>
   import PureTaskList from './PureTaskList.svelte';
   import { taskStore } from '../store';
@@ -119,6 +123,8 @@ In `src/components/TaskList.svelte`:
 The reason to keep the presentational version of the `TaskList` separate is because it is easier to test and isolate. As it doesn't rely on the presence of a store it is much easier to deal with from a testing perspective. Let's rename `src/components/TaskList.stories.js` into `src/components/PureTaskList.stories.js`, and ensure our stories use the presentational version:
 
 ```javascript
+// src/components/PureTaskList.stories.js
+
 import PureTaskList from './PureTaskList.svelte';
 import { taskData, actionsData } from './Task.stories';
 export default {
@@ -177,15 +183,17 @@ export const Empty = () => ({
 
 Similarly, we need to use `PureTaskList` in our Jest test:
 
-```js
+```javascript
+// src/components/TaskList.test.js
+
 import PureTaskList from './PureTaskList.svelte';
 import { render } from '@testing-library/svelte';
-import { withPinnedTasksData } from './PureTaskList.stories'
+import { withPinnedTasksData } from './PureTaskList.stories';
 
 test('TaskList', async () => {
   const { container } = await render(PureTaskList, {
     props: {
-      tasks: withPinnedTasksData
+      tasks: withPinnedTasksData,
     },
   });
   expect(container.firstChild.children[0].classList.contains('TASK_PINNED')).toBe(true);

--- a/content/intro-to-storybook/svelte/en/get-started.md
+++ b/content/intro-to-storybook/svelte/en/get-started.md
@@ -66,35 +66,31 @@ Create a `.babelrc` file in the root of the project with the following:
 Add a new field to `package.json`:
 
 ```json
-"jest": {
+{
+  "jest": {
     "transform": {
       "^.+\\.js$": "babel-jest",
       "^.+\\.svelte$": "jest-transform-svelte"
     },
-    "moduleFileExtensions": [
-      "js",
-      "svelte",
-      "json"
-    ],
+    "moduleFileExtensions": ["js", "svelte", "json"],
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|scss|stylesheet)$": "<rootDir>/__mocks__/styleMock.js"
     },
-    "setupFilesAfterEnv": [
-      "@testing-library/jest-dom/extend-expect"
-    ],
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/build/",
-      "/storybook-static/"
-    ]
+    "setupFilesAfterEnv": ["@testing-library/jest-dom/extend-expect"],
+    "testPathIgnorePatterns": ["/node_modules/", "/build/", "/storybook-static/"]
   }
+}
 ```
 
 And a new script is required to run Jest:
 
 ```json
-"test": "jest --watchAll"
+{
+  "scripts": {
+    "test": "jest --watchAll"
+  }
+}
 ```
 
 <div class="aside">The usage of the flag `--watchAll` in the script is to prevent a error being thrown by Jest, because at this stage there's still no repository configured. That will be addressed later on.</div>
@@ -102,6 +98,8 @@ And a new script is required to run Jest:
 To make sure everything is working properly we need to create a test file. In the `src` folder, add a file called `Sample.test.js` with the following:
 
 ```javascript
+// Sample.test.js
+
 function sum(a, b) {
   return a + b;
 }
@@ -153,8 +151,6 @@ To match the intended design, you'll need to download both the font and icon dir
 svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/icon public/icon
 svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/font public/font
 ```
-
-
 
 Finally we need to update our storybook script to serve the `public` directory (in `package.json`):
 

--- a/content/intro-to-storybook/svelte/en/screen.md
+++ b/content/intro-to-storybook/svelte/en/screen.md
@@ -12,8 +12,8 @@ In this chapter we continue to increase the sophistication by combining componen
 
 As our app is very simple, the screen we’ll build is pretty trivial, simply wrapping the `TaskList` component (which supplies its own data via Svelte Store) in some layout and pulling a top-level `error` field out of the store (let's assume we'll set that field if we have some problem connecting to our server). Create `InboxScreen.svelte` in your `components` folder:
 
-```html
-<!-- src/components/InboxScreen.svelte-->
+```svelte
+<!-- src/components/InboxScreen.svelte -->
 
 <script>
   import TaskList from './TaskList.svelte';
@@ -45,6 +45,8 @@ As our app is very simple, the screen we’ll build is pretty trivial, simply wr
 We need to update our store (in `src/store.js`) to include our new `error` field, transforming it into :
 
 ```javascript
+// src/store.js
+
 import { writable } from 'svelte/store';
 const TaskBox = () => {
   // creates a new writable store populated with some initial data
@@ -85,8 +87,9 @@ export const AppStore = appState();
 
 We also change the `App` component to render the `InboxScreen` (eventually we would use a router to choose the correct screen, but let's not worry about that here):
 
-```html
-<!-- src/App.svelte-->
+```svelte
+<!-- src/App.svelte -->
+
 <script>
   import { AppStore } from './store';
   import InboxScreen from './components/InboxScreen.svelte';
@@ -107,6 +110,7 @@ So when we setup our stories in `InboxScreen.stories.js`:
 
 ```javascript
 // src/components/InboxScreen.stories.js
+
 import InboxScreen from './InboxScreen.svelte';
 
 export default {

--- a/content/intro-to-storybook/svelte/en/simple-component.md
+++ b/content/intro-to-storybook/svelte/en/simple-component.md
@@ -25,8 +25,9 @@ First, let’s create the task component and its accompanying story file: `src/c
 
 We’ll begin with the baseline implementation of the `Task`, simply taking in the attributes we know we’ll need and the two actions you can take on a task (to move it between lists):
 
-```html
-<!--src/components/Task.svelte-->
+```svelte
+<!-- src/components/Task.svelte -->
+
 <script>
   import { createEventDispatcher } from 'svelte';
 
@@ -66,8 +67,9 @@ Below we build out Task’s three test states in the story file:
 
 ```javascript
 // src/components/Task.stories.js
+
 import Task from './Task.svelte';
-import { action } from "@storybook/addon-actions";
+import { action } from '@storybook/addon-actions';
 export default {
   title: 'Task',
   excludeStories: /.*Data$/,
@@ -158,18 +160,19 @@ Start by changing your Storybook configuration file (`.storybook/main.js`) to th
 
 ```javascript
 // .storybook/main.js
+
 module.exports = {
   stories: ['../src/components/**/*.stories.js'],
   addons: ['@storybook/addon-actions', '@storybook/addon-links'],
 };
-
 ```
 
 After completing the change above, inside the `.storybook` folder, add a new file called `preview.js` with the following:
 
 ```javascript
 // .storybook/preview.js
-import '../public/global.css'
+
+import '../public/global.css';
 ```
 
 Once we’ve done these two small changes, restarting Storybook should yield test cases for the three Task states:
@@ -181,15 +184,14 @@ Once we’ve done these two small changes, restarting Storybook should yield tes
   />
 </video>
 
-
 ## Build out the states
 
 Now we have Storybook setup, styles imported, and test cases built out, we can quickly start the work of implementing the HTML of the component to match the design.
 
 The component is still basic at the moment. First write the code that achieves the design without going into too much detail:
 
-```html
-<!--src/components/Task.svelte-->
+```svelte
+<!-- src/components/Task.svelte -->
 
 <script>
   import { createEventDispatcher } from 'svelte';
@@ -267,7 +269,7 @@ Make sure your components render data that doesn't change, so that your snapshot
 
 With the [Storyshots addon](https://github.com/storybooks/storybook/tree/master/addons/storyshots) a snapshot test is created for each of the stories. Use it by adding the following development dependency:
 
-```bash
+```shell
 npm install -D @storybook/addon-storyshots
 ```
 
@@ -275,6 +277,7 @@ Then create an `src/storybook.test.js` file with the following:
 
 ```javascript
 // src/storybook.test.js
+
 import initStoryshots from '@storybook/addon-storyshots';
 
 initStoryshots();
@@ -284,16 +287,13 @@ And finally we need to make a small adjustment to our `jest` key in `package.jso
 
 ```json
 {
-  .....
-  "jest":{
+  "jest": {
     "transform": {
       "^.+\\.js$": "babel-jest",
       "^.+\\.stories\\.[jt]sx?$": "<rootDir>node_modules/@storybook/addon-storyshots/injectFileName",
       "^.+\\.svelte$": "jest-transform-svelte"
     },
-    "setupFilesAfterEnv": [
-      "@testing-library/jest-dom/extend-expect"
-    ],
+    "setupFilesAfterEnv": ["@testing-library/jest-dom/extend-expect"]
   }
 }
 ```

--- a/content/intro-to-storybook/svelte/en/test.md
+++ b/content/intro-to-storybook/svelte/en/test.md
@@ -74,10 +74,8 @@ A small change is required to the `build-storybook` script to allow the `chromat
 
 ```json
 {
-  ....
-  "scripts":{
-    ...
-    "build-storybook": "build-storybook -s public",
+  "scripts": {
+    "build-storybook": "build-storybook -s public"
   }
 }
 ```

--- a/content/intro-to-storybook/svelte/en/using-addons.md
+++ b/content/intro-to-storybook/svelte/en/using-addons.md
@@ -30,7 +30,7 @@ Knobs is an amazing resource for designers and developers to experiment and play
 
 First, we will need to install all the necessary dependencies.
 
-```bash
+```shell
 npm install -D @storybook/addon-knobs
 ```
 
@@ -61,6 +61,7 @@ First, import the `withKnobs` decorator and the `object` knob type to `Task.stor
 
 ```javascript
 // src/components/Task.stories.js
+
 import { action } from '@storybook/addon-actions';
 import { withKnobs, object } from '@storybook/addon-knobs';
 ```
@@ -81,6 +82,7 @@ Lastly, integrate the `object` knob type within the "standard" story:
 
 ```javascript
 // src/components/Task.stories.js
+
 export const Default = () => ({
   Component: Task,
   props: {
@@ -111,7 +113,7 @@ Additionally, with easy access to editing passed data to a component, QA Enginee
 Thanks to quickly being able to try different inputs to a component we can find and fix such problems with relative ease! Let's fix the issue with overflowing by adding a style to `Task.svelte`:
 
 ```svelte
-<!-- src/components/Task.svelte-->
+<!-- src/components/Task.svelte -->
 
 <!-- This is the input for our task title. In practice we would probably update the styles for this element
   but for this tutorial, let's fix the problem with an inline style-->

--- a/content/intro-to-storybook/svelte/es/composite-component.md
+++ b/content/intro-to-storybook/svelte/es/composite-component.md
@@ -22,8 +22,8 @@ Un componente compuesto no es muy diferente de los componentes básicos que cont
 
 Comienza con una implementación aproximada de la `TaskList`. Necesitarás importar el componente `Task` del capítulo anterior y pasarle los atributos y acciones como entrada.
 
-```html
-<!--src/components/TaskList.svelte-->
+```svelte
+<!-- src/components/TaskList.svelte -->
 
 <script>
   import Task from './Task.svelte';
@@ -39,7 +39,7 @@ Comienza con una implementación aproximada de la `TaskList`. Necesitarás impor
 {/if}
 {#if emptyTasks}
   <div class="list-items">empty</div>
-{/if} 
+{/if}
 {#each tasks as task}
   <Task {task} on:onPinTask on:onArchiveTask />
 {/each}
@@ -49,57 +49,58 @@ A continuación, crea los estados de prueba de `Tasklist` en el archivo de histo
 
 ```javascript
 // src/components/TaskList.stories.js
-import TaskList from "./TaskList.svelte";
-import { taskData, actionsData } from "./Task.stories";
+
+import TaskList from './TaskList.svelte';
+import { taskData, actionsData } from './Task.stories';
 export default {
-  title: "TaskList",
-  excludeStories: /.*Data$/
+  title: 'TaskList',
+  excludeStories: /.*Data$/,
 };
 
 export const defaultTasksData = [
-  { ...taskData, id: "1", title: "Task 1" },
-  { ...taskData, id: "2", title: "Task 2" },
-  { ...taskData, id: "3", title: "Task 3" },
-  { ...taskData, id: "4", title: "Task 4" },
-  { ...taskData, id: "5", title: "Task 5" },
-  { ...taskData, id: "6", title: "Task 6" }
+  { ...taskData, id: '1', title: 'Task 1' },
+  { ...taskData, id: '2', title: 'Task 2' },
+  { ...taskData, id: '3', title: 'Task 3' },
+  { ...taskData, id: '4', title: 'Task 4' },
+  { ...taskData, id: '5', title: 'Task 5' },
+  { ...taskData, id: '6', title: 'Task 6' },
 ];
 export const withPinnedTasksData = [
   ...defaultTasksData.slice(0, 5),
-  { id: "6", title: "Task 6 (pinned)", state: "TASK_PINNED" }
+  { id: '6', title: 'Task 6 (pinned)', state: 'TASK_PINNED' },
 ];
 
 // default TaskList state
 export const Default = () => ({
   Component: TaskList,
-   props: {
-    tasks: defaultTasksData
+  props: {
+    tasks: defaultTasksData,
   },
   on: {
-    ...actionsData
-  }
+    ...actionsData,
+  },
 });
 // tasklist with pinned tasks
 export const WithPinnedTasks = () => ({
   Component: TaskList,
   props: {
-    tasks: withPinnedTasksData
+    tasks: withPinnedTasksData,
   },
   on: {
-    ...actionsData
-  }
+    ...actionsData,
+  },
 });
 // tasklist in loading state
 export const Loading = () => ({
   Component: TaskList,
   props: {
-    loading: true
+    loading: true,
   },
 });
 // tasklist no tasks
 export const Empty = () => ({
   Component: TaskList,
-}); 
+});
 ```
 
 `taskData` provee la forma de un `Task` que creamos y exportamos desde el archivo `Task.stories.js`. De manera similar, `actionsData` define las acciones (llamadas simuladas) que espera un componente `Task`, el cual también necesita la `TaskList`.
@@ -122,7 +123,7 @@ Para el caso del borde de carga, crearemos un nuevo componente que mostrará el 
 Cree un nuevo archivo llamado `LoadingRow.svelte` y agregue el siguiente marcado:
 
 ```html
-<!--src/components/LoadingRow.svelte-->
+<!-- src/components/LoadingRow.svelte -->
 <div class="loading-item">
   <span class="glow-checkbox" />
   <span class="glow-text">
@@ -135,8 +136,8 @@ Cree un nuevo archivo llamado `LoadingRow.svelte` y agregue el siguiente marcado
 
 Y actualice `TaskList.svelte` a lo siguiente:
 
-```html
-<!--src/components/TaskList.svelte-->
+```svelte
+<!-- src/components/TaskList.svelte -->
 
 <script>
   import Task from './Task.svelte';
@@ -160,7 +161,7 @@ Y actualice `TaskList.svelte` a lo siguiente:
   <LoadingRow />
   <LoadingRow />
 </div>
-{/if} 
+{/if}
 {#if tasks.length === 0 && !loading}
 <div class="list-items">
   <div class="wrapper-message">
@@ -169,7 +170,7 @@ Y actualice `TaskList.svelte` a lo siguiente:
     <div class="subtitle-message">Sit back and relax</div>
   </div>
 </div>
-{/if} 
+{/if}
 {#each tasksInOrder as task}
   <Task {task} on:onPinTask on:onArchiveTask />
 {/each}
@@ -206,9 +207,10 @@ Crea un archivo de prueba llamado `src/components/TaskList.test.js`. Aquí vamos
 
 ```javascript
 // src/components/TaskList.test.js
+
 import TaskList from './TaskList.svelte';
 import { render } from '@testing-library/svelte';
-import { withPinnedTasksData } from './TaskList.stories'
+import { withPinnedTasksData } from './TaskList.stories';
 test('TaskList ', async () => {
   const { container } = await render(TaskList, {
     props: {

--- a/content/intro-to-storybook/svelte/es/creating-addons.md
+++ b/content/intro-to-storybook/svelte/es/creating-addons.md
@@ -23,6 +23,8 @@ Tenemos nuestro objetivo, ahora definamos qué características admitirá nuestr
 La forma en que adjuntaremos la lista de recursos a las historias es a través de [parámetros](https://storybook.js.org/docs/configurations/options-parameter/), que es una opción de Storybook que nos permite inyectar parámetros personalizados para nuestras historias. La forma de usarlo es bastante similar a cómo usamos un decorador en capítulos anteriores.
 
 ```javascript
+// YourComponent.stories.js
+
 export default {
   title: 'Your component',
   decorators: [
@@ -35,8 +37,6 @@ export default {
 };
 ```
 
-<!-- -->
-
 ## Configuración
 
 Hemos esbozado lo que hará nuestro complemento, es hora de configurar nuestro entorno de desarrollo local.
@@ -45,7 +45,7 @@ Comenzaremos agregando un paquete adicional a nuestro proyecto. Más específica
 
 Abra una consola, navegue a la carpeta de su proyecto y ejecute el siguiente comando:
 
-```bash
+```shell
   npm install -D @babel/preset-react
 ```
 
@@ -80,7 +80,8 @@ Finalmente dentro de su carpeta `.storybook`, cree una nueva carpeta llamada `de
 Agregue lo siguiente a su archivo creado recientemente:
 
 ```javascript
-//.storybook/design-addon/register.js
+// .storybook/design-addon/register.js
+
 import React from 'react';
 import { AddonPanel } from '@storybook/components';
 import { addons, types } from '@storybook/addons';
@@ -107,6 +108,7 @@ Comenzando Storybook en este punto, aún no podremos ver el complemento. Como hi
 
 ```js
 // .storybook/main.js
+
 module.exports = {
   stories: ['../src/components/**/*.stories.js'],
   addons: [
@@ -131,7 +133,8 @@ Para completarlo, necesitamos hacer algunos cambios en nuestras importaciones e 
 Realice los siguientes cambios en el archivo de complemento:
 
 ```javascript
-//.storybook/design-addon/register.js
+// .storybook/design-addon/register.js
+
 import React, { Fragment } from 'react';
 /* same as before */
 import { useParameter } from '@storybook/api';
@@ -157,7 +160,8 @@ Creamos el componente, modificamos las importaciones, todo lo que falta es conec
 Su código debería tener el siguiente aspecto:
 
 ```javascript
-//.storybook/design-addon/register.js
+// .storybook/design-addon/register.js
+
 import React, { Fragment } from 'react';
 import { AddonPanel } from '@storybook/components';
 import { useParameter } from '@storybook/api';
@@ -201,6 +205,7 @@ Para hacerlo, haremos un pequeño cambio en el archivo `task.stories.js` y agreg
 
 ```javascript
 // src/components/task.stories.js
+
 export default {
   component: Task,
   title: 'Task',
@@ -227,7 +232,8 @@ Continúe y reinicie su Storybook y seleccione la historia de la Tarea, debería
 En esta etapa, podemos ver que el complemento está funcionando como debería, pero ahora cambiemos el componente `Content` para mostrar realmente lo que queremos:
 
 ```javascript
-//.storybook/design-addon/register.js
+// .storybook/design-addon/register.js
+
 import React, { Fragment } from 'react';
 import { AddonPanel } from '@storybook/components';
 import { useParameter, useStorybookState } from '@storybook/api';
@@ -307,7 +313,8 @@ Para el último, vamos a necesitar algún tipo de estado, podríamos usar el hoo
 Necesitamos ajustar nuestras importaciones a nuestras necesidades:
 
 ```javascript
-//.storybook/design-addon/register.js
+// .storybook/design-addon/register.js
+
 import { useParameter, useStorybookState, useAddonState } from '@storybook/api';
 import { AddonPanel, ActionBar } from '@storybook/components';
 /* same as before */
@@ -316,7 +323,8 @@ import { AddonPanel, ActionBar } from '@storybook/components';
 Y modifique nuestro componente `Content`, para que podamos cambiar entre recursos:
 
 ```javascript
-//.storybook/design-addon/register.js
+// .storybook/design-addon/register.js
+
 const Content = () => {
   // story's parameter being retrieved here
   const results = useParameter('assets', []);
@@ -360,6 +368,7 @@ Hemos logrado lo que nos propusimos hacer, que es crear un complemento de Storyb
 
 ```javascript
 // .storybook/design-addon/register.js
+
 import React, { Fragment } from 'react';
 
 import { useParameter, useStorybookState, useAddonState } from '@storybook/api';

--- a/content/intro-to-storybook/svelte/es/data.md
+++ b/content/intro-to-storybook/svelte/es/data.md
@@ -55,7 +55,9 @@ Luego se cambiará el componente `TaskList` para leer los datos del store. Pero 
 
 En `src/components/PureTaskList.svelte`:
 
-```html
+```svelte
+<!-- src/components/PureTaskList.svelte -->
+
 <!--This file moved from TaskList.svelte-->
 <script>
   import Task from './Task.svelte';
@@ -78,7 +80,7 @@ En `src/components/PureTaskList.svelte`:
   <LoadingRow />
   <LoadingRow />
 </div>
-{/if} 
+{/if}
 {#if noTasks && !loading}
 <div class="list-items">
   <div class="wrapper-message">
@@ -87,7 +89,7 @@ En `src/components/PureTaskList.svelte`:
     <div class="subtitle-message">Sit back and relax</div>
   </div>
 </div>
-{/if} 
+{/if}
 {#each tasksInOrder as task}
 <Task {task} on:onPinTask on:onArchiveTask />
 {/each}
@@ -95,7 +97,9 @@ En `src/components/PureTaskList.svelte`:
 
 En `src/components/TaskList.svelte`:
 
-```html
+```svelte
+<!-- src/components/TaskList.svelte -->
+
 <script>
   import PureTaskList from './PureTaskList.svelte';
   import { taskStore } from '../store';
@@ -119,6 +123,8 @@ En `src/components/TaskList.svelte`:
 La razón para mantener separada la versión de la `TaskList` es porque es más fácil de probar y aislar. Como no depende de la presencia de un store, es mucho más fácil tratar desde una perspectiva de prueba. Cambiemos el nombre de `src/components/TaskList.stories.js` a`src/components/PureTaskList.stories.js`, con esto garantizamos que nuestras stories usen la versión actual:
 
 ```javascript
+// src/components/PureTaskList.stories.js
+
 import PureTaskList from './PureTaskList.svelte';
 import { taskData, actionsData } from './Task.stories';
 export default {
@@ -177,15 +183,17 @@ export const Empty = () => ({
 
 Del mismo modo, necesitamos usar `PureTaskList` en nuestra prueba de Jest:
 
-```js
+```javascript
+// src/components/TaskList.test.js
+
 import PureTaskList from './PureTaskList.svelte';
 import { render } from '@testing-library/svelte';
-import { withPinnedTasksData } from './PureTaskList.stories'
+import { withPinnedTasksData } from './PureTaskList.stories';
 
 test('TaskList', async () => {
   const { container } = await render(PureTaskList, {
     props: {
-      tasks: withPinnedTasksData
+      tasks: withPinnedTasksData,
     },
   });
   expect(container.firstChild.children[0].classList.contains('TASK_PINNED')).toBe(true);

--- a/content/intro-to-storybook/svelte/es/get-started.md
+++ b/content/intro-to-storybook/svelte/es/get-started.md
@@ -66,35 +66,31 @@ Cree un archivo `.babelrc` en la raíz del proyecto con lo siguiente:
 Y un nuevo campo en `package.json`:
 
 ```json
-"jest": {
+{
+  "jest": {
     "transform": {
       "^.+\\.js$": "babel-jest",
       "^.+\\.svelte$": "jest-transform-svelte"
     },
-    "moduleFileExtensions": [
-      "js",
-      "svelte",
-      "json"
-    ],
+    "moduleFileExtensions": ["js", "svelte", "json"],
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|scss|stylesheet)$": "<rootDir>/__mocks__/styleMock.js"
     },
-    "setupFilesAfterEnv": [
-      "@testing-library/jest-dom/extend-expect"
-    ],
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/build/",
-      "/storybook-static/"
-    ]
+    "setupFilesAfterEnv": ["@testing-library/jest-dom/extend-expect"],
+    "testPathIgnorePatterns": ["/node_modules/", "/build/", "/storybook-static/"]
   }
+}
 ```
 
 Y se requiere un nuevo script para ejecutar Jest:
 
 ```json
-"test": "jest --watchAll"
+{
+  "scripts": {
+    "test": "jest --watchAll"
+  }
+}
 ```
 
 <div class="aside">El uso de la bandera `--watchAll` en el script es para evitar que Jest arroje un error, porque en esta etapa todavía no hay un repositorio configurado. Eso se abordará más adelante.</div>
@@ -102,6 +98,8 @@ Y se requiere un nuevo script para ejecutar Jest:
 Para asegurarnos de que todo funciona correctamente, necesitamos crear un archivo de prueba. En la carpeta `src`, agregue un archivo llamado `Sample.test.js` con lo siguiente:
 
 ```javascript
+// Sample.test.js
+
 function sum(a, b) {
   return a + b;
 }

--- a/content/intro-to-storybook/svelte/es/screen.md
+++ b/content/intro-to-storybook/svelte/es/screen.md
@@ -12,8 +12,8 @@ En este capítulo aumentaremos la sofisticación al combinar los componentes que
 
 Como nuestra aplicación es muy simple, la pantalla que construiremos es bastante trivial, simplemente envolviendo el componente `TaskList` (que proporciona sus propios datos a través de Svelte Store) en alguna maqueta y sacando un campo `error` de el store (asumamos que pondremos ese campo si tenemos algún problema para conectarnos a nuestro servidor). Ahora crearemos `InboxScreen.svelte` dentro de la carpeta `components`:
 
-```html
-<!-- src/components/InboxScreen.svelte-->
+```svelte
+<!-- src/components/InboxScreen.svelte -->
 
 <script>
   import TaskList from './TaskList.svelte';
@@ -45,6 +45,8 @@ Como nuestra aplicación es muy simple, la pantalla que construiremos es bastant
 Necesitamos actualizar nuestro store (en `src/store.js`) para incluir nuestro nuevo campo `error`, transformándolo en:
 
 ```javascript
+// src/store.js
+
 import { writable } from 'svelte/store';
 const TaskBox = () => {
   // creates a new writable store populated with some initial data
@@ -85,8 +87,9 @@ export const AppStore = appState();
 
 También cambiamos nuestro componente `App` para que incluya `InboxScreen` (en una aplicación real esto sería manejado por el enrutador pero podemos obviarlo):
 
-```html
-<!-- src/App.svelte-->
+```svelte
+<!-- src/App.svelte -->
+
 <script>
   import { AppStore } from './store';
   import InboxScreen from './components/InboxScreen.svelte';
@@ -107,6 +110,7 @@ Entonces, cuando configuramos nuestras historias en `InboxScreen.stories.js`:
 
 ```javascript
 // src/components/InboxScreen.stories.js
+
 import InboxScreen from './InboxScreen.svelte';
 
 export default {
@@ -125,7 +129,7 @@ export const error = () => ({
 });
 ```
 
-Vemos que aunque la historia de `error` y `standard` funciona bien. (También encontrarás problemas similares cuando intentes probar la `PureInboxScreen` con un test unitario si no se proporcionan datos como lo hicimos con` TaskList`).
+Vemos que aunque la historia de `error` y `standard` funciona bien. (También encontrarás problemas similares cuando intentes probar la `PureInboxScreen` con un test unitario si no se proporcionan datos como lo hicimos con`TaskList`).
 
 <div class="aside">
 Por otro lado, la transmisión de datos a nivel jerárquico es un enfoque legítimo, especialmente cuando utilizas <a href="http://graphql.org/">GraphQL</a>. Así es como hemos construido <a href="https://www.chromatic.com">Chromatic</a> junto a más de 800+ historias.

--- a/content/intro-to-storybook/svelte/es/simple-component.md
+++ b/content/intro-to-storybook/svelte/es/simple-component.md
@@ -25,8 +25,9 @@ Primero, vamos a crear el componente Task y el archivo de historias de Storybook
 
 Comenzaremos con una implementación básica de `Task`, simplemente teniendo en cuenta los atributos que sabemos que necesitaremos y las dos acciones que puedes realizar con una tarea (para moverla entre las listas):
 
-```html
-<!--src/components/Task.svelte-->
+```svelte
+<!-- src/components/Task.svelte -->
+
 <script>
   import { createEventDispatcher } from 'svelte';
 
@@ -66,8 +67,9 @@ A continuación creamos los tres estados de prueba de Task dentro del archivo de
 
 ```javascript
 // src/components/Task.stories.js
+
 import Task from './Task.svelte';
-import { action } from "@storybook/addon-actions";
+import { action } from '@storybook/addon-actions';
 export default {
   title: 'Task',
   excludeStories: /.*Data$/,
@@ -158,18 +160,19 @@ Comencemos cambiando el archivo de configuración de Storybook (`.storybook/main
 
 ```javascript
 // .storybook/main.js
+
 module.exports = {
   stories: ['../src/components/**/*.stories.js'],
   addons: ['@storybook/addon-actions', '@storybook/addon-links'],
 };
-
 ```
 
 Después de hacer este cambio, una vez más dentro de la carpeta `.storybook`, cree un nuevo archivo llamado `preview.js` con el siguiente contenido:
 
 ```javascript
 // .storybook/preview.js
-import '../public/global.css'
+
+import '../public/global.css';
 ```
 
 Una vez que hayamos hecho esto, reiniciando el servidor de Storybook debería producir casos de prueba para los tres estados de Task:
@@ -181,15 +184,14 @@ Una vez que hayamos hecho esto, reiniciando el servidor de Storybook debería pr
   />
 </video>
 
-
 ## Construyendo los estados
 
 Ahora tenemos configurado Storybook, los estilos importados y los casos de prueba construidos; podemos comenzar rápidamente el trabajo de implementar el HTML del componente para que coincida con el diseño.
 
 Nuestro componente todavía es bastante rudimentario en este momento. Vamos a hacer algunos cambios para que coincida con el diseño previsto sin entrar en demasiados detalles:
 
-```html
-<!--src/components/Task.svelte-->
+```svelte
+<!-- src/components/Task.svelte -->
 
 <script>
   import { createEventDispatcher } from 'svelte';
@@ -275,6 +277,7 @@ Luego crea un archivo `src/storybook.test.js` con el siguiente contenido:
 
 ```javascript
 // src/storybook.test.js
+
 import initStoryshots from '@storybook/addon-storyshots';
 
 initStoryshots();
@@ -284,16 +287,13 @@ Finalmente, necesitamos hacer un pequeño ajuste a nuestro campo `jest` en `pack
 
 ```json
 {
-  .....
-  "jest":{
+  "jest": {
     "transform": {
       "^.+\\.js$": "babel-jest",
       "^.+\\.stories\\.[jt]sx?$": "<rootDir>node_modules/@storybook/addon-storyshots/injectFileName",
       "^.+\\.svelte$": "jest-transform-svelte"
     },
-    "setupFilesAfterEnv": [
-      "@testing-library/jest-dom/extend-expect"
-    ],
+    "setupFilesAfterEnv": ["@testing-library/jest-dom/extend-expect"]
   }
 }
 ```

--- a/content/intro-to-storybook/svelte/es/test.md
+++ b/content/intro-to-storybook/svelte/es/test.md
@@ -74,10 +74,8 @@ Se requiere un pequeño cambio en el script `build-storybook` para permitir que 
 
 ```json
 {
-  ....
-  "scripts":{
-    ...
-    "build-storybook": "build-storybook -s public",
+  "scripts": {
+    "build-storybook": "build-storybook -s public"
   }
 }
 ```

--- a/content/intro-to-storybook/svelte/es/using-addons.md
+++ b/content/intro-to-storybook/svelte/es/using-addons.md
@@ -61,6 +61,7 @@ Primero, importe el decorador `withKnobs` y el tipo de knob `object` a `Task.sto
 
 ```javascript
 // src/components/Task.stories.js
+
 import { action } from '@storybook/addon-actions';
 import { withKnobs, object } from '@storybook/addon-knobs';
 ```
@@ -81,6 +82,7 @@ Por último, integre el tipo de knob `object` dentro de la historia "predetermin
 
 ```javascript
 // src/components/Task.stories.js
+
 export const Default = () => ({
   Component: Task,
   props: {
@@ -111,7 +113,7 @@ Además, con un fácil acceso para editar los datos pasados ​​a un component
 ¡Gracias a poder probar rápidamente diferentes entradas a un componente, podemos encontrar y solucionar estos problemas con relativa facilidad! Arreglemos el problema de desbordamiento agregando un estilo a `Task.svelte`:
 
 ```svelte
-<!-- src/components/Task.svelte-->
+<!-- src/components/Task.svelte -->
 
 <!-- This is the input for our task title. In practice we would probably update the styles for this element
   but for this tutorial, let's fix the problem with an inline style:-->
@@ -159,10 +161,3 @@ Si estamos utilizando [pruebas de regresión visual](/svelte/es/test/), también
 ### Fusionar cambios
 
 ¡No olvides fusionar tus cambios con git!
-
-<!-- this is commented based on the restructuring that was introduced with pr 341. Once 6.0 lands this needs to be added back based on controls.-->
-
-<!-- ## Compartir complementos con el equipo
-
-Knobs es una excelente manera de hacer que los no desarrolladores jueguen con sus componentes e historias. Sin embargo, puede ser difícil para ellos ejecutar Storybook en su máquina local. Es por eso que implementar storybook en una ubicación en línea puede ser realmente útil. ¡En el próximo capítulo haremos exactamente eso!
- -->


### PR DESCRIPTION
This pull partially addresses #358, now the snippets for the svelte edition of Intro to Storybook are updated and they prettier shouldn't have any issues with breaking the formatting and snippets.

What was done:
- Updated the snippets to be referenced as svelte instead of html. It seems that prettier does not support `*.svelte` file extensions. Both editions of the tutorial are now using this format.
- Missing file references were added to the snippets in both editions of the tutorial.
- The Svelte create addons page initial wording was updated to reflect the recent change.

Feel free to provide feedback