### PR TITLE
Update import for @storybook/addon-knobs

### DIFF
--- a/content/intro-to-storybook/react/en/using-addons.md
+++ b/content/intro-to-storybook/react/en/using-addons.md
@@ -70,7 +70,7 @@ First, import the `withKnobs` decorator and the `object` knob type to `Task.stor
 
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, object } from '@storybook/addon-knobs/react';
+import { withKnobs, object } from '@storybook/addon-knobs';
 ```
 
 <div class="aside">


### PR DESCRIPTION
Using Javascript, importing from `@storybook/addon-knobs/react` gives an error in `"react": "^16.13.1"` and `"@storybook/addon-knobs": "^6.0.19"`

Changing the import to `@storybook/addon-knobs` instead fixes the error

So, the import line becomes:
`import { withKnobs, object } from '@storybook/addon-knobs';`