### PR TITLE
Chore: Fix translation status

### DIFF
--- a/content/intro-to-storybook/angular/es/get-started.md
+++ b/content/intro-to-storybook/angular/es/get-started.md
@@ -5,9 +5,6 @@ description: 'Configurar Angular Storybook en tu entorno de desarrollo'
 commit: 0818d47
 ---
 
-<div class="aside"><p>
-¡Esta traducción está desactualizada! Ayúdenos a mejorarlo haciendo clic en el enlace en la parte inferior de la página. No solo el equipo te lo agradece, sino toda la comunidad.</p></div>
-
 Storybook se ejecuta en conjunto con tu aplicación en modo desarrollo. Te ayuda a crear componentes de interfaz gráfica aislados de la lógica y el contexto de tu aplicación. Esta edición de Aprende Storybook es para Angular; existe otras ediciones para [React](/react/es/get-started), [React Native](/react-native/es/get-started), [Vue](/vue/es/get-started) y [Svelte](/svelte/es/get-started).
 
 ![Storybook and your app](/intro-to-storybook/storybook-relationship.jpg)

--- a/content/intro-to-storybook/react/es/get-started.md
+++ b/content/intro-to-storybook/react/es/get-started.md
@@ -5,9 +5,6 @@ description: 'Configurar React Storybook en tu entorno de desarrollo'
 commit: '8741257'
 ---
 
-<div class="aside"><p>
-¡Esta traducción está desactualizada! Ayúdenos a mejorarlo haciendo clic en el enlace en la parte inferior de la página. No solo el equipo te lo agradece, sino toda la comunidad.</p></div>
-
 Storybook se ejecuta junto con tu aplicación en modo desarrollo. Te ayuda a crear componentes de UI aislados de la lógica y el contexto de tu aplicación. Esta edición de Aprende Storybook es para React; existe otras ediciones para [React Native](/react-native/es/get-started), [Vue](/vue/es/get-started), [Angular](/angular/es/get-started) y [Svelte](/svelte/es/get-started).
 
 ![Storybook and your app](/intro-to-storybook/storybook-relationship.jpg)

--- a/content/intro-to-storybook/react/zh-CN/get-started.md
+++ b/content/intro-to-storybook/react/zh-CN/get-started.md
@@ -5,12 +5,6 @@ description: '在你的开发环境下, 设置 React Storybook '
 commit: '8741257'
 ---
 
-<div class="aside">
-<p>
-  此翻译未更新！您可以通过单击页面底部的链接来帮助我们改进它，不仅团队会感激它，而且整个社区都会感激不尽
-</p>
-</div>
-
 Storybook 是在开发模式下 与 您的应用程序一起运行的. 它可以帮助您构建 UI 组件,并与 应用程序的 业务逻辑和上下文 隔离开来. 本期"学习 Storybook"适用于 **React**; `Vue和Angular`版本即将推出.
 
 ![Storybook and your app](/intro-to-storybook/storybook-relationship.jpg)

--- a/content/intro-to-storybook/react/zh-TW/get-started.md
+++ b/content/intro-to-storybook/react/zh-TW/get-started.md
@@ -5,9 +5,6 @@ description: '在你的開發環境下, 設定 React Storybook '
 commit: '8741257'
 ---
 
