### PR TITLE
Fixed the broken link on the (https://www.learnstorybook.com/design-s…

### DIFF
--- a/content/design-systems-for-developers/react/en/document.md
+++ b/content/design-systems-for-developers/react/en/document.md
@@ -36,7 +36,7 @@ As Storybook users, we have a head start because component variations are alread
 ## Write stories, generate docs
 
 With the Storybook Docs addon, we can generate rich documentation from existing stories to reduce maintenance time and get out of the box defaults.
-Like the addons we've covered in the [build](/react/en/build/) chapter (Controls and Actions), the Docs addon is also included and configured with each Storybook install, so we can focus on writing good documentation.
+Like the addons we've covered in the [build](/design-systems-for-developers/react/en/build/) chapter (Controls and Actions), the Docs addon is also included and configured with each Storybook install, so we can focus on writing good documentation.
 
 Each time you open your Storybook you should see two tabs:
 


### PR DESCRIPTION
…ystems-for-developers/react/en/document/) page

Signed-off-by: Vansh Bhatia <vansh.bhatia@mayadata.io>

I was going through the docs and saw a broken link (https://www.learnstorybook.com/design-systems-for-developers/react/en/document/) highlighted below:

![Screenshot from 2020-10-17 04-06-50](https://user-images.githubusercontent.com/40641427/96320819-195e8980-1031-11eb-90f5-1f10406d8b0a.png)

Leading to:

![Screenshot from 2020-10-17 03-59-12](https://user-images.githubusercontent.com/40641427/96320837-28453c00-1031-11eb-96b2-16fc2bbb623b.png)

Instead of:

![Screenshot from 2020-10-17 03-59-14](https://user-images.githubusercontent.com/40641427/96320868-37c48500-1031-11eb-9cd2-a24b422e68cb.png)

Updated the link in the file `content/design-systems-for-developers/react/en/document.md` and tested locally. Please consider reviewing.