### PR TITLE
Changed capitalization when using Default property

### DIFF
--- a/content/intro-to-storybook/react/en/composite-component.md
+++ b/content/intro-to-storybook/react/en/composite-component.md
@@ -77,12 +77,12 @@ Default.args = {
   // Shaping the stories through args composition.
   // The data was inherited from the Default story in task.stories.js.
   tasks: [
-    { ...TaskStories.default.args, id: '1', title: 'Task 1' },
-    { ...TaskStories.default.args, id: '2', title: 'Task 2' },
-    { ...TaskStories.default.args, id: '3', title: 'Task 3' },
-    { ...TaskStories.default.args, id: '4', title: 'Task 4' },
-    { ...TaskStories.default.args, id: '5', title: 'Task 5' },
-    { ...TaskStories.default.args, id: '6', title: 'Task 6' },
+    { ...TaskStories.Default.args, id: '1', title: 'Task 1' },
+    { ...TaskStories.Default.args, id: '2', title: 'Task 2' },
+    { ...TaskStories.Default.args, id: '3', title: 'Task 3' },
+    { ...TaskStories.Default.args, id: '4', title: 'Task 4' },
+    { ...TaskStories.Default.args, id: '5', title: 'Task 5' },
+    { ...TaskStories.Default.args, id: '6', title: 'Task 6' },
   ],
 };
 


### PR DESCRIPTION
The jest test was broken because of the lower case 'd' when accessing the Default property of the imported TaskStories.