### PR TITLE
Optimize google font loading

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -12,6 +12,7 @@ export default function HTML(props) {
         <meta httpEquiv="x-ua-compatible" content="ie=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
         {props.headComponents}
+        <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin />
         <link href={global.fontUrl} rel="stylesheet" />
       </head>
       <body {...props.bodyAttributes}>


### PR DESCRIPTION
This preconnects to the google fonts domain so fonts load faster. Technique from [this article](https://medium.com/clio-calliope/making-google-fonts-faster-aadf3c02a36d).