### PR TITLE
change yarn start to yarn web

### DIFF
--- a/content/intro-to-storybook/react-native/en/get-started.md
+++ b/content/intro-to-storybook/react-native/en/get-started.md
@@ -89,7 +89,7 @@ yarn test
 yarn storybook
 
 # Run the frontend app proper on port 19002:
-yarn start
+yarn web
 ```
 
 ![3 modalities](/intro-to-storybook/app-three-modalities-rn.png)

--- a/content/intro-to-storybook/react-native/en/get-started.md
+++ b/content/intro-to-storybook/react-native/en/get-started.md
@@ -94,6 +94,8 @@ yarn web
 
 ![3 modalities](/intro-to-storybook/app-three-modalities-rn.png)
 
+Your storybook server won't be able to load the stories list just yet, but we'll fix this in the next steps.
+
 Depending on what part of the app you’re working on, you may want to run one or more of these simultaneously. Since our current focus is creating a single UI component, we’ll stick with running Storybook.
 
 ## Reuse CSS

--- a/content/intro-to-storybook/react-native/en/get-started.md
+++ b/content/intro-to-storybook/react-native/en/get-started.md
@@ -94,7 +94,7 @@ yarn web
 
 ![3 modalities](/intro-to-storybook/app-three-modalities-rn.png)
 
-Your storybook server won't be able to load the stories list just yet, but we'll fix this in the next steps.
+Checking our Storybook at this point, you might see that there's no stories displayed. That's ok, we'll take care of it shortly, for now, let's continue working on getting our application properly setup.
 
 Depending on what part of the app you’re working on, you may want to run one or more of these simultaneously. Since our current focus is creating a single UI component, we’ll stick with running Storybook.
 


### PR DESCRIPTION
Running yarn start will only run the bundler and not the app.

I've added a comment here to let people know that the stories won't actually load at this point since this is causing some confusion. It would also be good to update the screenshots here.

In order for the stories to be loaded on the serverUI like they are in the screenshot the storybookUI needs to be loaded. This happens later when the linksScreen gets updated.