### PR TITLE
Chore: (Docs Intro to Storybook) Intro to Storybook adjustments

### DIFF
--- a/content/create-an-addon/react/en/getting-started.md
+++ b/content/create-an-addon/react/en/getting-started.md
@@ -4,9 +4,6 @@ description: 'Get started with the Addon Kit'
 commit: 'd3b6651'
 ---
 
-<!-- - Getting started (with addon kit)
-- Building the UI & registering the addon -->
-
 ![](../../images/addon-kit-demo.gif)
 
 We'll use the [Addon Kit](https://github.com/storybookjs/addon-kit) to bootstrap our project. It gives you everything you need to build a Storybook addon:

--- a/content/create-an-addon/react/en/introduction.md
+++ b/content/create-an-addon/react/en/introduction.md
@@ -55,5 +55,3 @@ Our addon code has four parts that we'll cover in the next few chapters:
 - **Registration** of the addon with Storybook.
 - **State management** to track the toggle state of the tool. This controls whether the outlines are visible or not.
 - **Decorator** that injects CSS in the preview iframe to draw the outlines.
-
-<!-- Getting started is straightforward. The [addon API](https://storybook.js.org/docs/react/addons/addons-api/) makes it easy for you to configure and customize Storybook to suit your specific needs. -->

--- a/content/intro-to-storybook/angular/en/contribute.md
+++ b/content/intro-to-storybook/angular/en/contribute.md
@@ -3,7 +3,9 @@ title: 'Contribute'
 description: 'Help share Storybook with the world'
 ---
 
-Contributions to Learn Storybook are encouraged! If it’s something small like grammar or punctuation, open up a pull request. If it’s a bigger change, [add an issue](https://github.com/chromaui/learnstorybook.com/issues) for discussion.
+Contributions to Storybook's tutorials are encouraged! If it’s something small like grammar or punctuation, open up a pull request. If it’s a bigger change, [add an issue](https://github.com/chromaui/learnstorybook.com/issues) for discussion.
+
+Storybook's tutorials were created and maintained primarily by the community, so we need everyone's help to keep it up to date and ensure any rough edges are smoothed out over time. All help is appreciated!
 
 ## Translations
 

--- a/content/intro-to-storybook/angular/en/get-started.md
+++ b/content/intro-to-storybook/angular/en/get-started.md
@@ -5,7 +5,7 @@ description: 'Setup Angular Storybook in your development environment'
 commit: 0818d47
 ---
 
-Storybook runs alongside your app in development mode. It helps you build UI components isolated from the business logic and context of your app. This edition of Learn Storybook is for Angular; other editions exist for [React](/intro-to-storybook/react/en/get-started), [React Native](/intro-to-storybook/react-native/en/get-started), [Vue](/intro-to-storybook/vue/en/get-started), [Svelte](/intro-to-storybook/svelte/en/get-started) and [Ember](/intro-to-storybook/ember/en/get-started).
+Storybook runs alongside your app in development mode. It helps you build UI components isolated from the business logic and context of your app. This edition of the Intro to Storybook tutorial is for Angular; other editions exist for [React](/intro-to-storybook/react/en/get-started), [React Native](/intro-to-storybook/react-native/en/get-started), [Vue](/intro-to-storybook/vue/en/get-started), [Svelte](/intro-to-storybook/svelte/en/get-started) and [Ember](/intro-to-storybook/ember/en/get-started).
 
 ![Storybook and your app](/intro-to-storybook/storybook-relationship.jpg)
 

--- a/content/intro-to-storybook/ember/en/composite-component.md
+++ b/content/intro-to-storybook/ember/en/composite-component.md
@@ -136,7 +136,6 @@ Create a new file called `loading-row.hbs` and inside add the following markup:
 And update `task-list.hbs` to the following:
 
 ```diff:title=app/components/task-list.hbs
-
 + {{#if @loading}}
 +  <LoadingRow />
 +  <LoadingRow />

--- a/content/intro-to-storybook/ember/en/composite-component.md
+++ b/content/intro-to-storybook/ember/en/composite-component.md
@@ -22,7 +22,7 @@ A composite component isn’t much different than the basic components it contai
 
 Start with a rough implementation of the `TaskList`. You’ll need to import the `Task` component from earlier and pass in the attributes and actions as inputs.
 
-```hbs:title=app/components/task-list.hbs
+```handlebars:title=app/components/task-list.hbs
 {{#if @loading}}
  <div class="list-items">loading</div>>
 {{else if @tasks}}
@@ -122,7 +122,7 @@ For the loading edge case, we're going to create a new component that will displ
 
 Create a new file called `loading-row.hbs` and inside add the following markup:
 
-```hbs:title=app/components/loading-row.hbs
+```handlebars:title=app/components/loading-row.hbs
 <div class="loading-item">
   <span class="glow-checkbox" />
   <span class="glow-text">
@@ -135,30 +135,30 @@ Create a new file called `loading-row.hbs` and inside add the following markup:
 
 And update `task-list.hbs` to the following:
 
-```diff:title=app/components/task-list.hbs
-+ {{#if @loading}}
-+  <LoadingRow />
-+  <LoadingRow />
-+  <LoadingRow/>
-+  <LoadingRow />
-+  <LoadingRow />
-+ {{else if this.tasksInOrder}}
-+   {{#each this.tasksInOrder as |task|}}
-+     <Task
-+       @task={{task}}
-+       @pin={{fn @pinTask task.id}}
-+       @archive={{fn @archiveTask task.id}}
-+     />
-+   {{/each}}
-+ {{else}}
-+   <div class="list-items">
-+     <div class="wrapper-message">
-+       <span class="icon-check" />
-+       <div class="title-message">You have no tasks</div>
-+       <div class="subtitle-message">Sit back and relax</div>
-+     </div>
-+   </div>
-+ {{/if}}
+```handlebars:title=app/components/task-list.hbs
+{{#if @loading}}
+  <LoadingRow />
+  <LoadingRow />
+  <LoadingRow/>
+  <LoadingRow />
+  <LoadingRow />
+{{else if this.tasksInOrder}}
+  {{#each this.tasksInOrder as |task|}}
+    <Task
+       @task={{task}}
+       @pin={{fn @pinTask task.id}}
+       @archive={{fn @archiveTask task.id}}
+    />
+   {{/each}}
+{{else}}
+  <div class="list-items">
+    <div class="wrapper-message">
+      <span class="icon-check" />
+      <div class="title-message">You have no tasks</div>
+      <div class="subtitle-message">Sit back and relax</div>
+    </div>
+  </div>
+{{/if}}
 ```
 
 And finally create a new file called `task-list.js` to the following:

--- a/content/intro-to-storybook/ember/en/composite-component.md
+++ b/content/intro-to-storybook/ember/en/composite-component.md
@@ -22,9 +22,7 @@ A composite component isn’t much different than the basic components it contai
 
 Start with a rough implementation of the `TaskList`. You’ll need to import the `Task` component from earlier and pass in the attributes and actions as inputs.
 
-```handlebars
-{{!-- app/components/task-list.hbs--}}
-
+```hbs:title=app/components/task-list.hbs
 {{#if @loading}}
  <div class="list-items">loading</div>>
 {{else if @tasks}}
@@ -44,10 +42,9 @@ Start with a rough implementation of the `TaskList`. You’ll need to import the
 
 Next create `Tasklist`’s test states in the story file.
 
-```javascript
-// app/components/task-list.stories.js
-
+```js:title=app/components/task-list.stories.js
 import { hbs } from 'ember-cli-htmlbars';
+
 import * as TaskStories from './task.stories';
 
 export default {
@@ -125,9 +122,7 @@ For the loading edge case, we're going to create a new component that will displ
 
 Create a new file called `loading-row.hbs` and inside add the following markup:
 
-```handlebars
-{{!-- app/components/loading-row.hbs --}}
-
+```hbs:title=app/components/loading-row.hbs
 <div class="loading-item">
   <span class="glow-checkbox" />
   <span class="glow-text">
@@ -140,39 +135,36 @@ Create a new file called `loading-row.hbs` and inside add the following markup:
 
 And update `task-list.hbs` to the following:
 
-```handlebars
-{{!-- app/components/task-list.hbs--}}
+```diff:title=app/components/task-list.hbs
 
-{{#if @loading}}
- <LoadingRow />
- <LoadingRow />
- <LoadingRow/>
- <LoadingRow />
- <LoadingRow />
-{{else if this.tasksInOrder}}
-  {{#each this.tasksInOrder as |task|}}
-    <Task
-      @task={{task}}
-      @pin={{fn @pinTask task.id}}
-      @archive={{fn @archiveTask task.id}}
-    />
-  {{/each}}
-{{else}}
-  <div class="list-items">
-    <div class="wrapper-message">
-      <span class="icon-check" />
-      <div class="title-message">You have no tasks</div>
-      <div class="subtitle-message">Sit back and relax</div>
-    </div>
-  </div>
-{{/if}}
++ {{#if @loading}}
++  <LoadingRow />
++  <LoadingRow />
++  <LoadingRow/>
++  <LoadingRow />
++  <LoadingRow />
++ {{else if this.tasksInOrder}}
++   {{#each this.tasksInOrder as |task|}}
++     <Task
++       @task={{task}}
++       @pin={{fn @pinTask task.id}}
++       @archive={{fn @archiveTask task.id}}
++     />
++   {{/each}}
++ {{else}}
++   <div class="list-items">
++     <div class="wrapper-message">
++       <span class="icon-check" />
++       <div class="title-message">You have no tasks</div>
++       <div class="subtitle-message">Sit back and relax</div>
++     </div>
++   </div>
++ {{/if}}
 ```
 
 And finally create a new file called `task-list.js` to the following:
 
-```javascript
-// app/components/task-list.js
-
+```js:title=app/components/task-list.js
 import Component from '@glimmer/component';
 
 export default class TaskList extends Component {
@@ -215,13 +207,12 @@ So, to avoid this problem, we can use Qunit to render the component and run some
 
 Create a test file called `tests/integration/task-list-test.js`. Here, we’ll build out our tests that make assertions about the output.
 
-```javascript
-// tests/integration/task-list-test.js
-
+```js:title=tests/integration/task-list-test.js
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+
 module('Integration | Component | TaskList', function(hooks) {
   setupRenderingTest(hooks);
   const taskData = {

--- a/content/intro-to-storybook/ember/en/contribute.md
+++ b/content/intro-to-storybook/ember/en/contribute.md
@@ -3,9 +3,9 @@ title: 'Contribute'
 description: 'Help share Storybook with the world'
 ---
 
-Contributions to Learn Storybook are encouraged! If it’s something small like grammar or punctuation, open up a pull request. If it’s a bigger change, [add an issue](https://github.com/chromaui/learnstorybook.com/issues) for discussion.
+Contributions to Storybook's tutorials are encouraged! If it’s something small like grammar or punctuation, open up a pull request. If it’s a bigger change, [add an issue](https://github.com/chromaui/learnstorybook.com/issues) for discussion.
 
-Learn Storybook has been primarily created and maintained by the community so we need everyone's help to keep it up to date and ensure any rough edges are smoothed out over time. All help is appreciated!
+Storybook's tutorials were created and maintained primarily by the community, so we need everyone's help to keep it up to date and ensure any rough edges are smoothed out over time. All help is appreciated!
 
 ## Translations
 

--- a/content/intro-to-storybook/ember/en/data.md
+++ b/content/intro-to-storybook/ember/en/data.md
@@ -125,12 +125,12 @@ export default class TaskController extends Controller {
 
 And one final file called `template.hbs`, in which we'll add the presentational `<TaskList>` component we've created in the [previous chapter](/intro-to-storybook/ember/en/composite-component/):
 
-```diff:title=app/tasks/template.hbs
-+ <TaskList
-+  @tasks={{@model}}
-+  @pinTask={{this.pinTask}}
-+  @archiveTask={{this.archiveTask}}
-+ />
+```handlebars:title=app/tasks/template.hbs
+<TaskList
+  @tasks={{@model}}
+  @pinTask={{this.pinTask}}
+  @archiveTask={{this.archiveTask}}
+ />
 ```
 
 With this we've accomplished what we've set out to do, we've managed to setup a data persistance layer and also we've managed to keep the components decoupled by adopting some best practices.

--- a/content/intro-to-storybook/ember/en/data.md
+++ b/content/intro-to-storybook/ember/en/data.md
@@ -25,9 +25,7 @@ ember install tracked-redux
 
 First we’ll construct a simple Redux store that responds to actions that change the state of tasks, in a file called `redux.js` in the `app` folder (intentionally kept simple):
 
-```js
-// app/store.js
-
+```js:title=app/store.js
 import { createStore } from 'tracked-redux';
 
 export const actions = {
@@ -89,9 +87,7 @@ For that we're going to use both a [route](https://guides.emberjs.com/release/ro
 
 Inside the `app` directory, create a new one called `tasks` and inside add a new file called `route.js` with the following:
 
-```js
-// app/tasks/route.js
-
+```js:title=app/tasks/route.js
 import Route from '@ember/routing/route';
 import { store } from '../store';
 
@@ -108,11 +104,10 @@ export default class TasksRoute extends Route {
 
 Next, we'll need the controller. Inside the `tasks` folder create another file called `controller.js` with the following:
 
-```js
-// app/tasks/controller.js
-
+```js:title=app/tasks/controller.js
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
+
 import { store, pinTask, archiveTask } from '../store';
 
 export default class TaskController extends Controller {
@@ -130,14 +125,12 @@ export default class TaskController extends Controller {
 
 And one final file called `template.hbs`, in which we'll add the presentational `<TaskList>` component we've created in the [previous chapter](/intro-to-storybook/ember/en/composite-component/):
 
-```hbs
-{{!--app/tasks/template.hbs --}}
-
-<TaskList
-  @tasks={{@model}}
-  @pinTask={{this.pinTask}}
-  @archiveTask={{this.archiveTask}}
-/>
+```diff:title=app/tasks/template.hbs
++ <TaskList
++  @tasks={{@model}}
++  @pinTask={{this.pinTask}}
++  @archiveTask={{this.archiveTask}}
++ />
 ```
 
 With this we've accomplished what we've set out to do, we've managed to setup a data persistance layer and also we've managed to keep the components decoupled by adopting some best practices.

--- a/content/intro-to-storybook/ember/en/deploy.md
+++ b/content/intro-to-storybook/ember/en/deploy.md
@@ -79,9 +79,7 @@ In the root folder of our project, create a new directory called `.github` then 
 
 Create a new file called `chromatic.yml` like the one below. Replace to change `project-token` with your project token.
 
-```yaml
-# .github/workflows/chromatic.yml
-
+```yaml:title=.github/workflows/chromatic.yml
 # Workflow name
 name: 'Chromatic Deployment'
 

--- a/content/intro-to-storybook/ember/en/get-started.md
+++ b/content/intro-to-storybook/ember/en/get-started.md
@@ -4,7 +4,7 @@ tocTitle: 'Get started'
 description: 'Setup Storybook in your development environment'
 ---
 
-Storybook runs alongside your app in development mode. It helps you build UI components isolated from the business logic and context of your app. This edition of Learn Storybook is for Ember; other editions exist for [React](/intro-to-storybook/react/en/get-started), [React Native](/intro-to-storybook/react-native/en/get-started), [Vue](/intro-to-storybook/vue/en/get-started), [Angular](/intro-to-storybook/angular/en/get-started) and [Svelte](/intro-to-storybook/svelte/en/get-started).
+Storybook runs alongside your app in development mode. It helps you build UI components isolated from the business logic and context of your app. This edition of the Intro to Storybook tutorial is for Ember; other editions exist for [React](/intro-to-storybook/react/en/get-started), [React Native](/intro-to-storybook/react-native/en/get-started), [Vue](/intro-to-storybook/vue/en/get-started), [Angular](/intro-to-storybook/angular/en/get-started) and [Svelte](/intro-to-storybook/svelte/en/get-started).
 
 ![Storybook and your app](/intro-to-storybook/storybook-relationship.jpg)
 

--- a/content/intro-to-storybook/ember/en/screen.md
+++ b/content/intro-to-storybook/ember/en/screen.md
@@ -14,8 +14,7 @@ As our app is very simple, the screen we’ll build is pretty trivial, simply wr
 
 Let's start by updating our store with the necessary fields:
 
-```js
-// app/store.js
+```diff:title=app/store.js
 
 import { createStore } from 'tracked-redux';
 
@@ -23,16 +22,16 @@ export const actions = {
   ARCHIVE_TASK: 'ARCHIVE_TASK',
   PIN_TASK: 'PIN_TASK',
   // The new actions to handle both error and loading state
-  SET_ERROR: 'SET_ERROR',
-  SET_LOADING: 'SET_LOADING',
++ SET_ERROR: 'SET_ERROR',
++ SET_LOADING: 'SET_LOADING',
 };
 
 // The action creators bundle actions with the data required to execute them
 export const archiveTask = id => ({ type: actions.ARCHIVE_TASK, id });
 export const pinTask = id => ({ type: actions.PIN_TASK, id });
 
-export const setError = () => ({ type: actions.SET_ERROR });
-export const setLoading = () => ({ type: actions.SET_LOADING });
++ export const setError = () => ({ type: actions.SET_ERROR });
++ export const setLoading = () => ({ type: actions.SET_LOADING });
 
 // A sample set of tasks
 const defaultTasks = [
@@ -68,16 +67,16 @@ const reducers = (state, action) => {
       return taskStateReducer('TASK_ARCHIVED')(state, action);
     case actions.PIN_TASK:
       return taskStateReducer('TASK_PINNED')(state, action);
-    case actions.SET_ERROR:
-      return {
-        ...state,
-        isError: true,
-      };
-    case actions.SET_LOADING:
-      return {
-        ...state,
-        isLoading: true,
-      };
++   case actions.SET_ERROR:
++     return {
++       ...state,
++       isError: true,
++     };
++   case actions.SET_LOADING:
++     return {
++       ...state,
++       isLoading: true,
++     };
     default:
       return state || initialState;
   }
@@ -88,8 +87,7 @@ export const store = createStore(reducers);
 
 Next, create a new component called `inbox-scree.hbs` inside the `app/components` directory:
 
-```handlebars
-{{!--app/components/inbox-screen.hbs--}}
+```hbs:title=app/components/inbox-screen.hbs
 
 <div>
   <div class="page lists-show">
@@ -133,11 +131,10 @@ We now have a way to handle the various states of our application. We can now mo
 
 Inside `app/components/inbox-screen.js` add the following:
 
-```javascript
-// app/components/inbox-screen.js
-
+```js:title=app/components/inbox-screen.js
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+
 import { store, pinTask, archiveTask } from '../store';
 
 export default class InboxScreenComponent extends Component {
@@ -169,10 +166,8 @@ export default class InboxScreenComponent extends Component {
 
 We can now safely delete the `tasks` folder we created in the [previous chapter](/intro-to-storybook/ember/en/data/) and add the `InboxScreen` to the `application` template.
 
-```handlebars
-{{!-- app/templates/aplication.hbs --}}
-
-<InboxScreen />
+```diff:title=app/templates/aplication.hbs
++ <InboxScreen />
 ```
 
 However, where things get interesting is in rendering the story in Storybook.
@@ -181,9 +176,7 @@ As `loading` and `error` are states internal to the `InboxScreen` component, the
 
 So when we setup our stories in `inbox-screen.stories.js`:
 
-```javascript
-// app/components/inbox-screen.stories.js
-
+```js:title=app/components/inbox-screen.stories.js
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {

--- a/content/intro-to-storybook/ember/en/screen.md
+++ b/content/intro-to-storybook/ember/en/screen.md
@@ -87,8 +87,7 @@ export const store = createStore(reducers);
 
 Next, create a new component called `inbox-scree.hbs` inside the `app/components` directory:
 
-```hbs:title=app/components/inbox-screen.hbs
-
+```handlebars:title=app/components/inbox-screen.hbs
 <div>
   <div class="page lists-show">
     <nav>
@@ -166,8 +165,8 @@ export default class InboxScreenComponent extends Component {
 
 We can now safely delete the `tasks` folder we created in the [previous chapter](/intro-to-storybook/ember/en/data/) and add the `InboxScreen` to the `application` template.
 
-```diff:title=app/templates/aplication.hbs
-+ <InboxScreen />
+```handlebars:title=app/templates/aplication.hbs
+<InboxScreen />
 ```
 
 However, where things get interesting is in rendering the story in Storybook.

--- a/content/intro-to-storybook/ember/en/simple-component.md
+++ b/content/intro-to-storybook/ember/en/simple-component.md
@@ -25,9 +25,7 @@ First, let’s create the necessary files for our task component and its accompa
 
 We’ll begin with a basic implementation of the `Task`, simply taking in the attributes we know we’ll need and the two actions you can take on a task (to move it between lists):
 
-```handlebars
-{{!-- app/components/task.hbs --}}
-
+```hbs:title=app/components/task.hbs
 <div class="list-item">
   <input type="text" value={{@task.title}} readonly={{true}}/>
 </div>
@@ -37,9 +35,7 @@ Above, we render straightforward markup for `Task` based on the existing HTML st
 
 Below we build out Task’s three test states in the story file:
 
-```javascript
-// app/components/task.stories.js
-
+```js:title=app/components/task.stories.js
 import { hbs } from 'ember-cli-htmlbars';
 
 import { action } from '@storybook/addon-actions';
@@ -124,12 +120,9 @@ When creating a story we use a base `task` arg to build out the shape of the tas
 
 We'll also need to make one small change to the Storybook configuration so it notices our recently created stories. Change your configuration file (`.storybook/main.js`) to the following:
 
-```javascript
-// .storybook/main.js
-
+```diff:title=.storybook/main.js
 module.exports = {
-  //👇 Location of our stories
-  stories: ['../app/components/**/*.stories.js'],
++ stories: ['../app/components/**/*.stories.js'],
   addons: ['@storybook/addon-actions', '@storybook/addon-links'],
 };
 ```
@@ -149,51 +142,47 @@ Now we have Storybook setup, styles imported, and test cases built out, we can q
 
 The component is still basic at the moment. First write the code that achieves the design without going into too much detail:
 
-```handlebars
-{{!-- app/components/task.hbs --}}
-
-<div class="list-item {{@task.state}}" data-test-task>
-  <label class="checkbox">
-    <input
-      type="checkbox"
-      disabled
-      name="checked"
-      checked={{this.isArchived}}
-    />
-    <span
-      class="checkbox-custom"
-      data-test-task-archive
-      {{on "click" this.archive}}
-    ></span>
-  </label>
-  <div class="title">
-    <input
-      type="text"
-      readonly
-      value={{@task.title}}
-      placeholder="Input title"
-    />
-  </div>
-  <div class="actions">
-    {{#unless this.isArchived}}
-      <span data-test-task-pin {{on "click" this.pin}}>
-        <span class="icon-star"></span>
-      </span>
-    {{/unless}}
-  </div>
-</div>
+```diff:title=app/components/task.hbs
++ <div class="list-item {{@task.state}}" data-test-task>
++   <label class="checkbox">
++     <input
++       type="checkbox"
++       disabled
++       name="checked"
++       checked={{this.isArchived}}
++     />
++     <span
++       class="checkbox-custom"
++       data-test-task-archive
++       {{on "click" this.archive}}
++     ></span>
++   </label>
++   <div class="title">
++     <input
++       type="text"
++       readonly
++       value={{@task.title}}
++       placeholder="Input title"
++     />
++   </div>
++   <div class="actions">
++     {{#unless this.isArchived}}
++       <span data-test-task-pin {{on "click" this.pin}}>
++         <span class="icon-star"></span>
++       </span>
++     {{/unless}}
++   </div>
++ </div>
 ```
 
 Then we'll need create a new file called `app/components/task.js` with the following:
 
-```js
-// app/components/task.js
-
+```js:title=app/components/task.js
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 export default class Task extends Component {
-  // computed property for the component (to assign a value to the task state checkbox)
+  // Computed property for the component (to assign a value to the task state checkbox)
   get isArchived() {
     return this.args.task.state === 'TASK_ARCHIVED';
   }

--- a/content/intro-to-storybook/ember/en/simple-component.md
+++ b/content/intro-to-storybook/ember/en/simple-component.md
@@ -25,7 +25,7 @@ First, let’s create the necessary files for our task component and its accompa
 
 We’ll begin with a basic implementation of the `Task`, simply taking in the attributes we know we’ll need and the two actions you can take on a task (to move it between lists):
 
-```hbs:title=app/components/task.hbs
+```handlebars:title=app/components/task.hbs
 <div class="list-item">
   <input type="text" value={{@task.title}} readonly={{true}}/>
 </div>
@@ -142,37 +142,37 @@ Now we have Storybook setup, styles imported, and test cases built out, we can q
 
 The component is still basic at the moment. First write the code that achieves the design without going into too much detail:
 
-```diff:title=app/components/task.hbs
-+ <div class="list-item {{@task.state}}" data-test-task>
-+   <label class="checkbox">
-+     <input
-+       type="checkbox"
-+       disabled
-+       name="checked"
-+       checked={{this.isArchived}}
-+     />
-+     <span
-+       class="checkbox-custom"
-+       data-test-task-archive
-+       {{on "click" this.archive}}
-+     ></span>
-+   </label>
-+   <div class="title">
-+     <input
-+       type="text"
-+       readonly
-+       value={{@task.title}}
-+       placeholder="Input title"
-+     />
-+   </div>
-+   <div class="actions">
-+     {{#unless this.isArchived}}
-+       <span data-test-task-pin {{on "click" this.pin}}>
-+         <span class="icon-star"></span>
-+       </span>
-+     {{/unless}}
-+   </div>
-+ </div>
+```handlebars:title=app/components/task.hbs
+<div class="list-item {{@task.state}}" data-test-task>
+  <label class="checkbox">
+    <input
+      type="checkbox"
+      disabled
+      name="checked"
+      checked={{this.isArchived}}
+    />
+    <span
+      class="checkbox-custom"
+      data-test-task-archive
+      {{on "click" this.archive}}
+    ></span>
+  </label>
+  <div class="title">
+    <input
+      type="text"
+      readonly
+      value={{@task.title}}
+      placeholder="Input title"
+    />
+  </div>
+  <div class="actions">
+    {{#unless this.isArchived}}
+      <span data-test-task-pin {{on "click" this.pin}}>
+        <span class="icon-star"></span>
+      </span>
+    {{/unless}}
+  </div>
+</div>
 ```
 
 Then we'll need create a new file called `app/components/task.js` with the following:

--- a/content/intro-to-storybook/ember/en/test.md
+++ b/content/intro-to-storybook/ember/en/test.md
@@ -42,16 +42,14 @@ git checkout -b change-task-background
 
 Change `Task` to the following:
 
-```hbs
-{{!-- app/components/task.hbs --}}
-
+```diff:title=app/components/task.hbs
 <div class="title">
     <input
       type="text"
       readonly
       value={{@task.title}}
       placeholder="Input title"
-      style="background:red;"
++     style="background:red;"
     />
 </div>
 ```

--- a/content/intro-to-storybook/ember/en/using-addons.md
+++ b/content/intro-to-storybook/ember/en/using-addons.md
@@ -39,16 +39,14 @@ Controls allowed us to quickly verify different inputs to a component. In this c
 
 Now let's fix the issue with overflowing by adding a style to `task.hbs`:
 
-```hbs
-{{!-- app/components/task.hbs --}}
-
+```diff:title=app/components/task.hbs
 <div class="title">
     <input
       type="text"
       readonly
       value={{@task.title}}
       placeholder="Input title"
-      style="text-overflow: ellipsis;"
++     style="text-overflow: ellipsis;"
     />
   </div>
 ```
@@ -63,9 +61,7 @@ In the future, We can manually reproduce this problem by entering the same strin
 
 Add a new story for the long text case in `task.stories.js`:
 
-```js
-// app/components/task.stories.js
-
+```js:title=app/components/task.stories.js
 const longTitleString = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not!`;
 
 export const LongTitle = Template.bind({});

--- a/content/intro-to-storybook/react-native/en/contribute.md
+++ b/content/intro-to-storybook/react-native/en/contribute.md
@@ -3,9 +3,9 @@ title: 'Contribute'
 description: 'Help share Storybook with the world'
 ---
 
-Contributions to Learn Storybook are encouraged! If it’s something small like grammar or punctuation, open up a pull request. If it’s a bigger change, [add an issue](https://github.com/chromaui/learnstorybook.com/issues) for discussion.
+Contributions to Storybook's tutorials are encouraged! If it’s something small like grammar or punctuation, open up a pull request. If it’s a bigger change, [add an issue](https://github.com/chromaui/learnstorybook.com/issues) for discussion.
 
-Learn Storybook has been primarily created and maintained by the community so we need everyone's help to keep it up to date and ensure any rough edges are smoothed out over time. All help is appreciated!
+Storybook's tutorials were created and maintained primarily by the community, so we need everyone's help to keep it up to date and ensure any rough edges are smoothed out over time. All help is appreciated!
 
 ## Translations
 

--- a/content/intro-to-storybook/react-native/en/get-started.md
+++ b/content/intro-to-storybook/react-native/en/get-started.md
@@ -4,7 +4,7 @@ tocTitle: 'Get started'
 description: 'Setup Storybook in your development environment'
 ---
 
-Storybook runs alongside your app in development mode. It helps you build UI components isolated from the business logic and context of your app. This edition of Learn Storybook is for React Native; other editions exist for [React](/intro-to-storybook/react/en/get-started), [Vue](/intro-to-storybook/vue/en/get-started), [Angular](/intro-to-storybook/angular/en/get-started), [Svelte](/intro-to-storybook/svelte/en/get-started) and [Ember](/intro-to-storybook/ember/en/get-started).
+Storybook runs alongside your app in development mode. It helps you build UI components isolated from the business logic and context of your app. This edition of the Intro to Storybook tutorial is for React Native; other editions exist for [React](/intro-to-storybook/react/en/get-started), [Vue](/intro-to-storybook/vue/en/get-started), [Angular](/intro-to-storybook/angular/en/get-started), [Svelte](/intro-to-storybook/svelte/en/get-started) and [Ember](/intro-to-storybook/ember/en/get-started).
 
 ![Storybook and your app](/intro-to-storybook/storybook-relationship.jpg)
 

--- a/content/intro-to-storybook/react/en/composite-component.md
+++ b/content/intro-to-storybook/react/en/composite-component.md
@@ -23,9 +23,7 @@ A composite component isn’t much different than the basic components it contai
 
 Start with a rough implementation of the `TaskList`. You’ll need to import the `Task` component from earlier and pass in the attributes and actions as inputs.
 
-```javascript
-// src/components/TaskList.js
-
+```js:title=src/components/TaskList.js
 import React from 'react';
 
 import Task from './Task';
@@ -56,9 +54,7 @@ export default function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
 
 Next create `Tasklist`’s test states in the story file.
 
-```javascript
-// src/components/TaskList.stories.js
-
+```js:title=src/components/TaskList.stories.js
 import React from 'react';
 
 import TaskList from './TaskList';
@@ -130,9 +126,7 @@ Now check Storybook for the new `TaskList` stories.
 
 Our component is still rough but now we have an idea of the stories to work toward. You might be thinking that the `.list-items` wrapper is overly simplistic. You're right – in most cases we wouldn’t create a new component just to add a wrapper. But the **real complexity** of `TaskList` component is revealed in the edge cases `withPinnedTasks`, `loading`, and `empty`.
 
-```javascript
-// src/components/TaskList.js
-
+```diff:title=src/components/TaskList.js
 import React from 'react';
 
 import Task from './Task';
@@ -143,48 +137,48 @@ export default function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
     onArchiveTask,
   };
 
-  const LoadingRow = (
-    <div className="loading-item">
-      <span className="glow-checkbox" />
-      <span className="glow-text">
-        <span>Loading</span> <span>cool</span> <span>state</span>
-      </span>
-    </div>
-  );
-  if (loading) {
-    return (
-      <div className="list-items">
-        {LoadingRow}
-        {LoadingRow}
-        {LoadingRow}
-        {LoadingRow}
-        {LoadingRow}
-        {LoadingRow}
-      </div>
-    );
-  }
-  if (tasks.length === 0) {
-    return (
-      <div className="list-items">
-        <div className="wrapper-message">
-          <span className="icon-check" />
-          <div className="title-message">You have no tasks</div>
-          <div className="subtitle-message">Sit back and relax</div>
-        </div>
-      </div>
-    );
-  }
-  const tasksInOrder = [
-    ...tasks.filter(t => t.state === 'TASK_PINNED'),
-    ...tasks.filter(t => t.state !== 'TASK_PINNED'),
-  ];
-  return (
-    <div className="list-items">
-      {tasksInOrder.map(task => (
-        <Task key={task.id} task={task} {...events} />
-      ))}
-    </div>
-  );
++ const LoadingRow = (
++   <div className="loading-item">
++     <span className="glow-checkbox" />
++     <span className="glow-text">
++       <span>Loading</span> <span>cool</span> <span>state</span>
++     </span>
++   </div>
++ );
++ if (loading) {
++   return (
++     <div className="list-items">
++       {LoadingRow}
++       {LoadingRow}
++       {LoadingRow}
++       {LoadingRow}
++       {LoadingRow}
++       {LoadingRow}
++     </div>
++   );
++ }
++ if (tasks.length === 0) {
++   return (
++     <div className="list-items">
++       <div className="wrapper-message">
++         <span className="icon-check" />
++         <div className="title-message">You have no tasks</div>
++         <div className="subtitle-message">Sit back and relax</div>
++       </div>
++     </div>
++   );
++ }
++ const tasksInOrder = [
++   ...tasks.filter(t => t.state === 'TASK_PINNED'),
++   ...tasks.filter(t => t.state !== 'TASK_PINNED'),
++ ];
++ return (
++   <div className="list-items">
++     {tasksInOrder.map(task => (
++       <Task key={task.id} task={task} {...events} />
++     ))}
++   </div>
++ );
 }
 ```
 
@@ -203,9 +197,7 @@ Note the position of the pinned item in the list. We want the pinned item to ren
 
 As the component grows, so too do input requirements. Define the prop requirements of `TaskList`. Because `Task` is a child component, make sure to provide data in the right shape to render it. To save time and headache, reuse the propTypes you defined in `Task` earlier.
 
-```javascript
-// src/components/TaskList.js
-
+```diff:title=src/components/TaskList.js
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -215,19 +207,19 @@ export default function TaskList() {
   ...
 }
 
-TaskList.propTypes = {
-  /** Checks if it's in loading state */
-  loading: PropTypes.bool,
-  /** The list of tasks */
-  tasks: PropTypes.arrayOf(Task.propTypes.task).isRequired,
-  /** Event to change the task to pinned */
-  onPinTask: PropTypes.func,
-  /** Event to change the task to archived */
-  onArchiveTask: PropTypes.func,
-};
-TaskList.defaultProps = {
-  loading: false,
-};
++ TaskList.propTypes = {
++  /** Checks if it's in loading state */
++  loading: PropTypes.bool,
++  /** The list of tasks */
++  tasks: PropTypes.arrayOf(Task.propTypes.task).isRequired,
++  /** Event to change the task to pinned */
++  onPinTask: PropTypes.func,
++  /** Event to change the task to archived */
++  onArchiveTask: PropTypes.func,
++ };
++ TaskList.defaultProps = {
++  loading: false,
++ };
 ```
 
 ## Automated testing
@@ -248,11 +240,10 @@ So, to avoid this problem, we can use Jest to render the story to the DOM and ru
 
 Create a test file called `src/components/TaskList.test.js`. Here, we’ll build out our tests that make assertions about the output.
 
-```javascript
-// src/components/TaskList.test.js
-
+```js:title=src/components/TaskList.test.js
 import React from 'react';
 import ReactDOM from 'react-dom';
+
 import '@testing-library/jest-dom/extend-expect';
 
 import { WithPinnedTasks } from './TaskList.stories'; //👈  Our story imported here

--- a/content/intro-to-storybook/react/en/composite-component.md
+++ b/content/intro-to-storybook/react/en/composite-component.md
@@ -126,7 +126,7 @@ Now check Storybook for the new `TaskList` stories.
 
 Our component is still rough but now we have an idea of the stories to work toward. You might be thinking that the `.list-items` wrapper is overly simplistic. You're right – in most cases we wouldn’t create a new component just to add a wrapper. But the **real complexity** of `TaskList` component is revealed in the edge cases `withPinnedTasks`, `loading`, and `empty`.
 
-```diff:title=src/components/TaskList.js
+```js:title=src/components/TaskList.js
 import React from 'react';
 
 import Task from './Task';
@@ -137,48 +137,48 @@ export default function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
     onArchiveTask,
   };
 
-+ const LoadingRow = (
-+   <div className="loading-item">
-+     <span className="glow-checkbox" />
-+     <span className="glow-text">
-+       <span>Loading</span> <span>cool</span> <span>state</span>
-+     </span>
-+   </div>
-+ );
-+ if (loading) {
-+   return (
-+     <div className="list-items">
-+       {LoadingRow}
-+       {LoadingRow}
-+       {LoadingRow}
-+       {LoadingRow}
-+       {LoadingRow}
-+       {LoadingRow}
-+     </div>
-+   );
-+ }
-+ if (tasks.length === 0) {
-+   return (
-+     <div className="list-items">
-+       <div className="wrapper-message">
-+         <span className="icon-check" />
-+         <div className="title-message">You have no tasks</div>
-+         <div className="subtitle-message">Sit back and relax</div>
-+       </div>
-+     </div>
-+   );
-+ }
-+ const tasksInOrder = [
-+   ...tasks.filter(t => t.state === 'TASK_PINNED'),
-+   ...tasks.filter(t => t.state !== 'TASK_PINNED'),
-+ ];
-+ return (
-+   <div className="list-items">
-+     {tasksInOrder.map(task => (
-+       <Task key={task.id} task={task} {...events} />
-+     ))}
-+   </div>
-+ );
+  const LoadingRow = (
+    <div className="loading-item">
+      <span className="glow-checkbox" />
+      <span className="glow-text">
+        <span>Loading</span> <span>cool</span> <span>state</span>
+      </span>
+    </div>
+  );
+  if (loading) {
+    return (
+      <div className="list-items">
+        {LoadingRow}
+        {LoadingRow}
+        {LoadingRow}
+        {LoadingRow}
+        {LoadingRow}
+        {LoadingRow}
+      </div>
+    );
+  }
+  if (tasks.length === 0) {
+    return (
+      <div className="list-items">
+        <div className="wrapper-message">
+          <span className="icon-check" />
+          <div className="title-message">You have no tasks</div>
+          <div className="subtitle-message">Sit back and relax</div>
+        </div>
+      </div>
+    );
+  }
+  const tasksInOrder = [
+    ...tasks.filter(t => t.state === 'TASK_PINNED'),
+    ...tasks.filter(t => t.state !== 'TASK_PINNED'),
+  ];
+  return (
+    <div className="list-items">
+      {tasksInOrder.map(task => (
+        <Task key={task.id} task={task} {...events} />
+      ))}
+    </div>
+  );
 }
 ```
 

--- a/content/intro-to-storybook/react/en/contribute.md
+++ b/content/intro-to-storybook/react/en/contribute.md
@@ -3,9 +3,9 @@ title: 'Contribute'
 description: 'Help share Storybook with the world'
 ---
 
-Contributions to Learn Storybook are encouraged! If it’s something small like grammar or punctuation, open up a pull request. If it’s a bigger change, [add an issue](https://github.com/chromaui/learnstorybook.com/issues) for discussion.
+Contributions to Storybook's tutorials are encouraged! If it’s something small like grammar or punctuation, open up a pull request. If it’s a bigger change, [add an issue](https://github.com/chromaui/learnstorybook.com/issues) for discussion.
 
-Learn Storybook has been primarily created and maintained by the community so we need everyone's help to keep it up to date and ensure any rough edges are smoothed out over time. All help is appreciated!
+Storybook's tutorials were created and maintained primarily by the community, so we need everyone's help to keep it up to date and ensure any rough edges are smoothed out over time. All help is appreciated!
 
 ## Translations
 

--- a/content/intro-to-storybook/react/en/data.md
+++ b/content/intro-to-storybook/react/en/data.md
@@ -77,43 +77,43 @@ export default createStore(reducer, { tasks: defaultTasks });
 
 Then we’ll update the default export from the `TaskList` component to connect to the Redux store and render the tasks we are interested in:
 
-```diff:title=src/components/TaskList.js
+```js:title=src/components/TaskList.js
 import React from 'react';
 import PropTypes from 'prop-types';
 
 import Task from './Task';
 
-+ import { connect } from 'react-redux';
-+ import { archiveTask, pinTask } from '../lib/redux';
+import { connect } from 'react-redux';
+import { archiveTask, pinTask } from '../lib/redux';
 
-+ export function PureTaskList({ loading, tasks, onPinTask, onArchiveTask }) {
-+  /* previous implementation of TaskList */
-+ }
+export function PureTaskList({ loading, tasks, onPinTask, onArchiveTask }) {
+  /* previous implementation of TaskList */
+}
 
-+ PureTaskList.propTypes = {
-+  /** Checks if it's in loading state */
-+  loading: PropTypes.bool,
-+  /** The list of tasks */
-+  tasks: PropTypes.arrayOf(Task.propTypes.task).isRequired,
-+  /** Event to change the task to pinned */
-+  onPinTask: PropTypes.func.isRequired,
-+  /** Event to change the task to archived */
-+  onArchiveTask: PropTypes.func.isRequired,
-+ };
+PureTaskList.propTypes = {
+  /** Checks if it's in loading state */
+  loading: PropTypes.bool,
+  /** The list of tasks */
+  tasks: PropTypes.arrayOf(Task.propTypes.task).isRequired,
+  /** Event to change the task to pinned */
+  onPinTask: PropTypes.func.isRequired,
+  /** Event to change the task to archived */
+  onArchiveTask: PropTypes.func.isRequired,
+};
 
-+ PureTaskList.defaultProps = {
-+  loading: false,
-+ };
+PureTaskList.defaultProps = {
+  loading: false,
+};
 
-+ export default connect(
-+  ({ tasks }) => ({
-+    tasks: tasks.filter(t => t.state === 'TASK_INBOX' || t.state === 'TASK_PINNED'),
-+  }),
-+  dispatch => ({
-+    onArchiveTask: id => dispatch(archiveTask(id)),
-+    onPinTask: id => dispatch(pinTask(id)),
-+  })
-+ )(PureTaskList);
+export default connect(
+  ({ tasks }) => ({
+    tasks: tasks.filter(t => t.state === 'TASK_INBOX' || t.state === 'TASK_PINNED'),
+  }),
+  dispatch => ({
+    onArchiveTask: id => dispatch(archiveTask(id)),
+    onPinTask: id => dispatch(pinTask(id)),
+  })
+)(PureTaskList);
 ```
 
 Now that we have some real data populating our component, obtained from Redux, we could have wired it to `src/app.js` and render the component there. But for now let's hold off doing that and continue on our component-driven journey.

--- a/content/intro-to-storybook/react/en/data.md
+++ b/content/intro-to-storybook/react/en/data.md
@@ -23,9 +23,7 @@ yarn add react-redux redux
 
 First we’ll construct a simple Redux store that responds to actions that change the state of tasks, in a file called `lib/redux.js` in the `src` folder (intentionally kept simple):
 
-```javascript
-// src/lib/redux.js
-
+```js:title=src/lib/redux.js
 // A simple redux store/actions/reducer implementation.
 // A true app would be more complex and separated into different files.
 import { createStore } from 'redux';
@@ -79,44 +77,43 @@ export default createStore(reducer, { tasks: defaultTasks });
 
 Then we’ll update the default export from the `TaskList` component to connect to the Redux store and render the tasks we are interested in:
 
-```javascript
-// src/components/TaskList.js
-
+```diff:title=src/components/TaskList.js
 import React from 'react';
 import PropTypes from 'prop-types';
 
 import Task from './Task';
-import { connect } from 'react-redux';
-import { archiveTask, pinTask } from '../lib/redux';
 
-export function PureTaskList({ loading, tasks, onPinTask, onArchiveTask }) {
-  /* previous implementation of TaskList */
-}
++ import { connect } from 'react-redux';
++ import { archiveTask, pinTask } from '../lib/redux';
 
-PureTaskList.propTypes = {
-  /** Checks if it's in loading state */
-  loading: PropTypes.bool,
-  /** The list of tasks */
-  tasks: PropTypes.arrayOf(Task.propTypes.task).isRequired,
-  /** Event to change the task to pinned */
-  onPinTask: PropTypes.func.isRequired,
-  /** Event to change the task to archived */
-  onArchiveTask: PropTypes.func.isRequired,
-};
++ export function PureTaskList({ loading, tasks, onPinTask, onArchiveTask }) {
++  /* previous implementation of TaskList */
++ }
 
-PureTaskList.defaultProps = {
-  loading: false,
-};
++ PureTaskList.propTypes = {
++  /** Checks if it's in loading state */
++  loading: PropTypes.bool,
++  /** The list of tasks */
++  tasks: PropTypes.arrayOf(Task.propTypes.task).isRequired,
++  /** Event to change the task to pinned */
++  onPinTask: PropTypes.func.isRequired,
++  /** Event to change the task to archived */
++  onArchiveTask: PropTypes.func.isRequired,
++ };
 
-export default connect(
-  ({ tasks }) => ({
-    tasks: tasks.filter(t => t.state === 'TASK_INBOX' || t.state === 'TASK_PINNED'),
-  }),
-  dispatch => ({
-    onArchiveTask: id => dispatch(archiveTask(id)),
-    onPinTask: id => dispatch(pinTask(id)),
-  })
-)(PureTaskList);
++ PureTaskList.defaultProps = {
++  loading: false,
++ };
+
++ export default connect(
++  ({ tasks }) => ({
++    tasks: tasks.filter(t => t.state === 'TASK_INBOX' || t.state === 'TASK_PINNED'),
++  }),
++  dispatch => ({
++    onArchiveTask: id => dispatch(archiveTask(id)),
++    onPinTask: id => dispatch(pinTask(id)),
++  })
++ )(PureTaskList);
 ```
 
 Now that we have some real data populating our component, obtained from Redux, we could have wired it to `src/app.js` and render the component there. But for now let's hold off doing that and continue on our component-driven journey.
@@ -127,21 +124,19 @@ At this stage, our Storybook tests will have stopped working because `TaskList` 
 
 However, we can easily solve this problem by simply rendering the `PureTaskList` --the presentational component, to which we've just added the `export` statement in the previous step-- in our Storybook stories:
 
-```javascript
-// src/components/TaskList.stories.js
-
+```diff:title=src/components/TaskList.stories.js
 import React from 'react';
 
-import { PureTaskList } from './TaskList';
++ import { PureTaskList } from './TaskList';
 import * as TaskStories from './Task.stories';
 
 export default {
-  component: PureTaskList,
++ component: PureTaskList,
   title: 'TaskList',
   decorators: [story => <div style={{ padding: '3rem' }}>{story()}</div>],
 };
 
-const Template = args => <PureTaskList {...args} />;
++ const Template = args => <PureTaskList {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/content/intro-to-storybook/react/en/deploy.md
+++ b/content/intro-to-storybook/react/en/deploy.md
@@ -80,9 +80,7 @@ In the root folder of our project, create a new directory called `.github` then 
 
 Create a new file called `chromatic.yml` like the one below. Replace to change `project-token` with your project token.
 
-```yaml
-# .github/workflows/chromatic.yml
-
+```yaml:title=.github/workflows/chromatic.yml
 # Workflow name
 name: 'Chromatic Deployment'
 

--- a/content/intro-to-storybook/react/en/get-started.md
+++ b/content/intro-to-storybook/react/en/get-started.md
@@ -5,7 +5,7 @@ description: 'Setup Storybook in your development environment'
 commit: 'ac1ec13'
 ---
 
-Storybook runs alongside your app in development mode. It helps you build UI components isolated from the business logic and context of your app. This edition of Learn Storybook is for React; other editions exist for [React Native](/intro-to-storybook/react-native/en/get-started), [Vue](/intro-to-storybook/vue/en/get-started), [Angular](/intro-to-storybook/angular/en/get-started), [Svelte](/intro-to-storybook/svelte/en/get-started) and [Ember](/intro-to-storybook/ember/en/get-started).
+Storybook runs alongside your app in development mode. It helps you build UI components isolated from the business logic and context of your app. This edition of the Intro to Storybook tutorial is for React; other editions exist for [React Native](/intro-to-storybook/react-native/en/get-started), [Vue](/intro-to-storybook/vue/en/get-started), [Angular](/intro-to-storybook/angular/en/get-started), [Svelte](/intro-to-storybook/svelte/en/get-started) and [Ember](/intro-to-storybook/ember/en/get-started).
 
 ![Storybook and your app](/intro-to-storybook/storybook-relationship.jpg)
 

--- a/content/intro-to-storybook/react/en/screen.md
+++ b/content/intro-to-storybook/react/en/screen.md
@@ -33,7 +33,6 @@ export function PureInboxScreen({ error }) {
       </div>
     );
   }
-
   return (
     <div className="page lists-show">
       <nav>
@@ -60,21 +59,19 @@ export default connect(({ error }) => ({ error }))(PureInboxScreen);
 
 We also change the `App` component to render the `InboxScreen` (eventually we would use a router to choose the correct screen, but let's not worry about that here):
 
-```diff:title=src/App.js
-- import logo from './logo.svg';
-- import './App.css';
-+ import { Provider } from 'react-redux';
-+ import store from './lib/redux';
+```js:title=src/App.js
+import { Provider } from 'react-redux';
+import store from './lib/redux';
 
-+ import InboxScreen from './components/InboxScreen';
+import InboxScreen from './components/InboxScreen';
 
-+ import './index.css';
+import './index.css';
 
 function App() {
   return (
-+   <Provider store={store}>
-+     <InboxScreen />
-+   </Provider>
+    <Provider store={store}>
+      <InboxScreen />
+    </Provider>
   );
 }
 export default App;

--- a/content/intro-to-storybook/react/en/screen.md
+++ b/content/intro-to-storybook/react/en/screen.md
@@ -13,11 +13,10 @@ In this chapter we continue to increase the sophistication by combining componen
 
 As our app is very simple, the screen we’ll build is pretty trivial, simply wrapping the `TaskList` component (which supplies its own data via Redux) in some layout and pulling a top-level `error` field out of redux (let's assume we'll set that field if we have some problem connecting to our server). Create `InboxScreen.js` in your `components` folder:
 
-```javascript
-// src/components/InboxScreen.js
-
+```js:title=src/components/InboxScreen.js
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import { connect } from 'react-redux';
 
 import TaskList from './TaskList';
@@ -61,21 +60,21 @@ export default connect(({ error }) => ({ error }))(PureInboxScreen);
 
 We also change the `App` component to render the `InboxScreen` (eventually we would use a router to choose the correct screen, but let's not worry about that here):
 
-```javascript
-// src/App.js
+```diff:title=src/App.js
+- import logo from './logo.svg';
+- import './App.css';
++ import { Provider } from 'react-redux';
++ import store from './lib/redux';
 
-import React from 'react';
-import { Provider } from 'react-redux';
-import store from './lib/redux';
++ import InboxScreen from './components/InboxScreen';
 
-import InboxScreen from './components/InboxScreen';
++ import './index.css';
 
-import './index.css';
 function App() {
   return (
-    <Provider store={store}>
-      <InboxScreen />
-    </Provider>
++   <Provider store={store}>
++     <InboxScreen />
++   </Provider>
   );
 }
 export default App;
@@ -89,9 +88,7 @@ When placing the `TaskList` into Storybook, we were able to dodge this issue by 
 
 However, for the `PureInboxScreen` we have a problem because although the `PureInboxScreen` itself is presentational, its child, the `TaskList`, is not. In a sense the `PureInboxScreen` has been polluted by “container-ness”. So when we setup our stories in `InboxScreen.stories.js`:
 
-```javascript
-// src/components/InboxScreen.stories.js
-
+```js:title=src/components/InboxScreen.stories.js
 import React from 'react';
 
 import { PureInboxScreen } from './InboxScreen';
@@ -127,29 +124,30 @@ However, developers **will** inevitably need to render containers further down t
 
 The good news is that it is easy to supply a Redux store to the `InboxScreen` in a story! We can just use a mocked version of the Redux store provided in a decorator:
 
-```javascript
-// src/components/InboxScreen.stories.js
-
+```diff:title=src/components/InboxScreen.stories.js
 import React from 'react';
-import { Provider } from 'react-redux';
-import { action } from '@storybook/addon-actions';
-import { PureInboxScreen } from './InboxScreen';
-import * as TaskListStories from './TaskList.stories';
 
-// A super-simple mock of a redux store
-const store = {
-  getState: () => {
-    return {
-      tasks: TaskListStories.Default.args.tasks,
-    };
-  },
-  subscribe: () => 0,
-  dispatch: action('dispatch'),
-};
+import { PureInboxScreen } from './InboxScreen';
+
++ import { Provider } from 'react-redux';
++ import { action } from '@storybook/addon-actions';
++ import { PureInboxScreen } from './InboxScreen';
++ import * as TaskListStories from './TaskList.stories';
+
++ // A super-simple mock of a redux store
++ const store = {
++   getState: () => {
++    return {
++      tasks: TaskListStories.Default.args.tasks,
++    };
++   },
++   subscribe: () => 0,
++   dispatch: action('dispatch'),
++ };
 
 export default {
   component: PureInboxScreen,
-  decorators: [story => <Provider store={store}>{story()}</Provider>],
++ decorators: [story => <Provider store={store}>{story()}</Provider>],
   title: 'InboxScreen',
 };
 

--- a/content/intro-to-storybook/react/en/screen.md
+++ b/content/intro-to-storybook/react/en/screen.md
@@ -126,12 +126,12 @@ The good news is that it is easy to supply a Redux store to the `InboxScreen` in
 
 ```diff:title=src/components/InboxScreen.stories.js
 import React from 'react';
++ import { Provider } from 'react-redux';
 
 import { PureInboxScreen } from './InboxScreen';
 
-+ import { Provider } from 'react-redux';
 + import { action } from '@storybook/addon-actions';
-+ import { PureInboxScreen } from './InboxScreen';
+
 + import * as TaskListStories from './TaskList.stories';
 
 + // A super-simple mock of a redux store

--- a/content/intro-to-storybook/react/en/simple-component.md
+++ b/content/intro-to-storybook/react/en/simple-component.md
@@ -111,7 +111,7 @@ When creating a story we use a base `task` arg to build out the shape of the tas
 
 ## Config
 
-We'll need to make a couple of changes to Storybook's configuration files so it notices not only our recently created stories, but also allow us to use the application's CSS file (located in `src/index.css`).
+We'll need to make a couple of changes to Storybook's configuration files so it notices not only our recently created stories and allow us to use the application's CSS file (located in `src/index.css`).
 
 Start by changing your Storybook configuration file (`.storybook/main.js`) to the following:
 
@@ -156,35 +156,35 @@ Now we have Storybook setup, styles imported, and test cases built out, we can q
 
 The component is still basic at the moment. First write the code that achieves the design without going into too much detail:
 
-```diff:title=src/components/Task.js
+```js:title=src/components/Task.js
 import React from 'react';
 
 export default function Task({ task: { id, title, state }, onArchiveTask, onPinTask }) {
-+ return (
-+   <div className={`list-item ${state}`}>
-+     <label className="checkbox">
-+       <input
-+         type="checkbox"
-+         defaultChecked={state === 'TASK_ARCHIVED'}
-+         disabled={true}
-+         name="checked"
-+       />
-+       <span className="checkbox-custom" onClick={() => onArchiveTask(id)} />
-+     </label>
-+     <div className="title">
-+       <input type="text" value={title} readOnly={true} placeholder="Input title" />
-+     </div>
+  return (
+    <div className={`list-item ${state}`}>
+      <label className="checkbox">
+        <input
+          type="checkbox"
+          defaultChecked={state === 'TASK_ARCHIVED'}
+          disabled={true}
+          name="checked"
+        />
+        <span className="checkbox-custom" onClick={() => onArchiveTask(id)} />
+      </label>
+      <div className="title">
+        <input type="text" value={title} readOnly={true} placeholder="Input title" />
+      </div>
 
-+     <div className="actions" onClick={event => event.stopPropagation()}>
-+       {state !== 'TASK_ARCHIVED' && (
-+         // eslint-disable-next-line jsx-a11y/anchor-is-valid
-+         <a onClick={() => onPinTask(id)}>
-+           <span className={`icon-star`} />
-+         </a>
-+       )}
-+     </div>
-+   </div>
-+ );
+      <div className="actions" onClick={event => event.stopPropagation()}>
+        {state !== 'TASK_ARCHIVED' && (
+          // eslint-disable-next-line jsx-a11y/anchor-is-valid
+          <a onClick={() => onPinTask(id)}>
+            <span className={`icon-star`} />
+          </a>
+        )}
+      </div>
+    </div>
+  );
 }
 ```
 

--- a/content/intro-to-storybook/react/en/simple-component.md
+++ b/content/intro-to-storybook/react/en/simple-component.md
@@ -24,9 +24,7 @@ First, let’s create the task component and its accompanying story file: `src/c
 
 We’ll begin with a basic implementation of the `Task`, simply taking in the attributes we know we’ll need and the two actions you can take on a task (to move it between lists):
 
-```javascript
-// src/components/Task.js
-
+```js:title=src/components/Task.js
 import React from 'react';
 
 export default function Task({ task: { id, title, state }, onArchiveTask, onPinTask }) {
@@ -42,9 +40,7 @@ Above, we render straightforward markup for `Task` based on the existing HTML st
 
 Below we build out Task’s three test states in the story file:
 
-```javascript
-// src/components/Task.stories.js
-
+```js:title=src/components/Task.stories.js
 import React from 'react';
 
 import Task from './Task';
@@ -115,16 +111,13 @@ When creating a story we use a base `task` arg to build out the shape of the tas
 
 ## Config
 
-We'll need to make a couple of changes to the Storybook configuration so it notices not only our recently created stories, but also allows us to use the CSS file that was introduced in the [previous chapter](/intro-to-storybook/react/en/get-started).
+We'll need to make a couple of changes to Storybook's configuration files so it notices not only our recently created stories, but also allow us to use the application's CSS file (located in `src/index.css`).
 
 Start by changing your Storybook configuration file (`.storybook/main.js`) to the following:
 
-```javascript
-// .storybook/main.js
-
+```diff:title=.storybook/main.js
 module.exports = {
-  //👇 Location of our stories
-  stories: ['../src/components/**/*.stories.js'],
++ stories: ['../src/components/**/*.stories.js'],
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',
@@ -135,10 +128,8 @@ module.exports = {
 
 After completing the change above, inside the `.storybook` folder, change your `preview.js` to the following:
 
-```javascript
-// .storybook/preview.js
-
-import '../src/index.css'; //👈 The app's CSS file goes here
+```diff:title=.storybook/preview.js
++ import '../src/index.css';
 
 //👇 Configures Storybook to log the actions( onArchiveTask and onPinTask ) in the UI.
 export const parameters = {
@@ -165,37 +156,35 @@ Now we have Storybook setup, styles imported, and test cases built out, we can q
 
 The component is still basic at the moment. First write the code that achieves the design without going into too much detail:
 
-```javascript
-// src/components/Task.js
-
+```diff:title=src/components/Task.js
 import React from 'react';
 
 export default function Task({ task: { id, title, state }, onArchiveTask, onPinTask }) {
-  return (
-    <div className={`list-item ${state}`}>
-      <label className="checkbox">
-        <input
-          type="checkbox"
-          defaultChecked={state === 'TASK_ARCHIVED'}
-          disabled={true}
-          name="checked"
-        />
-        <span className="checkbox-custom" onClick={() => onArchiveTask(id)} />
-      </label>
-      <div className="title">
-        <input type="text" value={title} readOnly={true} placeholder="Input title" />
-      </div>
++ return (
++   <div className={`list-item ${state}`}>
++     <label className="checkbox">
++       <input
++         type="checkbox"
++         defaultChecked={state === 'TASK_ARCHIVED'}
++         disabled={true}
++         name="checked"
++       />
++       <span className="checkbox-custom" onClick={() => onArchiveTask(id)} />
++     </label>
++     <div className="title">
++       <input type="text" value={title} readOnly={true} placeholder="Input title" />
++     </div>
 
-      <div className="actions" onClick={event => event.stopPropagation()}>
-        {state !== 'TASK_ARCHIVED' && (
-          // eslint-disable-next-line jsx-a11y/anchor-is-valid
-          <a onClick={() => onPinTask(id)}>
-            <span className={`icon-star`} />
-          </a>
-        )}
-      </div>
-    </div>
-  );
++     <div className="actions" onClick={event => event.stopPropagation()}>
++       {state !== 'TASK_ARCHIVED' && (
++         // eslint-disable-next-line jsx-a11y/anchor-is-valid
++         <a onClick={() => onPinTask(id)}>
++           <span className={`icon-star`} />
++         </a>
++       )}
++     </div>
++   </div>
++ );
 }
 ```
 
@@ -212,9 +201,7 @@ The additional markup from above combined with the CSS we imported earlier yield
 
 It’s best practice to use `propTypes` in React to specify the shape of data that a component expects. Not only is it self documenting, it also helps catch problems early.
 
-```javascript
-// src/components/Task.js
-
+```diff:title=src/components/Task.js
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -222,21 +209,21 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
   // ...
 }
 
-Task.propTypes = {
-  /** Composition of the task */
-  task: PropTypes.shape({
-    /** Id of the task */
-    id: PropTypes.string.isRequired,
-    /** Title of the task */
-    title: PropTypes.string.isRequired,
-    /** Current state of the task */
-    state: PropTypes.string.isRequired,
-  }),
-  /** Event to change the task to archived */
-  onArchiveTask: PropTypes.func,
-  /** Event to change the task to pinned */
-  onPinTask: PropTypes.func,
-};
++ Task.propTypes = {
++  /** Composition of the task */
++  task: PropTypes.shape({
++    /** Id of the task */
++    id: PropTypes.string.isRequired,
++    /** Title of the task */
++    title: PropTypes.string.isRequired,
++    /** Current state of the task */
++    state: PropTypes.string.isRequired,
++  }),
++  /** Event to change the task to archived */
++  onArchiveTask: PropTypes.func,
++  /** Event to change the task to pinned */
++  onPinTask: PropTypes.func,
++ };
 ```
 
 Now a warning in development will appear if the Task component is misused.
@@ -271,9 +258,7 @@ yarn add -D @storybook/addon-storyshots react-test-renderer
 
 Then create an `src/storybook.test.js` file with the following in it:
 
-```javascript
-// src/storybook.test.js
-
+```js:title=src/storybook.test.js
 import initStoryshots from '@storybook/addon-storyshots';
 initStoryshots();
 ```

--- a/content/intro-to-storybook/react/en/test.md
+++ b/content/intro-to-storybook/react/en/test.md
@@ -43,16 +43,14 @@ git checkout -b change-task-background
 
 Change `src/components/Task.js` to the following:
 
-```js
-// src/components/Task.js
-
+```diff:title=src/components/Task.js
 <div className="title">
   <input
     type="text"
     value={title}
     readOnly={true}
     placeholder="Input title"
-    style={{ background: 'red' }}
++   style={{ background: 'red' }}
   />
 </div>
 ```

--- a/content/intro-to-storybook/react/en/using-addons.md
+++ b/content/intro-to-storybook/react/en/using-addons.md
@@ -40,15 +40,13 @@ Controls allowed us to quickly verify different inputs to a component. In this c
 
 Now let's fix the issue with overflowing by adding a style to `Task.js`:
 
-```js
-// src/components/Task.js
-
+```diff:title=src/components/Task.js
 <input
   type="text"
   value={title}
   readOnly={true}
   placeholder="Input title"
-  style={{ textOverflow: 'ellipsis' }}
++ style={{ textOverflow: 'ellipsis' }}
 />
 ```
 
@@ -62,9 +60,7 @@ In the future, We can manually reproduce this problem by entering the same strin
 
 Add a new story for the long text case in `Task.stories.js`:
 
-```js
-// src/components/Task.stories.js
-
+```js:title=src/components/Task.stories.js
 const longTitleString = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not!`;
 
 export const LongTitle = Template.bind({});

--- a/content/intro-to-storybook/react/ja/composite-component.md
+++ b/content/intro-to-storybook/react/ja/composite-component.md
@@ -117,9 +117,6 @@ Empty.args = {
 
 `TaskStories` をインポートすることで、ストーリーに必要な引数 (args) を最小限の労力で[組み合わせる](https://storybook.js.org/docs/react/writing-stories/args#args-composition)ことができます。そうすることで、2 つのコンポーネントが想定するデータとアクション (呼び出しのモック) の一貫性が保たれます。
 
-<!--
-`taskData` は `Task.stories.js` ファイルでエクスポートした `Task` のデータ構造です。同様に `actionsData` は `Task` コンポーネントが想定するアクション (呼び出しのモック) を定義しています。`TaskList` でも同様に必要となります。 -->
-
 それでは `TaskList` の新しいストーリーを Storybook で確認してみましょう。
 
 <video autoPlay muted playsInline loop>

--- a/content/intro-to-storybook/react/ko/composite-component.md
+++ b/content/intro-to-storybook/react/ko/composite-component.md
@@ -119,9 +119,6 @@ Empty.args = {
 
 이를 통해 두 컴포넌트가 받을 수 있는 데이터와 액션(mocked callbacks)이 모두 보존됩니다.
 
-<!--
-`taskData`는 `Task.stories.js` 파일에서 만들고 내보낸 `Task`의 형태를 제공합니다. 마찬가지로 `actionsData`는 `Task` 컴포넌트가 예상하는 액션(mocked callbacks)을 정의하며 이는 `TaskList`에도 필요합니다. -->
-
 이제 Storybook에서 새로운 `TaskList` 스토리를 확인해보겠습니다.
 
 <video autoPlay muted playsInline loop>

--- a/content/intro-to-storybook/react/ko/deploy.md
+++ b/content/intro-to-storybook/react/ko/deploy.md
@@ -151,8 +151,4 @@ GitHub action을 설정하면 코드를 푸시할 때마다 Storybook이 Chromat
 
 ![Chromatic의 Storybook 링크](/intro-to-storybook/chromatic-build-storybook-link.png)
 
-<!--
-이제, 변경 사항을 커밋하고 푸시하는 것만으로도 Storybook 배포를 성공적으로 자동화할 수 있습니다
- -->
-
 링크를 사용하여 팀원들과 공유하세요. 이는 표준화된 앱 개발 과정일 뿐만 아니라 여러분의 작업을 팀원들에게 자랑할 수 있게끔 도와줄 것입니다 💅.

--- a/content/intro-to-storybook/svelte/en/composite-component.md
+++ b/content/intro-to-storybook/svelte/en/composite-component.md
@@ -22,9 +22,7 @@ A composite component isn’t much different than the basic components it contai
 
 Start with a rough implementation of the `TaskList`. You’ll need to import the `Task` component from earlier and pass in the attributes and actions as inputs.
 
-```svelte
-<!-- src/components/TaskList.svelte -->
-
+```svelte:title=src/components/TaskList.svelte
 <script>
   import Task from './Task.svelte';
   export let loading = false;
@@ -47,10 +45,9 @@ Start with a rough implementation of the `TaskList`. You’ll need to import the
 
 Next create `Tasklist`’s test states in the story file.
 
-```javascript
-// src/components/TaskList.stories.js
-
+```js:title= src/components/TaskList.stories.js
 import TaskList from './TaskList.svelte';
+
 import * as TaskStories from './Task.stories';
 
 export default {
@@ -127,9 +124,7 @@ For the loading edge case, we're going to create a new component that will displ
 
 Create a new file called `LoadingRow.svelte` and inside add the following markup:
 
-```svelte
-<!-- src/components/LoadingRow.svelte -->
-
+```svelte:title=src/components/LoadingRow.svelte
 <div class="loading-item">
   <span class="glow-checkbox" />
   <span class="glow-text">
@@ -142,44 +137,42 @@ Create a new file called `LoadingRow.svelte` and inside add the following markup
 
 And update `TaskList.svelte` to the following:
 
-```svelte
-<!-- src/components/TaskList.svelte -->
-
+```diff:title=src/components/TaskList.svelte
 <script>
-  import Task from './Task.svelte';
-  import LoadingRow from './LoadingRow.svelte';
+ import Task from './Task.svelte';
++ import LoadingRow from './LoadingRow.svelte';
   export let loading = false;
   export let tasks = [];
 
-  // reactive declaration (computed prop in other frameworks)
+  //👇 Reactive declarations (computed props in other frameworks)
   $: noTasks = tasks.length === 0;
   $: emptyTasks = noTasks && !loading;
-  $: tasksInOrder = [
-    ...tasks.filter(t => t.state === 'TASK_PINNED'),
-    ...tasks.filter(t => t.state !== 'TASK_PINNED'),
-  ];
++ $: tasksInOrder = [
++   ...tasks.filter(t => t.state === 'TASK_PINNED'),
++   ...tasks.filter(t => t.state !== 'TASK_PINNED'),
++ ];
 </script>
-{#if loading}
-<div class="list-items">
-  <LoadingRow />
-  <LoadingRow />
-  <LoadingRow />
-  <LoadingRow />
-  <LoadingRow />
-</div>
-{/if}
-{#if emptyTasks}
-<div class="list-items">
-  <div class="wrapper-message">
-    <span class="icon-check" />
-    <div class="title-message">You have no tasks</div>
-    <div class="subtitle-message">Sit back and relax</div>
-  </div>
-</div>
-{/if}
-{#each tasksInOrder as task}
-  <Task {task} on:onPinTask on:onArchiveTask />
-{/each}
++ {#if loading}
++   <div class="list-items">
++     <LoadingRow />
++     <LoadingRow />
++     <LoadingRow />
++     <LoadingRow />
++     <LoadingRow />
++   </div>
++ {/if}
++ {#if emptyTasks}
++   <div class="list-items">
++     <div class="wrapper-message">
++       <span class="icon-check" />
++       <div class="title-message">You have no tasks</div>
++       <div class="subtitle-message">Sit back and relax</div>
++     </div>
++   </div>
++ {/if}
++ {#each tasksInOrder as task}
++   <Task {task} on:onPinTask on:onArchiveTask />
++ {/each}
 ```
 
 The added markup results in the following UI:
@@ -211,11 +204,11 @@ So, to avoid this problem, we can use Jest to render the story to the DOM and ru
 
 Create a test file called `src/components/TaskList.test.js`. Here, we’ll build out our tests that make assertions about the output.
 
-```javascript
-// src/components/TaskList.test.js
-
+```js:title=src/components/TaskList.test.js
 import TaskList from './TaskList.svelte';
+
 import { render } from '@testing-library/svelte';
+
 import { WithPinnedTasks } from './TaskList.stories'; //👈  Our story imported here
 
 test('TaskList', () => {

--- a/content/intro-to-storybook/svelte/en/composite-component.md
+++ b/content/intro-to-storybook/svelte/en/composite-component.md
@@ -139,7 +139,7 @@ And update `TaskList.svelte` to the following:
 
 ```diff:title=src/components/TaskList.svelte
 <script>
- import Task from './Task.svelte';
+  import Task from './Task.svelte';
 + import LoadingRow from './LoadingRow.svelte';
   export let loading = false;
   export let tasks = [];

--- a/content/intro-to-storybook/svelte/en/contribute.md
+++ b/content/intro-to-storybook/svelte/en/contribute.md
@@ -3,9 +3,9 @@ title: 'Contribute'
 description: 'Help share Storybook with the world'
 ---
 
-Contributions to Learn Storybook are encouraged! If it’s something small like grammar or punctuation, open up a pull request. If it’s a bigger change, [add an issue](https://github.com/chromaui/learnstorybook.com/issues) for discussion.
+Contributions to Storybook's tutorials are encouraged! If it’s something small like grammar or punctuation, open up a pull request. If it’s a bigger change, [add an issue](https://github.com/chromaui/learnstorybook.com/issues) for discussion.
 
-Learn Storybook has been primarily created and maintained by the community so we need everyone's help to keep it up to date and ensure any rough edges are smoothed out over time. All help is appreciated!
+Storybook's tutorials were created and maintained primarily by the community, so we need everyone's help to keep it up to date and ensure any rough edges are smoothed out over time. All help is appreciated!
 
 ## Translations
 

--- a/content/intro-to-storybook/svelte/en/data.md
+++ b/content/intro-to-storybook/svelte/en/data.md
@@ -16,16 +16,14 @@ This example uses [Svelte's Stores](https://svelte.dev/docs#svelte_store), Svelt
 
 First we’ll construct a simple Svelte store that responds to actions that change the state of tasks, in a file called `src/store.js` (intentionally kept simple):
 
-```javascript
-// src/store.js
-
+```js:title=src/store.js
 // A simple Svelte store implementation with update methods and initial data.
 // A true app would be more complex and separated into different files.
 
 import { writable } from 'svelte/store';
 
 const TaskBox = () => {
-  // creates a new writable store populated with some initial data
+  // Creates a new writable store populated with some initial data
   const { subscribe, update } = writable([
     { id: '1', title: 'Something', state: 'TASK_INBOX' },
     { id: '2', title: 'Something more', state: 'TASK_INBOX' },
@@ -35,12 +33,12 @@ const TaskBox = () => {
 
   return {
     subscribe,
-    // method to archive a task, think of a action with redux or Vuex
+    // Method to archive a task, think of a action with redux or Vuex
     archiveTask: id =>
       update(tasks =>
         tasks.map(task => (task.id === id ? { ...task, state: 'TASK_ARCHIVED' } : task))
       ),
-    // method to archive a task, think of a action with redux or Vuex
+    // Method to archive a task, think of a action with redux or Vuex
     pinTask: id =>
       update(tasks =>
         tasks.map(task => (task.id === id ? { ...task, state: 'TASK_PINNED' } : task))
@@ -55,9 +53,7 @@ Then we'll update our `TaskList` to read data out of the store. First let's move
 
 In `src/components/PureTaskList.svelte`:
 
-```svelte
-<!-- src/components/PureTaskList.svelte -->
-
+```svelte:title=src/components/PureTaskList.svelte
 <!--This file moved from TaskList.svelte-->
 <script>
   import Task from './Task.svelte';
@@ -91,40 +87,37 @@ In `src/components/PureTaskList.svelte`:
 </div>
 {/if}
 {#each tasksInOrder as task}
-<Task {task} on:onPinTask on:onArchiveTask />
+  <Task {task} on:onPinTask on:onArchiveTask />
 {/each}
 ```
 
 In `src/components/TaskList.svelte`:
 
-```svelte
-<!-- src/components/TaskList.svelte -->
+```diff:title=src/components/TaskList.svelte
 
 <script>
-  import PureTaskList from './PureTaskList.svelte';
-  import { taskStore } from '../store';
-  function onPinTask(event) {
-    taskStore.pinTask(event.detail.id);
-  }
-  function onArchiveTask(event) {
-    taskStore.archiveTask(event.detail.id);
-  }
++ import PureTaskList from './PureTaskList.svelte';
++ import { taskStore } from '../store';
++ function onPinTask(event) {
++   taskStore.pinTask(event.detail.id);
++ }
++ function onArchiveTask(event) {
++   taskStore.archiveTask(event.detail.id);
++ }
 </script>
 
 <div>
-  <PureTaskList
-    tasks={$taskStore}
-    on:onPinTask={onPinTask}
-    on:onArchiveTask={onArchiveTask}
-  />
++ <PureTaskList
++   tasks={$taskStore}
++   on:onPinTask={onPinTask}
++   on:onArchiveTask={onArchiveTask}
++ />
 </div>
 ```
 
 The reason to keep the presentational version of the `TaskList` separate is because it is easier to test and isolate. As it doesn't rely on the presence of a store it is much easier to deal with from a testing perspective. Let's rename `src/components/TaskList.stories.js` into `src/components/PureTaskList.stories.js`, and ensure our stories use the presentational version:
 
-```javascript
-// src/components/PureTaskList.stories.js
-
+```js:title=src/components/PureTaskList.stories.js
 import PureTaskList from './PureTaskList.svelte';
 import * as TaskStories from './Task.stories';
 

--- a/content/intro-to-storybook/svelte/en/data.md
+++ b/content/intro-to-storybook/svelte/en/data.md
@@ -93,25 +93,25 @@ In `src/components/PureTaskList.svelte`:
 
 In `src/components/TaskList.svelte`:
 
-```diff:title=src/components/TaskList.svelte
+```svelte:title=src/components/TaskList.svelte
 
 <script>
-+ import PureTaskList from './PureTaskList.svelte';
-+ import { taskStore } from '../store';
-+ function onPinTask(event) {
-+   taskStore.pinTask(event.detail.id);
-+ }
-+ function onArchiveTask(event) {
-+   taskStore.archiveTask(event.detail.id);
-+ }
+  import PureTaskList from './PureTaskList.svelte';
+  import { taskStore } from '../store';
+  function onPinTask(event) {
+    taskStore.pinTask(event.detail.id);
+  }
+  function onArchiveTask(event) {
+    taskStore.archiveTask(event.detail.id);
+  }
 </script>
 
 <div>
-+ <PureTaskList
-+   tasks={$taskStore}
-+   on:onPinTask={onPinTask}
-+   on:onArchiveTask={onArchiveTask}
-+ />
+  <PureTaskList
+    tasks={$taskStore}
+    on:onPinTask={onPinTask}
+    on:onArchiveTask={onArchiveTask}
+  />
 </div>
 ```
 

--- a/content/intro-to-storybook/svelte/en/deploy.md
+++ b/content/intro-to-storybook/svelte/en/deploy.md
@@ -79,9 +79,7 @@ In the root folder of our project, create a new directory called `.github` then 
 
 Create a new file called `chromatic.yml` like the one below. Replace to change `project-token` with your project token.
 
-```yaml
-# .github/workflows/chromatic.yml
-
+```yaml:title=.github/workflows/chromatic.yml
 # Workflow name
 name: 'Chromatic Deployment'
 

--- a/content/intro-to-storybook/svelte/en/get-started.md
+++ b/content/intro-to-storybook/svelte/en/get-started.md
@@ -4,7 +4,7 @@ tocTitle: 'Get started'
 description: 'Setup Storybook in your development environment'
 ---
 
-Storybook runs alongside your app in development mode. It helps you build UI components isolated from the business logic and context of your app. This edition of Learn Storybook is for Svelte; other editions exist for [Vue](/intro-to-storybook/vue/en/get-started), [Angular](/intro-to-storybook/angular/en/get-started), [React](/intro-to-storybook/react/en/get-started), [React Native](/intro-to-storybook/react-native/en/get-started) and [Ember](/intro-to-storybook/ember/en/get-started).
+Storybook runs alongside your app in development mode. It helps you build UI components isolated from the business logic and context of your app. This edition of the Intro to Storybook tutorial is for Svelte; other editions exist for [Vue](/intro-to-storybook/vue/en/get-started), [Angular](/intro-to-storybook/angular/en/get-started), [React](/intro-to-storybook/react/en/get-started), [React Native](/intro-to-storybook/react-native/en/get-started) and [Ember](/intro-to-storybook/ember/en/get-started).
 
 ![Storybook and your app](/intro-to-storybook/storybook-relationship.jpg)
 

--- a/content/intro-to-storybook/svelte/en/screen.md
+++ b/content/intro-to-storybook/svelte/en/screen.md
@@ -12,9 +12,7 @@ In this chapter we continue to increase the sophistication by combining componen
 
 As our app is very simple, the screen we’ll build is pretty trivial, simply wrapping the `TaskList` component (which supplies its own data via Svelte Store) in some layout and pulling a top-level `error` field out of the store (let's assume we'll set that field if we have some problem connecting to our server). Create `InboxScreen.svelte` in your `components` folder:
 
-```svelte
-<!-- src/components/InboxScreen.svelte -->
-
+```svelte:title=src/components/InboxScreen.svelte
 <script>
   import TaskList from './TaskList.svelte';
   export let error = false;
@@ -22,34 +20,33 @@ As our app is very simple, the screen we’ll build is pretty trivial, simply wr
 
 <div>
   {#if error}
-  <div class="page lists-show">
-    <div class="wrapper-message">
-      <span class="icon-face-sad" />
-      <div class="title-message">Oh no!</div>
-      <div class="subtitle-message">Something went wrong</div>
+    <div class="page lists-show">
+      <div class="wrapper-message">
+        <span class="icon-face-sad" />
+        <div class="title-message">Oh no!</div>
+        <div class="subtitle-message">Something went wrong</div>
+      </div>
     </div>
-  </div>
   {:else}
-  <div class="page lists-show">
-    <nav>
-      <h1 class="title-page">
-        <span class="title-wrapper">Taskbox</span>
-      </h1>
-    </nav>
-    <TaskList />
-  </div>
+    <div class="page lists-show">
+      <nav>
+        <h1 class="title-page">
+          <span class="title-wrapper">Taskbox</span>
+        </h1>
+      </nav>
+      <TaskList />
+    </div>
   {/if}
 </div>
 ```
 
 We need to update our store (in `src/store.js`) to include our new `error` field, transforming it into :
 
-```javascript
-// src/store.js
-
+```diff:title=src/store.js
 import { writable } from 'svelte/store';
+
 const TaskBox = () => {
-  // creates a new writable store populated with some initial data
+  // Creates a new writable store populated with some initial data
   const { subscribe, update } = writable([
     { id: '1', title: 'Something', state: 'TASK_INBOX' },
     { id: '2', title: 'Something more', state: 'TASK_INBOX' },
@@ -59,44 +56,42 @@ const TaskBox = () => {
 
   return {
     subscribe,
-    // method to archive a task, think of a action with redux or Vuex
+    // Method to archive a task, think of a action with redux or Vuex
     archiveTask: id =>
       update(tasks =>
         tasks.map(task => (task.id === id ? { ...task, state: 'TASK_ARCHIVED' } : task))
       ),
-    // method to archive a task, think of a action with redux or Vuex
+    // Method to archive a task, think of a action with redux or Vuex
     pinTask: id =>
       update(tasks =>
         tasks.map(task => (task.id === id ? { ...task, state: 'TASK_PINNED' } : task))
       ),
   };
 };
-export const taskStore = TaskBox();
++ export const taskStore = TaskBox();
 
-// store to handle the app state
-const AppState = () => {
-  const { subscribe, update } = writable(false);
-  return {
-    subscribe,
-    error: () => update(error => !error),
-  };
-};
++ // Store to handle the app state
++ const AppState = () => {
++  const { subscribe, update } = writable(false);
++  return {
++    subscribe,
++    error: () => update(error => !error),
++  };
++ };
 
-export const AppStore = AppState();
++ export const AppStore = AppState();
 ```
 
 We also change the `App` component to render the `InboxScreen` (eventually we would use a router to choose the correct screen, but let's not worry about that here):
 
-```svelte
-<!-- src/App.svelte -->
-
+```diff:title=src/App.svelte
 <script>
   import './index.css'
-  import { AppStore } from './store';
-  import InboxScreen from './components/InboxScreen.svelte';
++ import { AppStore } from './store';
++ import InboxScreen from './components/InboxScreen.svelte';
 </script>
 
-<InboxScreen error="{$AppStore}" />
++ <InboxScreen error="{$AppStore}" />
 ```
 
 <div class="aside">
@@ -111,9 +106,7 @@ When placing the `TaskList` into Storybook, we were able to illustrate this issu
 
 So when we setup our stories in `InboxScreen.stories.js`:
 
-```javascript
-// src/components/InboxScreen.stories.js
-
+```js:title=src/components/InboxScreen.stories.js
 import InboxScreen from './InboxScreen.svelte';
 
 export default {

--- a/content/intro-to-storybook/svelte/en/screen.md
+++ b/content/intro-to-storybook/svelte/en/screen.md
@@ -84,14 +84,14 @@ const TaskBox = () => {
 
 We also change the `App` component to render the `InboxScreen` (eventually we would use a router to choose the correct screen, but let's not worry about that here):
 
-```diff:title=src/App.svelte
+```svelte:title=src/App.svelte
 <script>
   import './index.css'
-+ import { AppStore } from './store';
-+ import InboxScreen from './components/InboxScreen.svelte';
+  import { AppStore } from './store';
+  import InboxScreen from './components/InboxScreen.svelte';
 </script>
 
-+ <InboxScreen error="{$AppStore}" />
+<InboxScreen error="{$AppStore}" />
 ```
 
 <div class="aside">

--- a/content/intro-to-storybook/svelte/en/simple-component.md
+++ b/content/intro-to-storybook/svelte/en/simple-component.md
@@ -156,7 +156,7 @@ Another nice thing about bundling the `actionsData` that a component needs is th
 
 ## Config
 
-We'll need to make a couple of changes to Storybook's configuration files so it notices not only our recently created stories, but also allow us to use the application's CSS file (located in `src/index.css`).
+We'll need to make a couple of changes to Storybook's configuration files so it notices not only our recently created stories and allow us to use the application's CSS file (located in `src/index.css`).
 
 Start by changing your Storybook configuration file (`.storybook/main.js`) to the following:
 

--- a/content/intro-to-storybook/svelte/en/simple-component.md
+++ b/content/intro-to-storybook/svelte/en/simple-component.md
@@ -244,7 +244,7 @@ The component is still basic at the moment. First write the code that achieves t
 +     </a>
 +     {/if}
 +   </div>
-+ </div>
++  </div>
 ```
 
 The additional markup from above combined with the CSS we imported earlier yields the following UI:

--- a/content/intro-to-storybook/svelte/en/simple-component.md
+++ b/content/intro-to-storybook/svelte/en/simple-component.md
@@ -25,9 +25,7 @@ First, let’s create the task component and its accompanying story file: `src/c
 
 We’ll begin with the baseline implementation of the `Task`, simply taking in the attributes we know we’ll need and the two actions you can take on a task (to move it between lists):
 
-```svelte
-<!-- src/components/Task.svelte -->
-
+```svelte:title=src/components/Task.svelte
 <script>
   import { createEventDispatcher } from 'svelte';
 
@@ -65,10 +63,9 @@ Above, we render straightforward markup for `Task` based on the existing HTML st
 
 Below we build out Task’s three test states in the story file:
 
-```javascript
-// src/components/Task.stories.js
-
+```js:title=src/components/Task.stories.js
 import Task from './Task.svelte';
+
 import { action } from '@storybook/addon-actions';
 
 export const actionsData = {
@@ -80,7 +77,7 @@ export default {
   component: Task,
   title: 'Task',
   excludeStories: /.*Data$/,
-  // the argTypes are included so that they are properly displayed in the Actions Panel
+  //👇 The argTypes are included so that they are properly displayed in the Actions Panel
   argTypes: {
     onPinTask: { action: 'onPinTask' },
     onArchiveTask: { action: 'onArchiveTask' },
@@ -159,26 +156,23 @@ Another nice thing about bundling the `actionsData` that a component needs is th
 
 ## Config
 
-We'll need to make a couple of changes to the Storybook configuration so it notices not only our recently created stories, but also allows us to use the CSS file that was introduced in the [previous section](/intro-to-storybook/svelte/en/get-started).
+We'll need to make a couple of changes to Storybook's configuration files so it notices not only our recently created stories, but also allow us to use the application's CSS file (located in `src/index.css`).
 
 Start by changing your Storybook configuration file (`.storybook/main.js`) to the following:
 
-```javascript
+```diff:title=.storybook/main.js
 // .storybook/main.js
 
 module.exports = {
-  //👇 Location of our stories
-  stories: ['../src/components/**/*.stories.js'],
++ stories: ['../src/components/**/*.stories.js'],
   addons: ['@storybook/addon-actions', '@storybook/addon-links'],
 };
 ```
 
 After completing the change above, inside the `.storybook` folder, change your `preview.js` to the following:
 
-```javascript
-// .storybook/preview.js
-
-import '../src/index.css'; //👈 The app's CSS file goes here
+```diff:title=..storybook/preview.js
++ import '../src/index.css';
 
 //👇 Configures Storybook to log the actions( onArchiveTask and onPinTask ) in the UI.
 export const parameters = {
@@ -205,9 +199,7 @@ Now we have Storybook setup, styles imported, and test cases built out, we can q
 
 The component is still basic at the moment. First write the code that achieves the design without going into too much detail:
 
-```svelte
-<!-- src/components/Task.svelte -->
-
+```diff:title=src/components/Task.svelte
 <script>
   import { createEventDispatcher } from 'svelte';
 
@@ -237,22 +229,22 @@ The component is still basic at the moment. First write the code that achieves t
   // reactive declaration (computed prop in other frameworks)
   $: isChecked = task.state === 'TASK_ARCHIVED';
 </script>
-<div class="list-item {task.state}">
-  <label class="checkbox">
-    <input type="checkbox" checked={isChecked} disabled name="checked" />
-    <span class="checkbox-custom" on:click={ArchiveTask} />
-  </label>
-  <div class="title">
-    <input type="text" readonly value={task.title} placeholder="Input title" />
-  </div>
-  <div class="actions">
-    {#if task.state !== 'TASK_ARCHIVED'}
-    <a href="/" on:click|preventDefault={PinTask}>
-      <span class="icon-star" />
-    </a>
-    {/if}
-  </div>
-</div>
++  <div class="list-item {task.state}">
++   <label class="checkbox">
++     <input type="checkbox" checked={isChecked} disabled name="checked" />
++     <span class="checkbox-custom" on:click={ArchiveTask} />
++   </label>
++   <div class="title">
++     <input type="text" readonly value={task.title} placeholder="Input title" />
++   </div>
++   <div class="actions">
++     {#if task.state !== 'TASK_ARCHIVED'}
++     <a href="/" on:click|preventDefault={PinTask}>
++       <span class="icon-star" />
++     </a>
++     {/if}
++   </div>
++ </div>
 ```
 
 The additional markup from above combined with the CSS we imported earlier yields the following UI:
@@ -290,9 +282,7 @@ yarn add -D @storybook/addon-storyshots
 
 Then create an `src/storybook.test.js` file with the following:
 
-```javascript
-// src/storybook.test.js
-
+```js:title=src/storybook.test.js
 import initStoryshots from '@storybook/addon-storyshots';
 
 initStoryshots();
@@ -300,15 +290,14 @@ initStoryshots();
 
 And finally we need to make a small adjustment to our `jest` key in `package.json`:
 
-```json
+```diff:title=package.json
 {
   "jest": {
     "transform": {
       "^.+\\.js$": "babel-jest",
-      "^.+\\.stories\\.[jt]sx?$": "<rootDir>node_modules/@storybook/addon-storyshots/injectFileName",
++     "^.+\\.stories\\.[jt]sx?$": "<rootDir>node_modules/@storybook/addon-storyshots/injectFileName",
       "^.+\\.svelte$": "jest-transform-svelte"
     },
-    "setupFilesAfterEnv": ["@testing-library/jest-dom/extend-expect"]
   }
 }
 ```

--- a/content/intro-to-storybook/svelte/en/test.md
+++ b/content/intro-to-storybook/svelte/en/test.md
@@ -43,14 +43,12 @@ git checkout -b change-task-background
 
 Change `src/components/Task.svelte` to the following:
 
-```svelte
-<!-- src/components/Task.svelte -->
-
+```diff:title=src/components/Task.svelte
 <input
   type="text"
   readonly value={task.title}
   placeholder="Input title"
-  style="background: red;"
++ style="background: red;"
 />
 ```
 

--- a/content/intro-to-storybook/svelte/en/using-addons.md
+++ b/content/intro-to-storybook/svelte/en/using-addons.md
@@ -39,15 +39,13 @@ Controls allowed us to quickly verify different inputs to a component. In this c
 
 Now let's fix the issue with overflowing by adding a style to `Task.svelte`:
 
-```svelte
-<!-- src/components/Task.svelte -->
-
+```diff:title=src/components/Task.svelte
 <input
   type="text"
   value={task.title}
   readonly
   placeholder="Input title"
-  style="text-overflow: ellipsis;"
++ style="text-overflow: ellipsis;"
 />
 ```
 
@@ -61,9 +59,7 @@ In the future, We can manually reproduce this problem by entering the same strin
 
 Add a new story for the long text case in `Task.stories.js`:
 
-```js
-// src/components/Task.stories.js
-
+```js:title=src/components/Task.stories.js
 const longTitleString = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not!`;
 
 export const LongTitle = Template.bind({});

--- a/content/intro-to-storybook/vue/en/composite-component.md
+++ b/content/intro-to-storybook/vue/en/composite-component.md
@@ -23,9 +23,7 @@ A composite component isn’t much different than the basic components it contai
 
 Start with a rough implementation of the `TaskList`. You’ll need to import the `Task` component from earlier and pass in the attributes as inputs.
 
-```html
-<!-- src/components/TaskList.vue -->
-
+```html:title=src/components/TaskList.vue
 <template>
   <div class="list-items">
     <template v-if="loading">
@@ -60,9 +58,7 @@ Start with a rough implementation of the `TaskList`. You’ll need to import the
 
 Next create `Tasklist`’s test states in the story file.
 
-```javascript
-// src/components/TaskList.stories.js
-
+```js:title=src/components/TaskList.stories.js
 import TaskList from './TaskList';
 import * as TaskStories from './Task.stories';
 
@@ -138,28 +134,26 @@ Now check Storybook for the new `TaskList` stories.
 
 Our component is still rough but now we have an idea of the stories to work toward. You might be thinking that the `.list-items` wrapper is overly simplistic. You're right – in most cases we wouldn’t create a new component just to add a wrapper. But the **real complexity** of `TaskList` component is revealed in the edge cases `WithPinnedTasks`, `loading`, and `empty`.
 
-```html
-<!-- src/components/TaskList.vue -->
-
+```diff:title=src/components/TaskList.vue
 <template>
   <div class="list-items">
     <template v-if="loading">
-      <div v-for="n in 6" :key="n" class="loading-item">
-        <span class="glow-checkbox" />
-        <span class="glow-text"> <span>Loading</span> <span>cool</span> <span>state</span> </span>
-      </div>
++     <div v-for="n in 6" :key="n" class="loading-item">
++       <span class="glow-checkbox" />
++       <span class="glow-text"> <span>Loading</span> <span>cool</span> <span>state</span> </span>
++     </div>
     </template>
 
     <div v-else-if="isEmpty" class="list-items">
-      <div class="wrapper-message">
-        <span class="icon-check" />
-        <div class="title-message">You have no tasks</div>
-        <div class="subtitle-message">Sit back and relax</div>
-      </div>
++     <div class="wrapper-message">
++       <span class="icon-check" />
++       <div class="title-message">You have no tasks</div>
++       <div class="subtitle-message">Sit back and relax</div>
++     </div>
     </div>
 
     <template v-else>
-      <Task v-for="task in tasksInOrder" :key="task.id" :task="task" v-on="$listeners" />
++     <Task v-for="task in tasksInOrder" :key="task.id" :task="task" v-on="$listeners" />
     </template>
   </div>
 </template>
@@ -174,12 +168,12 @@ Our component is still rough but now we have an idea of the stories to work towa
       loading: { type: Boolean, default: false },
     },
     computed: {
-      tasksInOrder() {
-        return [
-          ...this.tasks.filter(t => t.state === 'TASK_PINNED'),
-          ...this.tasks.filter(t => t.state !== 'TASK_PINNED'),
-        ];
-      },
++     tasksInOrder() {
++       return [
++         ...this.tasks.filter(t => t.state === 'TASK_PINNED'),
++         ...this.tasks.filter(t => t.state !== 'TASK_PINNED'),
++       ];
++     },
       isEmpty() {
         return this.tasks.length === 0;
       },
@@ -217,11 +211,11 @@ So, to avoid this problem, we can use Jest to render the story to the DOM and ru
 
 Create a test file called `tests/unit/TaskList.spec.js`. Here we’ll build out our tests that make assertions about the output.
 
-```javascript
-// tests/unit/TaskList.spec.js
-
+```js:title=tests/unit/TaskList.spec.js
 import Vue from 'vue';
+
 import TaskList from '../../src/components/TaskList.vue';
+
 //👇 Our story imported here
 import { WithPinnedTasks } from '../../src/components/TaskList.stories';
 

--- a/content/intro-to-storybook/vue/en/contribute.md
+++ b/content/intro-to-storybook/vue/en/contribute.md
@@ -3,9 +3,9 @@ title: 'Contribute'
 description: 'Help share Storybook with the world'
 ---
 
-Contributions to Learn Storybook are encouraged! If it’s something small like grammar or punctuation, open up a pull request. If it’s a bigger change, [add an issue](https://github.com/chromaui/learnstorybook.com/issues) for discussion.
+Contributions to Storybook's tutorials are encouraged! If it’s something small like grammar or punctuation, open up a pull request. If it’s a bigger change, [add an issue](https://github.com/chromaui/learnstorybook.com/issues) for discussion.
 
-Learn Storybook has been primarily created and maintained by the community so we need everyone's help to keep it up to date and ensure any rough edges are smoothed out over time. All help is appreciated!
+Storybook's tutorials were created and maintained primarily by the community, so we need everyone's help to keep it up to date and ensure any rough edges are smoothed out over time. All help is appreciated!
 
 ## Translations
 

--- a/content/intro-to-storybook/vue/en/data.md
+++ b/content/intro-to-storybook/vue/en/data.md
@@ -23,10 +23,9 @@ yarn add vuex
 
 In a file called `src/store.js` we'll construct a standard Vuex store that responds to actions which will change the tasks state:
 
-```javascript
-// src/store.js
-
+```js:title=src/store.js
 import Vue from 'vue';
+
 import Vuex from 'vuex';
 
 Vue.use(Vuex);
@@ -61,24 +60,22 @@ export default new Vuex.Store({
 
 In our top-level app component (`src/App.vue`) we can wire the store into our component hierarchy fairly easily:
 
-```html
-<!--src/App.vue -->
-
+```diff:title=src/App.vue
 <template>
   <div id="app">
-    <task-list />
++   <task-list />
   </div>
 </template>
 
 <script>
-  import store from './store';
-  import TaskList from './components/TaskList.vue';
++ import store from './store';
++ import TaskList from './components/TaskList.vue';
 
   export default {
     name: 'app',
-    store,
++   store,
     components: {
-      TaskList,
++     TaskList,
     },
   };
 </script>
@@ -91,9 +88,7 @@ Then we'll update our `TaskList` to read data out of the store. First let's move
 
 In `src/components/PureTaskList.vue`:
 
-```html
-<!-- src/components/PureTaskList.vue -->
-
+```diff:title=src/components/PureTaskList.vue
 <template>
   <!-- same content as before -->
 </template>
@@ -101,7 +96,7 @@ In `src/components/PureTaskList.vue`:
 <script>
   import Task from './Task';
   export default {
-    name: 'PureTaskList',
++   name: 'PureTaskList',
     // same content as before
   };
 </script>
@@ -109,9 +104,7 @@ In `src/components/PureTaskList.vue`:
 
 In `src/components/TaskList.vue`:
 
-```html
-<!-- src/components/TaskList.vue -->
-
+```html:title=src/components/TaskList.vue
 <template>
   <PureTaskList :tasks="tasks" v-on="$listeners" @archive-task="archiveTask" @pin-task="pinTask" />
 </template>
@@ -132,24 +125,23 @@ In `src/components/TaskList.vue`:
 
 The reason to keep the presentational version of the `TaskList` separate is because it is easier to test and isolate. As it doesn't rely on the presence of a store it is much easier to deal with from a testing perspective. Let's rename `src/components/TaskList.stories.js` into `src/components/PureTaskList.stories.js`, and ensure our stories use the presentational version:
 
-```javascript
-// src/components/PureTaskList.stories.js
+```diff:title=src/components/PureTaskList.stories.js
++ import PureTaskList from './PureTaskList';
 
-import PureTaskList from './PureTaskList';
 import * as TaskStories from './Task.stories';
 
 export default {
-  component: PureTaskList,
-  title: 'PureTaskList',
++ component: PureTaskList,
++ title: 'PureTaskList',
   decorators: [() => '<div style="padding: 3rem;"><story /></div>'],
 };
 
 const Template = (args, { argTypes }) => ({
-  components: { PureTaskList },
++ components: { PureTaskList },
   props: Object.keys(argTypes),
   // We are reusing our actions from task.stories.js
   methods: TaskStories.actionsData,
-  template: '<PureTaskList v-bind="$props" @pin-task="onPinTask" @archive-task="onArchiveTask" />',
++ template: '<PureTaskList v-bind="$props" @pin-task="onPinTask" @archive-task="onArchiveTask" />',
 });
 
 export const Default = Template.bind({});
@@ -204,17 +196,17 @@ Empty.args = {
 
 Similarly, we need to use `PureTaskList` in our Jest test:
 
-```js
-// tests/unit/PureTaskList.spec.js
-
+```diff:title=tests/unit/PureTaskList.spec.js
 import Vue from 'vue';
-import PureTaskList from '../../src/components/PureTaskList.vue';
+
++ import PureTaskList from '../../src/components/PureTaskList.vue';
+
 //👇 Our story imported here
-import { WithPinnedTasks } from '../../src/components/PureTaskList.stories';
++ import { WithPinnedTasks } from '../../src/components/PureTaskList.stories';
 
 it('renders pinned tasks at the start of the list', () => {
   // render PureTaskList
-  const Constructor = Vue.extend(PureTaskList);
++ const Constructor = Vue.extend(PureTaskList);
   const vm = new Constructor({
     //👇 Story's args used with our test
     propsData: WithPinnedTasks.args,

--- a/content/intro-to-storybook/vue/en/data.md
+++ b/content/intro-to-storybook/vue/en/data.md
@@ -60,22 +60,22 @@ export default new Vuex.Store({
 
 In our top-level app component (`src/App.vue`) we can wire the store into our component hierarchy fairly easily:
 
-```diff:title=src/App.vue
+```html:title=src/App.vue
 <template>
   <div id="app">
-+   <task-list />
+    <task-list />
   </div>
 </template>
 
 <script>
-+ import store from './store';
-+ import TaskList from './components/TaskList.vue';
+  import store from './store';
+  import TaskList from './components/TaskList.vue';
 
   export default {
     name: 'app',
-+   store,
+    store,
     components: {
-+     TaskList,
+      TaskList,
     },
   };
 </script>
@@ -88,7 +88,7 @@ Then we'll update our `TaskList` to read data out of the store. First let's move
 
 In `src/components/PureTaskList.vue`:
 
-```diff:title=src/components/PureTaskList.vue
+```html:title=src/components/PureTaskList.vue
 <template>
   <!-- same content as before -->
 </template>
@@ -96,7 +96,7 @@ In `src/components/PureTaskList.vue`:
 <script>
   import Task from './Task';
   export default {
-+   name: 'PureTaskList',
+    name: 'PureTaskList',
     // same content as before
   };
 </script>

--- a/content/intro-to-storybook/vue/en/deploy.md
+++ b/content/intro-to-storybook/vue/en/deploy.md
@@ -80,9 +80,7 @@ In the root folder of our project, create a new directory called `.github` then 
 
 Create a new file called `chromatic.yml` like the one below. Replace to change `project-token` with your project token.
 
-```yaml
-# .github/workflows/chromatic.yml
-
+```yaml:title=.github/workflows/chromatic.yml
 # Workflow name
 name: 'Chromatic Deployment'
 

--- a/content/intro-to-storybook/vue/en/get-started.md
+++ b/content/intro-to-storybook/vue/en/get-started.md
@@ -5,7 +5,7 @@ description: 'Setup Vue Storybook in your development environment'
 commit: '9e3165c'
 ---
 
-Storybook runs alongside your app in development mode. It helps you build UI components isolated from the business logic and context of your app. This edition of Learn Storybook is for Vue; other editions exist for [React](/intro-to-storybook/react/en/get-started), [React Native](/intro-to-storybook/react-native/en/get-started/), [Angular](/intro-to-storybook/angular/en/get-started), [Svelte](/intro-to-storybook/svelte/en/get-started) and [Ember](/intro-to-storybook/ember/en/get-started).
+Storybook runs alongside your app in development mode. It helps you build UI components isolated from the business logic and context of your app. This edition of the Intro to Storybook tutorial is for Vue; other editions exist for [React](/intro-to-storybook/react/en/get-started), [React Native](/intro-to-storybook/react-native/en/get-started/), [Angular](/intro-to-storybook/angular/en/get-started), [Svelte](/intro-to-storybook/svelte/en/get-started) and [Ember](/intro-to-storybook/ember/en/get-started).
 
 ![Storybook and your app](/intro-to-storybook/storybook-relationship.jpg)
 

--- a/content/intro-to-storybook/vue/en/screen.md
+++ b/content/intro-to-storybook/vue/en/screen.md
@@ -23,7 +23,6 @@ As our app is very simple, the screen we’ll build is pretty trivial, simply wr
         <div class="subtitle-message">Something went wrong</div>
       </div>
     </div>
-
     <div v-else class="page lists-show">
       <nav>
         <h1 class="title-page">
@@ -71,17 +70,20 @@ We also change the `App` component to render the `InboxScreen` (eventually we wo
 ```diff:title=src/App.vue
 <template>
   <div id="app">
+-   <task-list />
 +   <InboxScreen />
   </div>
 </template>
 
 <script>
   import store from './store';
+- import TaskList from './components/TaskList.vue';
 + import InboxScreen from './components/InboxScreen.vue';
   export default {
     name: 'app',
     store,
     components: {
+-     TaskList
 +     InboxScreen,
     },
   };

--- a/content/intro-to-storybook/vue/en/screen.md
+++ b/content/intro-to-storybook/vue/en/screen.md
@@ -13,9 +13,7 @@ In this chapter we continue to increase the sophistication by combining componen
 
 As our app is very simple, the screen we’ll build is pretty trivial, simply wrapping the `TaskList` container component (which supplies its own data via Vuex) in some layout and pulling a top-level `error` field out of the store (let's assume we'll set that field if we have some problem connecting to our server). Let's create a presentational `PureInboxScreen.vue` in your `src/components/` folder:
 
-```html
-<!-- src/components/PureInboxScreen.vue -->
-
+```html:title=src/components/PureInboxScreen.vue
 <template>
   <div>
     <div v-if="error" class="page lists-show">
@@ -51,9 +49,7 @@ As our app is very simple, the screen we’ll build is pretty trivial, simply wr
 
 Then, we can create a container, which again grabs the data for the `PureInboxScreen` in `src/components/InboxScreen.vue`:
 
-```html
-<!-- src/components/InboxScreen.vue -->
-
+```html:title=src/components/InboxScreen.vue
 <template>
   <PureInboxScreen :error="error" />
 </template>
@@ -72,23 +68,21 @@ Then, we can create a container, which again grabs the data for the `PureInboxSc
 
 We also change the `App` component to render the `InboxScreen` (eventually we would use a router to choose the correct screen, but let's not worry about that here):
 
-```html
-<!-- src/App.vue -->
-
+```diff:title=src/App.vue
 <template>
   <div id="app">
-    <InboxScreen />
++   <InboxScreen />
   </div>
 </template>
 
 <script>
   import store from './store';
-  import InboxScreen from './components/InboxScreen.vue';
++ import InboxScreen from './components/InboxScreen.vue';
   export default {
     name: 'app',
     store,
     components: {
-      InboxScreen,
++     InboxScreen,
     },
   };
 </script>
@@ -106,9 +100,7 @@ When placing the `TaskList` into Storybook, we were able to dodge this issue by 
 
 However, for the `PureInboxScreen` we have a problem because although the `PureInboxScreen` itself is presentational, its child, the `TaskList`, is not. In a sense the `PureInboxScreen` has been polluted by “container-ness”. So when we setup our stories in `src/components/PureInboxScreen.stories.js`:
 
-```javascript
-// src/components/PureInboxScreen.stories.js
-
+```js:title=src/components/PureInboxScreen.stories.js
 import PureInboxScreen from './PureInboxScreen.vue';
 
 export default {
@@ -144,30 +136,30 @@ However, developers **will** inevitably need to render containers further down t
 
 The good news is that it is easy to supply a Vuex store to the `PureInboxScreen` in a story! We can create a new store in our story file and pass it in as the context of the story:
 
-```javascript
-// src/components/PureInboxScreen.stories.js
+```diff:title=src/components/PureInboxScreen.stories.js
++ import Vue from 'vue';
++ import Vuex from 'vuex';
 
-import Vue from 'vue';
-import Vuex from 'vuex';
 import PureInboxScreen from './PureInboxScreen.vue';
-import { action } from '@storybook/addon-actions';
-import * as TaskListStories from './PureTaskList.stories';
 
-Vue.use(Vuex);
++ import { action } from '@storybook/addon-actions';
++ import * as TaskListStories from './PureTaskList.stories';
 
-export const store = new Vuex.Store({
-  state: {
-    tasks: TaskListStories.Default.args.tasks,
-  },
-  actions: {
-    pinTask(context, id) {
-      action('pin-task')(id);
-    },
-    archiveTask(context, id) {
-      action('archive-task')(id);
-    },
-  },
-});
++Vue.use(Vuex);
+
++ export const store = new Vuex.Store({
++  state: {
++    tasks: TaskListStories.Default.args.tasks,
++  },
++  actions: {
++    pinTask(context, id) {
++      action('pin-task')(id);
++    },
++    archiveTask(context, id) {
++      action('archive-task')(id);
++    },
++  },
++ });
 
 export default {
   title: 'PureInboxScreen',

--- a/content/intro-to-storybook/vue/en/simple-component.md
+++ b/content/intro-to-storybook/vue/en/simple-component.md
@@ -26,9 +26,7 @@ First, let’s create the task component and its accompanying story file: `src/c
 
 We’ll begin with the baseline implementation of the `Task`, simply taking in the attributes we know we’ll need:
 
-```html
-<!-- src/components/Task.vue -->
-
+```html:title=src/components/Task.vue
 <template>
   <div class="list-item">
     <input type="text" readonly :value="task.title" />
@@ -54,10 +52,9 @@ Above, we render straightforward markup for `Task` based on the existing HTML st
 
 Below we build out Task’s three test states in the story file:
 
-```javascript
-// src/components/Task.stories.js
-
+```js:title=src/components/Task.stories.js
 import Task from './Task';
+
 import { action } from '@storybook/addon-actions';
 
 export default {
@@ -143,26 +140,22 @@ Another nice thing about bundling the `actionsData` that a component needs, is t
 
 ## Config
 
-We'll need to make a couple of changes to the Storybook configuration so it notices not only our recently created stories, but also allows us to use the CSS file that was introduced in the [previous chapter](/intro-to-storybook/vue/en/get-started).
+We'll need to make a couple of changes to Storybook's configuration files so it notices not only our recently created stories, but also allow us to use the application's CSS file (located in `src/index.css`).
 
 Start by changing your Storybook configuration file (`.storybook/main.js`) to the following:
 
-```javascript
-// .storybook/main.js
-
+```diff:title=.storybook/main.js
 module.exports = {
-  //👇 Location of our stories
-  stories: ['../src/components/**/*.stories.js'],
++ stories: ['../src/components/**/*.stories.js'],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
 };
 ```
 
 After completing the change above, inside the `.storybook` folder, change your `preview.js` to the following:
 
-```javascript
-// .storybook/preview.js
+```diff:title=.storybook/preview.js
 
-import '../src/index.css'; //👈 The app's CSS file goes here
++ import '../src/index.css';
 
 //👇 Configures Storybook to log the actions( onArchiveTask and onPinTask ) in the UI.
 export const parameters = {
@@ -189,25 +182,22 @@ Now we have Storybook setup, styles imported, and test cases built out, we can q
 
 Our component is still rather rudimentary at the moment. We're going to make some changes so that it matches the intended design without going into too much detail:
 
-```html
-<!-- src/components/Task.vue -->
-
+```diff:title=src/components/Task.vue
 <template>
-  <div class="list-item" :class="task.state">
-    <label class="checkbox">
-      <input type="checkbox" :checked="isChecked" disabled name="checked" />
-      <span class="checkbox-custom" @click="$emit('archive-task', task.id)" />
-    </label>
-    <div class="title">
-      <input type="text" :value="task.title" readonly placeholder="Input title" />
-    </div>
-
-    <div class="actions">
-      <a v-if="!isChecked" @click="$emit('pin-task', task.id)">
-        <span class="icon-star" />
-      </a>
-    </div>
-  </div>
++ <div class="list-item" :class="task.state">
++  <label class="checkbox">
++    <input type="checkbox" :checked="isChecked" disabled name="checked" />
++    <span class="checkbox-custom" @click="$emit('archive-task', task.id)" />
++  </label>
++  <div class="title">
++    <input type="text" :value="task.title" readonly placeholder="Input title" />
++  </div>
++  <div class="actions">
++   <a v-if="!isChecked" @click="$emit('pin-task', task.id)">
++    <span class="icon-star" />
++   </a>
++  </div>
++ </div>
 </template>
 
 <script>
@@ -221,11 +211,11 @@ Our component is still rather rudimentary at the moment. We're going to make som
         validator: task => ['id', 'state', 'title'].every(key => key in task),
       },
     },
-    computed: {
-      isChecked() {
-        return this.task.state === 'TASK_ARCHIVED';
-      },
-    },
++   computed: {
++     isChecked() {
++       return this.task.state === 'TASK_ARCHIVED';
++     },
++   },
   };
 </script>
 ```
@@ -265,9 +255,7 @@ yarn add -D @storybook/addon-storyshots jest-vue-preprocessor
 
 Then create a `tests/unit/storybook.spec.js` file with the following in it:
 
-```javascript
-// tests/unit/storybook.spec.js
-
+```js:title=tests/unit/storybook.spec.js
 import initStoryshots from '@storybook/addon-storyshots';
 
 initStoryshots();
@@ -275,10 +263,11 @@ initStoryshots();
 
 We need to add a line to our `jest.config.js`:
 
-```js
-  // jest.config.js
-
-  transformIgnorePatterns: ["/node_modules/(?!(@storybook/.*\\.vue$))"],
+```diff:title=jest.config.js
+module.exports = {
+  ...
++ transformIgnorePatterns: ["/node_modules/(?!(@storybook/.*\\.vue$))"],
+};
 ```
 
 Once the above is done, we can run `yarn test:unit` and see the following output:

--- a/content/intro-to-storybook/vue/en/simple-component.md
+++ b/content/intro-to-storybook/vue/en/simple-component.md
@@ -140,7 +140,7 @@ Another nice thing about bundling the `actionsData` that a component needs, is t
 
 ## Config
 
-We'll need to make a couple of changes to Storybook's configuration files so it notices not only our recently created stories, but also allow us to use the application's CSS file (located in `src/index.css`).
+We'll need to make a couple of changes to Storybook's configuration files so it notices not only our recently created stories and allow us to use the application's CSS file (located in `src/index.css`).
 
 Start by changing your Storybook configuration file (`.storybook/main.js`) to the following:
 

--- a/content/intro-to-storybook/vue/en/test.md
+++ b/content/intro-to-storybook/vue/en/test.md
@@ -44,15 +44,13 @@ git checkout -b change-task-background
 
 Change `Task` to the following:
 
-```html
-<!-- src/components/Task.vue -->
-
+```diff:title=src/components/Task.vue
 <input
   type="text"
   :value="task.title"
   readonly
   placeholder="Input title"
-  style="background: red;"
++ style="background: red;"
 />
 ```
 

--- a/content/intro-to-storybook/vue/en/using-addons.md
+++ b/content/intro-to-storybook/vue/en/using-addons.md
@@ -40,15 +40,13 @@ Controls allowed us to quickly verify different inputs to a component. In this c
 
 Now let's fix the issue with overflowing by adding a style to `Task.vue`:
 
-```html
-<!-- src/components/Task.vue -->
-
+```diff:title=src/components/Task.vue
 <input
   type="text"
   :value="task.title"
   readonly
   placeholder="Input title"
-  style="text-overflow: ellipsis;"
++ style="text-overflow: ellipsis;"
 />
 ```
 
@@ -62,9 +60,7 @@ In the future, We can manually reproduce this problem by entering the same strin
 
 Add a new story for the long text case in `Task.stories.js`:
 
-```js
-// src/components/Task.stories.js
-
+```js:title=src/components/Task.stories.js
 const longTitleString = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not!`;
 
 export const LongTitle = Template.bind({});


### PR DESCRIPTION
With this pull request the Intro to Storybook was adjusted to include the new way we're handling the snippets. 
Editions covered by this:
- React (en)
- Vue (en)
- Ember (en)
- Svelte (en)

The issue #447 is addressed and the get-started and contribute sections were adjusted to remove references of LearnStorybook.


This will be merged once i check the deploy preview.