### PR TITLE
Update simple-component.md

### DIFF
--- a/content/intro-to-storybook/angular/en/simple-component.md
+++ b/content/intro-to-storybook/angular/en/simple-component.md
@@ -147,7 +147,7 @@ We also need to make one small change to the Storybook configuration so it notic
 // .storybook/main.js
 module.exports = {
   stories: ['../src/app/components/**/*.stories.ts'],
-  addons: ['@storybook/addon-actions', '@storybook/addon-links', '@storybook/addon-notes'],
+  addons: ['@storybook/addon-actions', '@storybook/addon-links'],
 };
 ```
 

--- a/content/intro-to-storybook/angular/pt/simple-component.md
+++ b/content/intro-to-storybook/angular/pt/simple-component.md
@@ -146,7 +146,7 @@ Ao ser criada uma estória, é usada uma tarefa base (`taskData`) para definir a
 // .storybook/main.js
 module.exports = {
   stories: ['../src/app/components/**/*.stories.ts'],
-  addons: ['@storybook/addon-actions', '@storybook/addon-links', '@storybook/addon-notes'],
+  addons: ['@storybook/addon-actions', '@storybook/addon-links'],
 };
 ```
 


### PR DESCRIPTION
For Angular, addon-notes isn't included in the default configuration, so you get an error from NPM about a missing package when restarting Storybook after the change.

Simple fix, remove addon-notes from the addons array.