### PR TITLE
Chore: Intro to storybook Ember status update

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Currently the Intro to Storybook tutorial features the following translations. S
 |              | Portuguese       | ❌      |
 | Svelte       | English          | ❌      |
 |              | Spanish          | ❌      |
+| Ember        | English          | ✅      |
 
 The Design Systems for Developers features the following translations. Some are updated some are not. If you want to expand your Storybook and learn how to build a industry grade component library and you're a native speaker of any of the languages detailed below. Help us out by updating the translations. Comment in the issue above.
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -44,6 +44,9 @@ module.exports = {
           en: 5.3,
           es: 5.3,
         },
+        ember: {
+          en: 6.1,
+        },
       },
       'design-systems-for-developers': {
         react: {


### PR DESCRIPTION
The final piece for the Intro to Storybook for Ember is included in this pull request. As it was created before the status update pull request it's incorrectly showing that it's not updated when it is.

What was done:
- `gatsby-config.js` was updated to include current version of the ember tutorial.
- README.md is also updated to include the Ember reference