-<div class="aside"><p>
-此翻譯尚未更新！您可以通過單擊頁面底部的鏈接來幫助我們改進它，不僅團隊會感激它，而且整個社區也會感激不盡。
-</p></div>
 Storybook 是在開發模式下 與 您的應用程式一起執行的. 它可以幫助您構建 UI 元件,並與 應用程式的 業務邏輯和上下文 隔離開來. 本期"學習 Storybook"適用於 **React**; `Vue和Angular`版本即將推出.
 
 ![Storybook and your app](/intro-to-storybook/storybook-relationship.jpg)

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,6 +10,54 @@ module.exports = {
     siteUrl: permalink,
     githubUrl: 'https://github.com/chromaui/learnstorybook.com',
     contributeUrl: 'https://github.com/chromaui/learnstorybook.com/#contribute',
+    storybookVersion: 6.1,
+    tutorialStatus: {
+      'intro-to-storybook': {
+        react: {
+          de: 5.3,
+          en: 6.1,
+          es: 5.3,
+          fr: 6.1,
+          ja: 6.1,
+          kr: 6.0,
+          nl: 5.3,
+          pt: 5.3,
+          'zh-CN': 5.3,
+          'zh-TW': 5.3,
+        },
+        'react-native': {
+          en: 5.3,
+          es: 5.3,
+        },
+        vue: {
+          en: 6.1,
+          es: 5.3,
+          fr: 5.3,
+          pt: 5.3,
+        },
+        angular: {
+          en: 5.3,
+          es: 5.3,
+          pt: 5.3,
+        },
+        svelte: {
+          en: 5.3,
+          es: 5.3,
+        },
+      },
+      'design-systems-for-developers': {
+        react: {
+          en: 6.1,
+          kr: 6.1,
+          pt: 5.3,
+        },
+      },
+      'visual-testing-handbook': {
+        react: {
+          en: 6.1,
+        },
+      },
+    },
   },
   plugins: [
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -19,7 +19,7 @@ module.exports = {
           es: 5.3,
           fr: 6.1,
           ja: 6.1,
-          kr: 6.0,
+          kr: 6.1,
           nl: 5.3,
           pt: 5.3,
           'zh-CN': 5.3,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -66,7 +66,7 @@ const onCreateFrameworkChapterNode = ({ actions, node, slug }) => {
   if (!currentVersion) {
     return;
   }
-  createNodeField({ node, name: 'tutorialupdated', value: storybookVersion === currentVersion });
+  createNodeField({ node, name: 'tutorialUpToDate', value: storybookVersion === currentVersion });
 };
 
 exports.onCreateNode = ({ node, getNode, actions }) => {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -51,6 +51,22 @@ const onCreateFrameworkChapterNode = ({ actions, node, slug }) => {
     name: 'isDefaultTranslation',
     value: language === defaultLanguage && framework === defaultFramework,
   });
+  const { siteMetadata } = config;
+  const { storybookVersion, tutorialStatus } = siteMetadata;
+
+  const currentGuide = tutorialStatus[guide];
+  const currentFramework = currentGuide[framework];
+
+  // checks if the framework is defined
+  if (!currentFramework) {
+    return;
+  }
+  // gets and checks if the translation is defined
+  const currentVersion = currentFramework[language];
+  if (!currentVersion) {
+    return;
+  }
+  createNodeField({ node, name: 'tutorialupdated', value: storybookVersion === currentVersion });
 };
 
 exports.onCreateNode = ({ node, getNode, actions }) => {

--- a/src/components/screens/ChapterScreen/index.js
+++ b/src/components/screens/ChapterScreen/index.js
@@ -122,7 +122,7 @@ const Chapter = ({
         {!tutorialUpToDate && (
           <div className="translation-aside">
             {fetchStatusUpdate.guidenotupdated}{' '}
-            <a href={githubFileUrl}>{fetchStatusUpdate.pullrequestmessage}</a> .
+            <a href={githubFileUrl}>{fetchStatusUpdate.pullrequestmessage}</a>.
           </div>
         )}
         <HighlightWrapper>{html}</HighlightWrapper>

--- a/src/components/screens/ChapterScreen/index.js
+++ b/src/components/screens/ChapterScreen/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import styled from 'styled-components';
 import { graphql } from 'gatsby';
-import { Highlight, styles } from '@storybook/design-system';
+import { Highlight, Link, styles } from '@storybook/design-system';
 import ChapterLinks from './ChapterLinks';
 import GithubLink from './GithubLink';
 import Pagination from './Pagination';
@@ -122,7 +122,10 @@ const Chapter = ({
         {!tutorialUpToDate && (
           <div className="translation-aside">
             {fetchStatusUpdate.guidenotupdated}{' '}
-            <a href={githubFileUrl}>{fetchStatusUpdate.pullrequestmessage}</a>.
+            <Link tertiary href={githubFileUrl} target="_blank" rel="noopener">
+              {fetchStatusUpdate.pullrequestmessage}
+            </Link>
+            .
           </div>
         )}
         <HighlightWrapper>{html}</HighlightWrapper>

--- a/src/components/screens/ChapterScreen/index.js
+++ b/src/components/screens/ChapterScreen/index.js
@@ -118,7 +118,9 @@ const Chapter = ({
       <Content>
         <Title>{title}</Title>
         <Description>{description}</Description>
-        {!tutorialupdated && <div className="aside">{fetchTutorialNotUpdatedText(language)}</div>}
+        {!tutorialupdated && (
+          <div className="translation-aside">{fetchTutorialNotUpdatedText(language)}</div>
+        )}
         <HighlightWrapper>{html}</HighlightWrapper>
         <ChapterLinks
           codeGithubUrl={codeGithubUrl}

--- a/src/components/screens/ChapterScreen/index.js
+++ b/src/components/screens/ChapterScreen/index.js
@@ -8,6 +8,7 @@ import ChapterLinks from './ChapterLinks';
 import GithubLink from './GithubLink';
 import Pagination from './Pagination';
 import Sidebar from './Sidebar';
+import fetchTutorialNotUpdatedText from '../../../lib/getTranslationMessages';
 import tocEntries from '../../../lib/tocEntries';
 import { chapterFormatting } from '../../../styles/formatting';
 
@@ -59,7 +60,7 @@ const Chapter = ({
     currentPage: {
       html,
       frontmatter: { commit, title, description },
-      fields: { framework, guide, language, slug, chapter, permalink },
+      fields: { framework, guide, language, slug, chapter, permalink, tutorialupdated },
     },
     currentGuide: {
       frontmatter: { codeGithubUrl, title: currentGuideTitle, toc, twitterShareText },
@@ -79,7 +80,6 @@ const Chapter = ({
     /\/$/,
     ''
   )}.md`;
-
   return (
     <ChapterWrapper>
       <Helmet>
@@ -118,6 +118,7 @@ const Chapter = ({
       <Content>
         <Title>{title}</Title>
         <Description>{description}</Description>
+        {!tutorialupdated && <div className="aside">{fetchTutorialNotUpdatedText(language)}</div>}
         <HighlightWrapper>{html}</HighlightWrapper>
         <ChapterLinks
           codeGithubUrl={codeGithubUrl}
@@ -142,6 +143,7 @@ Chapter.propTypes = {
         framework: PropTypes.string,
         language: PropTypes.string.isRequired,
         permalink: PropTypes.string.isRequired,
+        tutorialupdated: PropTypes.bool,
       }).isRequired,
       frontmatter: PropTypes.shape({
         commit: PropTypes.string,
@@ -222,6 +224,7 @@ export const query = graphql`
         framework
         language
         permalink
+        tutorialupdated
       }
     }
     currentGuide: markdownRemark(fields: { guide: { eq: $guide }, pageType: { eq: "guide" } }) {

--- a/src/components/screens/ChapterScreen/index.js
+++ b/src/components/screens/ChapterScreen/index.js
@@ -80,6 +80,7 @@ const Chapter = ({
     /\/$/,
     ''
   )}.md`;
+  const fetchStatusUpdate = fetchTutorialNotUpdatedText(language);
   return (
     <ChapterWrapper>
       <Helmet>
@@ -119,7 +120,10 @@ const Chapter = ({
         <Title>{title}</Title>
         <Description>{description}</Description>
         {!tutorialUpToDate && (
-          <div className="translation-aside">{fetchTutorialNotUpdatedText(language)}</div>
+          <div className="translation-aside">
+            {fetchStatusUpdate.guidenotupdated}{' '}
+            <a href={githubFileUrl}>{fetchStatusUpdate.pullrequestmessage}</a> .
+          </div>
         )}
         <HighlightWrapper>{html}</HighlightWrapper>
         <ChapterLinks

--- a/src/components/screens/ChapterScreen/index.js
+++ b/src/components/screens/ChapterScreen/index.js
@@ -60,7 +60,7 @@ const Chapter = ({
     currentPage: {
       html,
       frontmatter: { commit, title, description },
-      fields: { framework, guide, language, slug, chapter, permalink, tutorialupdated },
+      fields: { framework, guide, language, slug, chapter, permalink, tutorialUpToDate },
     },
     currentGuide: {
       frontmatter: { codeGithubUrl, title: currentGuideTitle, toc, twitterShareText },
@@ -118,7 +118,7 @@ const Chapter = ({
       <Content>
         <Title>{title}</Title>
         <Description>{description}</Description>
-        {!tutorialupdated && (
+        {!tutorialUpToDate && (
           <div className="translation-aside">{fetchTutorialNotUpdatedText(language)}</div>
         )}
         <HighlightWrapper>{html}</HighlightWrapper>
@@ -145,7 +145,7 @@ Chapter.propTypes = {
         framework: PropTypes.string,
         language: PropTypes.string.isRequired,
         permalink: PropTypes.string.isRequired,
-        tutorialupdated: PropTypes.bool,
+        tutorialUpToDate: PropTypes.bool,
       }).isRequired,
       frontmatter: PropTypes.shape({
         commit: PropTypes.string,
@@ -226,7 +226,7 @@ export const query = graphql`
         framework
         language
         permalink
-        tutorialupdated
+        tutorialUpToDate
       }
     }
     currentGuide: markdownRemark(fields: { guide: { eq: $guide }, pageType: { eq: "guide" } }) {

--- a/src/components/screens/ChapterScreen/index.stories.js
+++ b/src/components/screens/ChapterScreen/index.stories.js
@@ -23,6 +23,7 @@ Default.args = {
         language: 'en',
         permalink: 'https://learnstorybook.com/sample-guide',
         slug: '/chapter-slug',
+        tutorialupdated: true,
       },
     },
     currentGuide: {
@@ -103,3 +104,28 @@ Default.args = {
     },
   },
 };
+
+export const TutorialNotUpdated = Story.bind({});
+TutorialNotUpdated.args = {
+  data: {
+    ...Default.args.data,
+    currentPage: {
+      html: '<div>The html</div>',
+      frontmatter: {
+        commit: '123456789',
+        title: 'Chapter Title',
+        description: 'A good chapter',
+      },
+      fields: {
+        chapter: 'chapter-1',
+        framework: 'react',
+        guide: 'sample-guide',
+        language: 'en',
+        permalink: 'https://learnstorybook.com/sample-guide',
+        slug: '/chapter-slug',
+        tutorialupdated: false,
+      },
+    },
+   
+  },
+}

--- a/src/lib/getTranslationMessages.js
+++ b/src/lib/getTranslationMessages.js
@@ -52,9 +52,7 @@ const translationMap = {
  * @returns {Object} with the necessary text to be added to the tutorial
  */
 const fetchTutorialNotUpdatedText = language => {
-  return translationMap[language]
-    ? translationMap[language].guidenotupdated
-    : translationMap.en.guidenotupdated;
+  return translationMap[language] ? translationMap[language] : translationMap.en;
 };
 
 export default fetchTutorialNotUpdatedText;

--- a/src/lib/getTranslationMessages.js
+++ b/src/lib/getTranslationMessages.js
@@ -1,0 +1,60 @@
+import EnglishLanguageMap from './locales/en';
+import PortugueseLanguageMap from './locales/pt';
+import SpanishLanguageMap from './locales/es';
+import NetherLandsLanguageMap from './locales/nl';
+import GermanLanguageMap from './locales/de';
+import SimplifiedChineseLanguageMap from './locales/zh-CN';
+import TraditionalChineseLanguageMap from './locales/zh-TW';
+
+import FrenchLanguageMap from './locales/fr';
+import ItalianLanguageMap from './locales/it';
+import JapaneseLanguageMap from './locales/ja';
+import KoreanLanguageMap from './locales/kr';
+
+const translationMap = {
+  en: {
+    ...EnglishLanguageMap,
+  },
+  pt: {
+    ...PortugueseLanguageMap,
+  },
+  es: {
+    ...SpanishLanguageMap,
+  },
+  nl: {
+    ...NetherLandsLanguageMap,
+  },
+  de: {
+    ...GermanLanguageMap,
+  },
+  'zh-CN': {
+    ...SimplifiedChineseLanguageMap,
+  },
+  'zh-TW': {
+    ...TraditionalChineseLanguageMap,
+  },
+  fr: {
+    ...FrenchLanguageMap,
+  },
+  it: {
+    ...ItalianLanguageMap,
+  },
+  ja: {
+    ...JapaneseLanguageMap,
+  },
+  kr: {
+    ...KoreanLanguageMap,
+  },
+};
+/**
+ *  function to fetch the necessary text for displaying the not current tutorial version
+ * @param {String} language will retrieve the necessary information based on the language supplied
+ * @returns {Object} with the necessary text to be added to the tutorial
+ */
+const fetchTutorialNotUpdatedText = language => {
+  return translationMap[language]
+    ? translationMap[language].guidenotupdated
+    : translationMap.en.guidenotupdated;
+};
+
+export default fetchTutorialNotUpdatedText;

--- a/src/lib/locales/de.js
+++ b/src/lib/locales/de.js
@@ -1,6 +1,7 @@
 const GermanLanguageMap = {
   guidenotupdated:
-    'Diese Übersetzung wird nicht aktualisiert! Sie können uns helfen, es zu verbessern, indem Sie auf den Link unten auf der Seite klicken. Nicht nur das Team wird es zu schätzen wissen, sondern auch die gesamte Community.',
+    'Diese Community-Übersetzung wurde noch nicht auf die neueste Storybook-Version aktualisiert. Helfen Sie uns, es zu aktualisieren, indem Sie die Änderungen im deutschen Leitfaden für diese Übersetzung übernehmen.',
+    pullrequestmessage: 'Pull requests sind willkommen',
 };
 
 export default GermanLanguageMap;

--- a/src/lib/locales/de.js
+++ b/src/lib/locales/de.js
@@ -1,0 +1,6 @@
+const GermanLanguageMap = {
+  guidenotupdated:
+    'Diese Übersetzung wird nicht aktualisiert! Sie können uns helfen, es zu verbessern, indem Sie auf den Link unten auf der Seite klicken. Nicht nur das Team wird es zu schätzen wissen, sondern auch die gesamte Community.',
+};
+
+export default GermanLanguageMap;

--- a/src/lib/locales/en.js
+++ b/src/lib/locales/en.js
@@ -1,6 +1,7 @@
 const EnglishLanguageMap = {
   guidenotupdated:
-    'This translation is not updated! You can help us improve it by clicking the link at the bottom of the page, not only the team will appreciate it but also the entire community.',
+    'This community translation has not been updated to the latest version of Storybook yet. Help us update it by applying the changes in the English guide to this translation.',
+  pullrequestmessage: 'Pull requests are welcome',
 };
 
 export default EnglishLanguageMap;

--- a/src/lib/locales/en.js
+++ b/src/lib/locales/en.js
@@ -1,0 +1,6 @@
+const EnglishLanguageMap = {
+  guidenotupdated:
+    'This translation is not updated! You can help us improve it by clicking the link at the bottom of the page, not only the team will appreciate it but also the entire community.',
+};
+
+export default EnglishLanguageMap;

--- a/src/lib/locales/es.js
+++ b/src/lib/locales/es.js
@@ -1,0 +1,6 @@
+const SpanishLanguageMap = {
+  guidenotupdated:
+    '¡Esta traducción no está actualizada! Puede ayudarnos a mejorarlo haciendo clic en el enlace en la parte inferior de la página, no solo el equipo lo apreciará, sino también toda la comunidad.',
+};
+
+export default SpanishLanguageMap;

--- a/src/lib/locales/es.js
+++ b/src/lib/locales/es.js
@@ -1,6 +1,7 @@
 const SpanishLanguageMap = {
   guidenotupdated:
-    '¡Esta traducción no está actualizada! Puede ayudarnos a mejorarlo haciendo clic en el enlace en la parte inferior de la página, no solo el equipo lo apreciará, sino también toda la comunidad.',
+    'Esta traducción de la comunidad aún no se ha actualizado a la última versión de Storybook. Ayúdanos a actualizarlo aplicando los cambios en la guía en español para esta traducción.',
+  pullrequestmessage: 'Pull requests son bienvenidos',
 };
 
 export default SpanishLanguageMap;

--- a/src/lib/locales/fr.js
+++ b/src/lib/locales/fr.js
@@ -1,5 +1,7 @@
 const FrenchLanguageMap = {
-  guidenotupdated: `Cette traduction n'est pas mise à jour! Vous pouvez nous aider à l'améliorer en cliquant sur le lien en bas de la page, non seulement l'équipe l'appréciera mais aussi toute la communauté.`,
+  guidenotupdated: `
+  Cette traduction de la communauté n'a pas encore été mise à jour avec la dernière version de Storybook. Aidez-nous à le mettre à jour en appliquant les modifications du guide français pour cette traduction.`,
+  pullrequestmessage: 'Pull requests sont bienvenus',
 };
 
 export default FrenchLanguageMap;

--- a/src/lib/locales/fr.js
+++ b/src/lib/locales/fr.js
@@ -1,0 +1,5 @@
+const FrenchLanguageMap = {
+  guidenotupdated: `Cette traduction n'est pas mise à jour! Vous pouvez nous aider à l'améliorer en cliquant sur le lien en bas de la page, non seulement l'équipe l'appréciera mais aussi toute la communauté.`,
+};
+
+export default FrenchLanguageMap;

--- a/src/lib/locales/it.js
+++ b/src/lib/locales/it.js
@@ -1,5 +1,7 @@
 const ItalianLanguageMap = {
-  guidenotupdated: `Questa traduzione non è aggiornata! Puoi aiutarci a migliorarlo facendo clic sul link in fondo alla pagina, non solo il team lo apprezzerà, ma anche l'intera comunità.`,
+  guidenotupdated: `
+  Questa traduzione della comunità non è stata ancora aggiornata all'ultima versione di Storybook. Aiutaci ad aggiornarlo applicando le modifiche nella guida italiana per questa traduzione.`,
+  pullrequestmessage: 'Pull requests sono benvenute',
 };
 
 export default ItalianLanguageMap;

--- a/src/lib/locales/it.js
+++ b/src/lib/locales/it.js
@@ -1,0 +1,5 @@
+const ItalianLanguageMap = {
+  guidenotupdated: `Questa traduzione non è aggiornata! Puoi aiutarci a migliorarlo facendo clic sul link in fondo alla pagina, non solo il team lo apprezzerà, ma anche l'intera comunità.`,
+};
+
+export default ItalianLanguageMap;

--- a/src/lib/locales/ja.js
+++ b/src/lib/locales/ja.js
@@ -1,6 +1,7 @@
 const JapaneseLanguageMap = {
   guidenotupdated:
-    'この翻訳は更新されていません！ページの下部にあるリンクをクリックすると、改善に役立てることができます。チームだけでなく、コミュニティ全体にも感謝します。',
+    'このコミュニティの翻訳は、最新のストーリーブックバージョンにまだ更新されていません。この翻訳の日本語ガイドの変更を適用して、更新にご協力ください。',
+  pullrequestmessage: 'Pull requests 彼らは大歓迎です',
 };
 
 export default JapaneseLanguageMap;

--- a/src/lib/locales/ja.js
+++ b/src/lib/locales/ja.js
@@ -1,0 +1,6 @@
+const JapaneseLanguageMap = {
+  guidenotupdated:
+    'この翻訳は更新されていません！ページの下部にあるリンクをクリックすると、改善に役立てることができます。チームだけでなく、コミュニティ全体にも感謝します。',
+};
+
+export default JapaneseLanguageMap;

--- a/src/lib/locales/kr.js
+++ b/src/lib/locales/kr.js
@@ -1,0 +1,6 @@
+const KoreanLanguageMap = {
+  guidenotupdated:
+    '이 번역은 업데이트되지 않았습니다! 페이지 하단에있는 링크를 클릭하여 개선하는 데 도움을 줄 수 있습니다. 팀뿐만 아니라 전체 커뮤니티도 감사 할 것입니다.',
+};
+
+export default KoreanLanguageMap;

--- a/src/lib/locales/kr.js
+++ b/src/lib/locales/kr.js
@@ -1,6 +1,7 @@
 const KoreanLanguageMap = {
   guidenotupdated:
-    '이 번역은 업데이트되지 않았습니다! 페이지 하단에있는 링크를 클릭하여 개선하는 데 도움을 줄 수 있습니다. 팀뿐만 아니라 전체 커뮤니티도 감사 할 것입니다.',
+    '이 커뮤니티 번역은 아직 최신 스토리 북 버전으로 업데이트되지 않았습니다. 이 번역에 대한 한국어 가이드의 변경 사항을 적용하여 업데이트 할 수 있도록 도와주세요.',
+  pullrequestmessage: 'Pull requests 환영합니다',
 };
 
 export default KoreanLanguageMap;

--- a/src/lib/locales/nl.js
+++ b/src/lib/locales/nl.js
@@ -1,6 +1,7 @@
 const NetherLandsLanguageMap = {
   guidenotupdated:
-    'Deze vertaling is niet bijgewerkt! Je kunt ons helpen het te verbeteren door op de link onderaan de pagina te klikken, niet alleen het team zal het waarderen, maar ook de hele community.',
+    'Deze gemeenschapsvertaling is nog niet bijgewerkt naar de nieuwste versie van Storybook. Help ons om het bij te werken door de wijzigingen in de Nederlandse gids voor deze vertaling toe te passen.',
+  pullrequestmessage: 'Pull requests ze zijn welkom',
 };
 
 export default NetherLandsLanguageMap;

--- a/src/lib/locales/nl.js
+++ b/src/lib/locales/nl.js
@@ -1,0 +1,6 @@
+const NetherLandsLanguageMap = {
+  guidenotupdated:
+    'Deze vertaling is niet bijgewerkt! Je kunt ons helpen het te verbeteren door op de link onderaan de pagina te klikken, niet alleen het team zal het waarderen, maar ook de hele community.',
+};
+
+export default NetherLandsLanguageMap;

--- a/src/lib/locales/pt.js
+++ b/src/lib/locales/pt.js
@@ -1,6 +1,7 @@
 const PortugueseLanguageMap = {
   guidenotupdated:
-    'Esta tradução está desatualizada! Ajuda-nos a melhorá-la clicando no link no fim da página. Não somente a equipa agradece, mas toda a comunidade.',
+    'Esta tradução feita pela comunidade ainda não foi atualizada para a versão mais recente do Storybook. Ajude-nos a atualizá-la aplicando as alterações no guia em português para esta tradução.',
+  pullrequestmessage: 'Pull requests são bem-vindos',
 };
 
 export default PortugueseLanguageMap;

--- a/src/lib/locales/pt.js
+++ b/src/lib/locales/pt.js
@@ -1,0 +1,6 @@
+const PortugueseLanguageMap = {
+  guidenotupdated:
+    'Esta tradução está desatualizada! Ajuda-nos a melhorá-la clicando no link no fim da página. Não somente a equipa agradece, mas toda a comunidade.',
+};
+
+export default PortugueseLanguageMap;

--- a/src/lib/locales/zh-CN.js
+++ b/src/lib/locales/zh-CN.js
@@ -1,0 +1,6 @@
+const SimplifiedChineseLanguageMap = {
+  guidenotupdated:
+    '此翻譯未更新！您可以通過單擊頁面底部的鏈接來幫助我們改進它，不僅團隊會感激它，而且整個社區也會感激。',
+};
+
+export default SimplifiedChineseLanguageMap;

--- a/src/lib/locales/zh-CN.js
+++ b/src/lib/locales/zh-CN.js
@@ -1,6 +1,7 @@
 const SimplifiedChineseLanguageMap = {
   guidenotupdated:
-    '此翻譯未更新！您可以通過單擊頁面底部的鏈接來幫助我們改進它，不僅團隊會感激它，而且整個社區也會感激。',
+    '此社区翻译尚未更新为最新的Storybook版本。通过应用此翻译的中文指南中的更改来帮助我们更新它。',
+  pullrequestmessage: 'Pull requests 欢迎他们',
 };
 
 export default SimplifiedChineseLanguageMap;

--- a/src/lib/locales/zh-TW.js
+++ b/src/lib/locales/zh-TW.js
@@ -1,6 +1,7 @@
 const TraditionalChineseLanguageMap = {
   guidenotupdated:
-    '此翻譯未更新！您可以通過單擊頁面底部的鏈接來幫助我們改進它，不僅團隊會感激它，而且整個社區也會感激。',
+    '此社區翻譯尚未更新為最新的Storybook版本。通過應用此翻譯的中文指南中的更改來幫助我們更新它。',
+  pullrequestmessage: 'Pull requests 歡迎他們',
 };
 
 export default TraditionalChineseLanguageMap;

--- a/src/lib/locales/zh-TW.js
+++ b/src/lib/locales/zh-TW.js
@@ -1,0 +1,6 @@
+const TraditionalChineseLanguageMap = {
+  guidenotupdated:
+    '此翻譯未更新！您可以通過單擊頁面底部的鏈接來幫助我們改進它，不僅團隊會感激它，而且整個社區也會感激。',
+};
+
+export default TraditionalChineseLanguageMap;

--- a/src/styles/formatting.js
+++ b/src/styles/formatting.js
@@ -224,7 +224,7 @@ export const chapterFormatting = css`
     background: #f8fafc;
     border-radius: ${styles.spacing.borderRadius.small}px;
     padding: 20px;
-    margin-bottom: 1.25rem;
+    margin-bottom: 1.5rem;
   }
 
   /* Tables based on GH markdown format */

--- a/src/styles/formatting.js
+++ b/src/styles/formatting.js
@@ -224,7 +224,7 @@ export const chapterFormatting = css`
     background: #f8fafc;
     border-radius: ${styles.spacing.borderRadius.small}px;
     padding: 20px;
-    margin-bottom: 1rem;
+    margin-bottom: 1.25rem;
   }
 
   /* Tables based on GH markdown format */

--- a/src/styles/formatting.js
+++ b/src/styles/formatting.js
@@ -218,6 +218,14 @@ export const chapterFormatting = css`
       margin-bottom: 0;
     }
   }
+  .translation-aside {
+    font-size: ${typography.size.s3}px;
+    color: ${color.darker};
+    background: #f8fafc;
+    border-radius: ${styles.spacing.borderRadius.small}px;
+    padding: 20px;
+    margin-bottom: 1rem;
+  }
 
   /* Tables based on GH markdown format */
   table {


### PR DESCRIPTION
With this pull request the issue #275 is addressed.

What was done:
- Changed `gatsby-node.js` to add a new node addressing the status of the tutorial.
- Changed `gatsby-config.js` to include the information regarding current Storybook version and the translations available, where they stand in terms of Storybook version.
- Created a folder called `lib/locales` with some files with the current languages available and a message to address the fact the tutorial is not updated.
- Created a new filed called `lib/getTranslationMessages.js` where the locales are imported and dealt with.
- Changed `src/components/screens/ChapterScreen/index.js` to include a `div` element that conditionally displays the message regarding the status of the tutorial.
- Updated the `src/components/screens/ChapterScreen/index.stories.js` with a new story to test the changes.

Feel free to provide feedback