### PR TITLE
Broken link on Storybook Tutorial for React(pt) page

### DIFF
--- a/content/intro-to-storybook/react/pt/get-started.md
+++ b/content/intro-to-storybook/react/pt/get-started.md
@@ -59,7 +59,7 @@ Mas, visto que o nosso foco é a criação de um único componente de interface 
 
 ## Reutilizar CSS
 
-A Taskbox reutiliza elementos de design deste [tutorial React e GraphQL](https://https://www.chromatic.com/blog/graphql-react-tutorial-part-1-6), logo não precisamos escrever CSS neste tutorial. Copie e cole o [CSS compilado](https://github.com/chromaui/learnstorybook-code/blob/master/src/index.css) no ficheiro (ou arquivo) `src/index.css`.
+A Taskbox reutiliza elementos de design deste [tutorial React e GraphQL](https://www.chromatic.com/blog/graphql-react-tutorial-part-1-6), logo não precisamos escrever CSS neste tutorial. Copie e cole o [CSS compilado](https://github.com/chromaui/learnstorybook-code/blob/master/src/index.css) no ficheiro (ou arquivo) `src/index.css`.
 
 ![Interface Utilizador Taskbox](/intro-to-storybook/ss-browserchrome-taskbox-learnstorybook.png)
 


### PR DESCRIPTION
I found a broken link on the "Storybook Tutorial for React"(pt) page.
(https) was written twice.
Hope this helps

https://www.learnstorybook.com/intro-to-storybook/react/pt/get-started/