### PR TITLE
Chore: remove svn mention from Intro to Storybook

### DIFF
--- a/content/intro-to-storybook/angular/en/get-started.md
+++ b/content/intro-to-storybook/angular/en/get-started.md
@@ -293,7 +293,7 @@ npx degit chromaui/learnstorybook-code/public/icon src/assets/icon
 ```
 
 <div class="aside">
-We've used <a href="https://github.com/Rich-Harris/degit">degit</a> to easily download folders from GitHub. If you want to do it manually, you can grab the folders <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.
+We use <a href="https://github.com/Rich-Harris/degit">degit</a> to download folders from GitHub. If you want to do it manually, you can grab the folders <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.
 </div>
 
 After adding styling and assets, the app will render a bit strangely. That’s OK. We aren’t working on the app right now. We’re starting off with building our first component!

--- a/content/intro-to-storybook/angular/en/get-started.md
+++ b/content/intro-to-storybook/angular/en/get-started.md
@@ -280,19 +280,20 @@ And make a small change to allow the icons in the `percolate` font to be correct
 ![Taskbox UI](/intro-to-storybook/ss-browserchrome-taskbox-learnstorybook.png)
 
 <div class="aside">
-If you want to modify the styling, the source LESS files are provided in the GitHub repo.
+If you want to modify the styling, the source LESS files are provided <a href="https://github.com/chromaui/learnstorybook-code/tree/master/src/style">here</a>.
 </div>
 
 ## Add assets
 
-To match the intended design, you'll need to download both the font and icon directories and place its contents inside your `src/assets` folder.
-
-<div class="aside">
-<p>We’ve used <code>svn</code> (Subversion) to easily download a folder of files from GitHub. If you don’t have subversion installed or want to just do it manually, you can grab the folders directly <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.</p></div>
+To match the intended design, you'll need to download both the font and icon directories and place its contents inside your `src/assets` folder. Issue the following commands in your terminal:
 
 ```bash
-svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/icon src/assets/icon
-svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/font src/assets/font
+npx degit chromaui/learnstorybook-code/public/font src/assets/font
+npx degit chromaui/learnstorybook-code/public/icon src/assets/icon
 ```
+
+<div class="aside">
+We've used <a href="https://github.com/Rich-Harris/degit">degit</a> to easily download folders from GitHub. If you want to do it manually, you can grab the folders <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.
+</div>
 
 After adding styling and assets, the app will render a bit strangely. That’s OK. We aren’t working on the app right now. We’re starting off with building our first component!

--- a/content/intro-to-storybook/react/en/get-started.md
+++ b/content/intro-to-storybook/react/en/get-started.md
@@ -58,19 +58,20 @@ Taskbox reuses design elements from the GraphQL and React Tutorial [example app]
 ![Taskbox UI](/intro-to-storybook/ss-browserchrome-taskbox-learnstorybook.png)
 
 <div class="aside">
-If you want to modify the styling, the source LESS files are provided in the GitHub repo.
+If you want to modify the styling, the source LESS files are provided <a href="https://github.com/chromaui/learnstorybook-code/tree/master/src/style">here</a>.
 </div>
 
 ## Add assets
 
-To match the intended design, you'll need to download both the font and icon directories and place its contents inside your `public` folder.
-
-<div class="aside">
-<p>We’ve used <code>svn</code> (Subversion) to easily download a folder of files from GitHub. If you don’t have subversion installed or want to just do it manually, you can grab the folders directly <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.</p></div>
+To match the intended design, you'll need to download both the font and icon directories and place its contents inside your `public` folder. Issue the following commands in your terminal:
 
 ```bash
-svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/icon public/icon
-svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/font public/font
+npx degit chromaui/learnstorybook-code/public/font public/font
+npx degit chromaui/learnstorybook-code/public/icon public/icon
 ```
+
+<div class="aside">
+We've used <a href="https://github.com/Rich-Harris/degit">degit</a> to easily download folders from GitHub. If you want to do it manually, you can grab the folders <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.
+</div>
 
 After adding styling and assets, the app will render a bit strangely. That’s OK. We aren’t working on the app right now. We’re starting off with building our first component!

--- a/content/intro-to-storybook/react/en/get-started.md
+++ b/content/intro-to-storybook/react/en/get-started.md
@@ -71,7 +71,7 @@ npx degit chromaui/learnstorybook-code/public/icon public/icon
 ```
 
 <div class="aside">
