### PR TITLE
Update English design systems guide to reflect the fact new GH repos now have a default branch named 'main'

### DIFF
--- a/content/design-systems-for-developers/react/en/architecture.md
+++ b/content/design-systems-for-developers/react/en/architecture.md
@@ -63,9 +63,9 @@ Then follow GitHub's instructions to setup the (the so-far mostly empty) reposit
 git init
 git add .
 git commit -m "first commit"
-git branch -M master
+git branch -M main
 git remote add origin https://github.com/your-username/learnstorybook-design-system.git
-git push -u origin master
+git push -u origin main
 ```
 
 Be sure to replace `your-username` with your own account name.

--- a/content/design-systems-for-developers/react/en/distribute.md
+++ b/content/design-systems-for-developers/react/en/distribute.md
@@ -167,7 +167,7 @@ GH_TOKEN=<value you just got from GitHub>
 NPM_TOKEN=<value you just got from npm>
 ```
 
-By adding the file to `.gitignore` we’ll be sure that we don’t accidentally push this value to an open-source repository that all our users can see! This is crucial. If other maintainers need to publish the package from locally (later we’ll set things up to auto publish when PRs are merged to master) they should set up their own `.env` file following this process:
+By adding the file to `.gitignore` we’ll be sure that we don’t accidentally push this value to an open-source repository that all our users can see! This is crucial. If other maintainers need to publish the package from locally (later we’ll set things up to auto publish when PRs are merged to the default branch) they should set up their own `.env` file following this process:
 
 ```
 dist
@@ -196,7 +196,7 @@ In the future, we’ll calculate new version numbers with `auto` via scripts, bu
 yarn auto changelog
 ```
 
-This will generate a long changelog entry with every commit we’ve created so far (and a warning we’ve been pushing to master, which we should stop doing soon).
+This will generate a long changelog entry with every commit we’ve created so far (and a warning we’ve been pushing to the default branch, which we should stop doing soon).
 
 Although it is useful to have an auto-generated changelog so you don’t miss things, it’s also a good idea to manually edit it and craft the message in the most useful way for users. In this case, the users don’t need to know about all the commits along the way. Let’s make a nice simple message for our first v0.1.0 version. First undo the commit that Auto just created (but keep the changes:
 
@@ -232,7 +232,7 @@ npm publish
 And use Auto to create a release on GitHub:
 
 ```shell
-git push --follow-tags origin master
+git push --follow-tags origin main
 yarn auto release
 ```
 
@@ -256,7 +256,7 @@ Let’s set up Auto to follow the same process when we want to publish the packa
 }
 ```
 
-Now, when we run `yarn release`, we'll go through all the steps we ran above (except using the auto-generated changelog) in an automated fashion. All commits to `master` will be published.
+Now, when we run `yarn release`, we'll go through all the steps we ran above (except using the auto-generated changelog) in an automated fashion. All commits to the default branch will be published.
 
 Congratulations! You setup the infrastructure to manually publish your design system releases. Now learn how to automate releases with continuous integration.
 
@@ -291,7 +291,7 @@ name: Release
 # the event that will trigger the action
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 # what the action will do
 jobs:
@@ -329,7 +329,7 @@ jobs:
 
 Save and commit your changes to the remote repository.
 
-Success! Now every time you merge a PR to master, it will automatically publish a new version, incrementing the version number as appropriate due to the labels you’ve added.
+Success! Now every time you merge a PR to the default branch, it will automatically publish a new version, incrementing the version number as appropriate due to the labels you’ve added.
 
 <div class="aside">We didn’t cover all of Auto’s many features and integrations that might be useful for growing design systems. Read the docs <a href="https://github.com/intuit/auto">here</a>.</div>
 

--- a/content/design-systems-for-developers/react/en/distribute.md
+++ b/content/design-systems-for-developers/react/en/distribute.md
@@ -251,7 +251,7 @@ Let’s set up Auto to follow the same process when we want to publish the packa
 ```json
 {
   "scripts": {
-    "release": "auto shipit"
+    "release": "auto shipit --base-branch=main"
   }
 }
 ```

--- a/content/design-systems-for-developers/react/en/review.md
+++ b/content/design-systems-for-developers/react/en/review.md
@@ -127,7 +127,7 @@ git commit -m "Storybook deployment with GitHub action"
 Finally, push it to the remote repository with:
 
 ```shell
-git push origin master
+git push origin main
 ```
 
 Success! We improved our infrastructure.

--- a/content/design-systems-for-developers/react/pt/architecture.md
+++ b/content/design-systems-for-developers/react/pt/architecture.md
@@ -52,7 +52,7 @@ Utilize as instruções fornecidas pelo GitHub para adicionar a localização re
 ```bash
 cd learnstorybook-design-system
 git remote add origin https://github.com/chromaui/learnstorybook-design-system.git
-git push -u origin master
+git push -u origin main
 ```
 
 Não se esqueça de substituir `chromaui` pelo seu nome de utilizador.

--- a/content/design-systems-for-developers/react/pt/distribute.md
+++ b/content/design-systems-for-developers/react/pt/distribute.md
@@ -218,7 +218,7 @@ npm publish
 E usamos o Auto para gerar uma versão de lançamento no GitHub:
 
 ```bash
-git push --follow-tags origin master
+git push --follow-tags origin main
 yarn auto release
 ```
 
@@ -250,7 +250,7 @@ Agora, quando for executado o `yarn release`, irão ser percorridos quase todos 
 - run: yarn test
 - run: npx chromatic --project-token=2wix88i1ziu
 - run: |
-    if [ $CIRCLE_BRANCH = "master" ]
+    if [ $CIRCLE_BRANCH = "main" ]
     then
       yarn release
     fi

--- a/content/design-systems-for-developers/react/pt/distribute.md
+++ b/content/design-systems-for-developers/react/pt/distribute.md
@@ -238,7 +238,7 @@ Vamos agora configurar o Auto para seguir o mesmo processo quando for necessári
 ```json
 {
   "scripts": {
-    "release": "auto shipit"
+    "release": "auto shipit --base-branch=main"
   }
 }
 ```


### PR DESCRIPTION
First off, thank you for a wonderful tool in Storybook and for this superb guide!

As described [here](https://github.com/github/renaming#new-repositories-use-main-as-default-branch-name), new GitHub repos now have a default branch named `main` instead of `master`.

I updated the code snippets in both the English version of the Design Systems guide and the Portuguese version, and other references to "master" in the English version (I don't speak Portuguese).

When "master" is referenced in copy (not code), I replaced it with "the default branch" since I figure it will take a little time for people to get used to references to `main` like "we’ve been pushing to main".

Remaining TODOs (I'm happy to take a stab at these if you like, except for non-English copy changes):
- Update code in https://github.com/chromaui/learnstorybook-design-system that references "master", like [this code](https://github.com/chromaui/learnstorybook-design-system/blob/2d0450a27643675ecd93b3d18656705c703c8bca/.github/workflows/push.yml#L7)
- Update the other guides
- Update the Portuguese copy for the Design Systems guide