### PR TITLE
Correct "Controls" const reference casing

### DIFF
--- a/content/design-systems-for-developers/react/en/build.md
+++ b/content/design-systems-for-developers/react/en/build.md
@@ -177,7 +177,7 @@ import React from 'react';
 const Template = args => <Avatar {...args} />;
 
 export const Controls = Template.bind({});
-controls.args = {
+Controls.args = {
   loading: false,
   size: 'tiny',
   username: 'Dominic Nguyen',


### PR DESCRIPTION
The const "Controls" is declared (with an uppercase first character) and then incorrectly referenced on the very next line (with a lowercase first character), which obviously doesn't work.