-We've used <a href="https://github.com/Rich-Harris/degit">degit</a> to easily download folders from GitHub. If you want to do it manually, you can grab the folders <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.
+We use <a href="https://github.com/Rich-Harris/degit">degit</a> to download folders from GitHub. If you want to do it manually, you can grab the folders <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.
 </div>
 
 After adding styling and assets, the app will render a bit strangely. That’s OK. We aren’t working on the app right now. We’re starting off with building our first component!

--- a/content/intro-to-storybook/svelte/en/get-started.md
+++ b/content/intro-to-storybook/svelte/en/get-started.md
@@ -10,7 +10,7 @@ Storybook runs alongside your app in development mode. It helps you build UI com
 
 ## Setup Svelte Storybook
 
-We’ll need to follow a few steps to get the build process set up in your environment. To start with, we want to use [Degit](https://github.com/Rich-Harris/degit) to setup our build system, and enable [Storybook](https://storybook.js.org/) and [Jest](https://facebook.github.io/jest/) testing in our created app. Let’s run the following commands:
+We’ll need to follow a few steps to get the build process set up in your environment. To start with, we want to use [degit](https://github.com/Rich-Harris/degit) to setup our build system, and enable [Storybook](https://storybook.js.org/) and [Jest](https://facebook.github.io/jest/) testing in our created app. Let’s run the following commands:
 
 ```bash
 # Create our application:
@@ -137,20 +137,21 @@ Taskbox reuses design elements from the GraphQL and React Tutorial [example app]
 ![Taskbox UI](/intro-to-storybook/ss-browserchrome-taskbox-learnstorybook.png)
 
 <div class="aside">
-If you want to modify the styling, the source LESS files are provided in the GitHub repo.
+If you want to modify the styling, the source LESS files are provided <a href="https://github.com/chromaui/learnstorybook-code/tree/master/src/style">here</a>.
 </div>
 
 ## Add assets
 
-To match the intended design, you'll need to download both the font and icon directories and place them inside the `public` folder.
-
-<div class="aside">
-<p>We’ve used <code>svn</code> (Subversion) to easily download a folder of files from GitHub. If you don’t have subversion installed or want to just do it manually, you can grab the folders directly <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.</p></div>
+To match the intended design, you'll need to download both the font and icon directories and place them inside the `public` folder. Issue the following commands in your terminal:
 
 ```bash
-svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/icon public/icon
-svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/font public/font
+npx degit chromaui/learnstorybook-code/public/font public/font
+npx degit chromaui/learnstorybook-code/public/icon public/icon
 ```
+
+<div class="aside">
+We've used <a href="https://github.com/Rich-Harris/degit">degit</a> once more, to make it easier to download folders from GitHub. If you want to do it manually, you can grab the folders <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.
+</div>
 
 Finally we need to update our storybook script to serve the `public` directory (in `package.json`):
 

--- a/content/intro-to-storybook/svelte/en/get-started.md
+++ b/content/intro-to-storybook/svelte/en/get-started.md
@@ -150,7 +150,7 @@ npx degit chromaui/learnstorybook-code/public/icon public/icon
 ```
 
 <div class="aside">
-We've used <a href="https://github.com/Rich-Harris/degit">degit</a> once more, to make it easier to download folders from GitHub. If you want to do it manually, you can grab the folders <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.
+We use <a href="https://github.com/Rich-Harris/degit">degit</a> to download folders from GitHub. If you want to do it manually, you can grab the folders <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.
 </div>
 
 Finally we need to update our storybook script to serve the `public` directory (in `package.json`):

--- a/content/intro-to-storybook/vue/en/get-started.md
+++ b/content/intro-to-storybook/vue/en/get-started.md
@@ -15,7 +15,7 @@ We’ll need to follow a few steps to get the build process set up in your envir
 
 ```bash
 # Create our application, using a preset that contains jest:
-npx -p @vue/cli vue create taskbox --preset chromaui/vue-preset-learnstorybook 
+npx -p @vue/cli vue create taskbox --preset chromaui/vue-preset-learnstorybook
 
 cd taskbox
 
@@ -60,21 +60,21 @@ Taskbox reuses design elements from the GraphQL and React Tutorial [example app]
 ![Taskbox UI](/intro-to-storybook/ss-browserchrome-taskbox-learnstorybook.png)
 
 <div class="aside">
-If you want to modify the styling, the source LESS files are provided in the GitHub repo.
+If you want to modify the styling, the source LESS files are provided <a href="https://github.com/chromaui/learnstorybook-code/tree/master/src/style">here</a>.
 </div>
 
 ## Add assets
 
-To match the intended design, you'll need to download both the font and icon directories and place its contents inside your `public` folder.
-
-<div class="aside">
-<p>We’ve used <code>svn</code> (Subversion) to easily download a folder of files from GitHub. If you don’t have subversion installed or want to just do it manually, you can grab the folders directly <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.</p></div>
+To match the intended design, you'll need to download both the font and icon directories and place its contents inside your `public` folder. Issue the following commands in your terminal:
 
 ```bash
-svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/icon public/icon
-svn export https://github.com/chromaui/learnstorybook-code/branches/master/public/font public/font
+npx degit chromaui/learnstorybook-code/public/font public/font
+npx degit chromaui/learnstorybook-code/public/icon public/icon
 ```
 
+<div class="aside">
+We've used <a href="https://github.com/Rich-Harris/degit">degit</a> to easily download folders from GitHub. If you want to do it manually, you can grab the folders <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.
+</div>
 
 We also need to update our storybook script to serve the `public` directory (in `package.json`):
 

--- a/content/intro-to-storybook/vue/en/get-started.md
+++ b/content/intro-to-storybook/vue/en/get-started.md
@@ -73,7 +73,7 @@ npx degit chromaui/learnstorybook-code/public/icon public/icon
 ```
 
 <div class="aside">
-We've used <a href="https://github.com/Rich-Harris/degit">degit</a> to easily download folders from GitHub. If you want to do it manually, you can grab the folders <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.
+We use <a href="https://github.com/Rich-Harris/degit">degit</a> to download folders from GitHub. If you want to do it manually, you can grab the folders <a href="https://github.com/chromaui/learnstorybook-code/tree/master/public">here</a>.
 </div>
 
 We also need to update our storybook script to serve the `public` directory (in `package.json`):

--- a/src/components/screens/IndexScreen/SocialValidation.js
+++ b/src/components/screens/IndexScreen/SocialValidation.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import User from '../../composite/User';
 import styled from 'styled-components';
 import { styles } from '@storybook/design-system';
+import User from '../../composite/User';
 
 const { breakpoint, pageMargins, typography } = styles;
 
@@ -130,7 +130,7 @@ const SocialValidation = () => (
     <Heading>+100,000 readers so far</Heading>
 
     <Logos>
-      {logos.map((logo) => (
+      {logos.map(logo => (
         <Logo key={logo.src}>
           <img src={logo.src} alt={logo.alt} />
         </Logo>
@@ -140,8 +140,8 @@ const SocialValidation = () => (
     <Testimonials>
       <Testimonial>
         Storybook is such a pivotal tool not just for workbenching a component in isolation, but
-        also to communicate your component's use cases and API to your whole team. You NEED to learn
-        how to use Storybook, and this is the place to learn.
+        also to communicate your component&#39;s use cases and API to your whole team. You NEED to
+        learn how to use Storybook, and this is the place to learn.
         <UserWrapper
           src="https://avatars2.githubusercontent.com/u/9523719"
           name="Kyle Holmberg"


### PR DESCRIPTION
With this pull request, the get started section for the angular, svelte, react and vue versions of the tutorial were updated to use degit instead of Subversion.

The react native was not updated as i'm getting inconsistent results, in a mac i can't download the nunito font i'm presented with a unexpected end of file related to zlib. But in windows i can download it ok. Probably something needs to be fixed upstream.

This follows up and closes #340 and #369