### PR TITLE
Chore: (Docs Intro to Storybook) Removes last references to LearnStorybook

### DIFF
--- a/content/intro-to-storybook/angular/en/conclusion.md
+++ b/content/intro-to-storybook/angular/en/conclusion.md
@@ -19,7 +19,7 @@ Want to dive deeper? Here are helpful resources.
 
 - [**The Delightful Storybook Workflow**](https://www.chromatic.com/blog/the-delightful-storybook-workflow) highlights workflow best practices used by high-velocity teams at Squarespace, Major League Soccer, Discovery Network, and Apollo GraphQL.
 
-- [**Visual Testing Handbook**](https://www.learnstorybook.com/visual-testing-handbook/) dives deep into using Storybook to visual test components. Free 31-page ebook.
+- [**Visual Testing Handbook**](https://storybook.js.org/tutorials/visual-testing-handbook/) dives deep into using Storybook to visual test components. Free 31-page ebook.
 
 - [**Storybook Discord chat**](https://discord.gg/UUt2PJb) puts you in contact with the Storybook community. Get and give help to other Storybook users.
 

--- a/content/intro-to-storybook/angular/es/conclusion.md
+++ b/content/intro-to-storybook/angular/es/conclusion.md
@@ -19,7 +19,7 @@ Storybook es una poderosa herramienta para React, Vue y Angular. Cuenta con una 
 
 - [**El delicioso flujo de trabajo de Storybook**](https://www.chromatic.com/blog/the-delightful-storybook-workflow) destaca las mejores prácticas del flujo de trabajo utilizado por equipos de alta velocidad en Squarespace, Major League Soccer, Discovery Network y Apollo GraphQL.
 
-- [**Manual de pruebas visuales**](https://www.learnstorybook.com/visual-testing-handbook/) se sumerge profundamente en el uso de Storybook para probar componentes visuales. Libro electrónico gratuito de 31 páginas.
+- [**Manual de pruebas visuales**](https://storybook.js.org/tutorials/visual-testing-handbook/) se sumerge profundamente en el uso de Storybook para probar componentes visuales. Libro electrónico gratuito de 31 páginas.
 
 - [**Discord de Storybook**](https://discord.gg/UUt2PJb) te pone en contacto con la comunidad de Storybook. Obtenga y brinde ayuda a otros usuarios de Storybook.
 

--- a/content/intro-to-storybook/angular/pt/conclusion.md
+++ b/content/intro-to-storybook/angular/pt/conclusion.md
@@ -21,7 +21,7 @@ Pretende saber mais? Aqui ficam alguns recursos que irão ajudar.
 - [**Manual de testes visuais**](https://www.chromatic.com/blog/the-delightful-storybook-workflow)
   enumera as boas práticas de fluxo de trabalho, usadas por equipas que operam a alta velocidade, tal como por exemplo a SquareSpace, a Major League Soccer, a Discovery Network e Apollo GraphQL.
 
-- [**Visual Testing Handbook**](https://www.learnstorybook.com/visual-testing-handbook/) aprofunda o uso de Storybook para testes visuais. Livro eletrónico livre de 31 páginas.
+- [**Visual Testing Handbook**](https://storybook.js.org/tutorials/visual-testing-handbook/) aprofunda o uso de Storybook para testes visuais. Livro eletrónico livre de 31 páginas.
 
 - [**Discord do Storybook**](https://discord.gg/UUt2PJb) põe-te em contacto direto com a comunidade Storybook. Onde podes oferecer e receber ajuda de outros utilizadores do Storybook.
 

--- a/content/intro-to-storybook/ember/en/conclusion.md
+++ b/content/intro-to-storybook/ember/en/conclusion.md
@@ -19,7 +19,7 @@ Want to dive deeper? Here are helpful resources.
 
 - [**The Delightful Storybook Workflow**](https://www.chromatic.com/blog/the-delightful-storybook-workflow) highlights workflow best practices used by high-velocity teams at Squarespace, Major League Soccer, Discovery Network, and Apollo GraphQL.
 
-- [**Visual Testing Handbook**](https://www.learnstorybook.com/visual-testing-handbook/) dives deep into using Storybook to visual test components. Free 31-page ebook.
+- [**Visual Testing Handbook**](https://storybook.js.org/tutorials/visual-testing-handbook/) dives deep into using Storybook to visual test components. Free 31-page ebook.
 
 - [**Storybook Discord chat**](https://discord.gg/UUt2PJb) puts you in contact with the Storybook community. Get and give help to other Storybook users.
 

--- a/content/intro-to-storybook/ember/en/deploy.md
+++ b/content/intro-to-storybook/ember/en/deploy.md
@@ -99,7 +99,7 @@ jobs:
       - uses: chromaui/action@v1
         # Options required for Chromatic's GitHub Action
         with:
-          #👇 Chromatic projectToken, see https://www.learnstorybook.com/intro-to-storybook/ember/en/deploy/ to obtain it
+          #👇 Chromatic projectToken, see https://storybook.js.org/tutorials/intro-to-storybook/ember/en/deploy/ to obtain it
           projectToken: project-token
           token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/content/intro-to-storybook/react-native/en/conclusion.md
+++ b/content/intro-to-storybook/react-native/en/conclusion.md
@@ -19,7 +19,7 @@ Want to dive deeper? Here are helpful resources.
 
 - [**The Delightful Storybook Workflow**](https://www.chromatic.com/blog/the-delightful-storybook-workflow) highlights workflow best practices used by high-velocity teams at Squarespace, Major League Soccer, Discovery Network, and Apollo GraphQL.
 
-- [**Visual Testing Handbook**](https://www.learnstorybook.com/visual-testing-handbook/) dives deep into using Storybook to visual test components. Free 31-page ebook.
+- [**Visual Testing Handbook**](https://storybook.js.org/tutorials/visual-testing-handbook/) dives deep into using Storybook to visual test components. Free 31-page ebook.
 
 - [**Storybook Discord chat**](https://discord.gg/UUt2PJb) puts you in contact with the Storybook community. Get and give help to other Storybook users.
 

--- a/content/intro-to-storybook/react-native/es/conclusion.md
+++ b/content/intro-to-storybook/react-native/es/conclusion.md
@@ -19,7 +19,7 @@ Quieres bucear más profundo? Aquí algunos recursos útiles:
 
 - [**El delicioso flujo de trabajo de Storybook**](https://www.chromatic.com/blog/the-delightful-storybook-workflow) destaca las mejores prácticas del flujo de trabajo utilizado por equipos de alta velocidad en Squarespace, Major League Soccer, Discovery Network y Apollo GraphQL.
 
-- [**Manual de pruebas visuales**](https://www.learnstorybook.com/visual-testing-handbook/) se sumerge profundamente en el uso de Storybook para probar componentes visuales. Libro electrónico gratuito de 31 páginas.
+- [**Manual de pruebas visuales**](https://storybook.js.org/tutorials/visual-testing-handbook/) se sumerge profundamente en el uso de Storybook para probar componentes visuales. Libro electrónico gratuito de 31 páginas.
 
 - [**Discord de Storybook**](https://discord.gg/UUt2PJb) te pone en contacto con la comunidad de Storybook. Obtenga y brinde ayuda a otros usuarios de Storybook.
 

--- a/content/intro-to-storybook/react/de/conclusion.md
+++ b/content/intro-to-storybook/react/de/conclusion.md
@@ -19,7 +19,7 @@ Möchtest du noch tiefer einsteigen? Hier ein paar hilfreiche Quellen.
 
 - [**Der Blog-Post "The Delightful Storybook Workflow"**](https://www.chromatic.com/blog/the-delightful-storybook-workflow) zeigt dir Workflows und Best-Practices der Hochgeschwindigkeits-Teams von Squarespace, Major League Soccer, Discovery Network, und Apollo GraphQL.
 
-- [**Das Handbuch für visuelle Tests**](https://www.learnstorybook.com/visual-testing-handbook/) taucht tief in die Verwendung von Storybook für visuelle Tests für Komponenten ein. Ein kostenloses 31-seitiges E-Book.
+- [**Das Handbuch für visuelle Tests**](https://storybook.js.org/tutorials/visual-testing-handbook/) taucht tief in die Verwendung von Storybook für visuelle Tests für Komponenten ein. Ein kostenloses 31-seitiges E-Book.
 
 ## Wer steckt hinter LearnStorybook.com?
 

--- a/content/intro-to-storybook/react/en/conclusion.md
+++ b/content/intro-to-storybook/react/en/conclusion.md
@@ -19,7 +19,7 @@ Want to dive deeper? Here are helpful resources.
 
 - [**The Delightful Storybook Workflow**](https://www.chromatic.com/blog/the-delightful-storybook-workflow) highlights workflow best practices used by high-velocity teams at Squarespace, Major League Soccer, Discovery Network, and Apollo GraphQL.
 
-- [**Visual Testing Handbook**](https://www.learnstorybook.com/visual-testing-handbook/) dives deep into using Storybook to visual test components. Free 31-page ebook.
+- [**Visual Testing Handbook**](https://storybook.js.org/tutorials/visual-testing-handbook/) dives deep into using Storybook to visual test components. Free 31-page ebook.
 
 - [**Storybook Discord chat**](https://discord.gg/UUt2PJb) puts you in contact with the Storybook community. Get and give help to other Storybook users.
 

--- a/content/intro-to-storybook/react/en/deploy.md
+++ b/content/intro-to-storybook/react/en/deploy.md
@@ -100,7 +100,7 @@ jobs:
       - uses: chromaui/action@v1
         # Options required for Chromatic's GitHub Action
         with:
-          #👇 Chromatic projectToken, see https://www.learnstorybook.com/intro-to-storybook/react/en/deploy/ to obtain it
+          #👇 Chromatic projectToken, see https://storybook.js.org/tutorials/intro-to-storybook/react/en/deploy/ to obtain it
           projectToken: project-token
           token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/content/intro-to-storybook/react/es/conclusion.md
+++ b/content/intro-to-storybook/react/es/conclusion.md
@@ -19,7 +19,7 @@ Quieres bucear más profundo? Aquí algunos recursos útiles:
 
 - [**El delicioso flujo de trabajo de Storybook**](https://www.chromatic.com/blog/the-delightful-storybook-workflow) destaca las mejores prácticas del flujo de trabajo utilizado por equipos de alta velocidad en Squarespace, Major League Soccer, Discovery Network y Apollo GraphQL.
 
-- [**Manual de pruebas visuales**](https://www.learnstorybook.com/visual-testing-handbook/) se sumerge profundamente en el uso de Storybook para probar componentes visuales. Libro electrónico gratuito de 31 páginas.
+- [**Manual de pruebas visuales**](https://storybook.js.org/tutorials/visual-testing-handbook/) se sumerge profundamente en el uso de Storybook para probar componentes visuales. Libro electrónico gratuito de 31 páginas.
 
 - [**Discord de Storybook**](https://discord.gg/UUt2PJb) te pone en contacto con la comunidad de Storybook. Obtenga y brinde ayuda a otros usuarios de Storybook.
 

--- a/content/intro-to-storybook/react/fr/conclusion.md
+++ b/content/intro-to-storybook/react/fr/conclusion.md
@@ -19,7 +19,7 @@ Envie de creuser plus? Voici des ressources utiles.
 
 - [**The Delightful Storybook Workflow**](https://www.chromatic.com/blog/the-delightful-storybook-workflow) met en évidence les meilleures pratiques de workflow utilisées par les équipes à grande vitesse de Squarespace, Major League Soccer, Discovery Network, et Apollo GraphQL.
 
-- [**Visual Testing Handbook**](https://www.learnstorybook.com/visual-testing-handbook/) plonge dans l'utilisation de Storybook pour tester visuellement les composants. Livre électronique gratuit de 31 pages.
+- [**Visual Testing Handbook**](https://storybook.js.org/tutorials/visual-testing-handbook/) plonge dans l'utilisation de Storybook pour tester visuellement les composants. Livre électronique gratuit de 31 pages.
 
 - [**Storybook Discord chat**](https://discord.gg/UUt2PJb) vous met en contact avec la communauté Storybook. Obtenez et donnez de l'aide aux autres utilisateurs de Storybook.
 

--- a/content/intro-to-storybook/react/fr/deploy.md
+++ b/content/intro-to-storybook/react/fr/deploy.md
@@ -114,7 +114,7 @@ jobs:
       - uses: chromaui/action@v1
         # Options required for Chromatic's GitHub Action
         with:
-          #👇 Chromatic projectToken, see https://www.learnstorybook.com/intro-to-storybook/react/en/deploy/ to obtain it
+          #👇 Chromatic projectToken, see https://storybook.js.org/tutorials/intro-to-storybook/react/en/deploy/ to obtain it
           projectToken: project-token
           token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/content/intro-to-storybook/react/ja/conclusion.md
+++ b/content/intro-to-storybook/react/ja/conclusion.md
@@ -19,7 +19,7 @@ Storybook は React、React Native、Vue、Angular、Svelte、その他のフレ
 
 - [**楽しい Storybook のワークフロー**](https://www.chromatic.com/blog/the-delightful-storybook-workflow)では Squarespace や、メジャーリーグサッカー、ディスカバリーネットワーク、 Apollo GraphQL といった効率の良いチームにおけるワークフローのベストプラクティスを紹介しています。
 
-- [**視覚的なテストのハンドブック**](https://www.learnstorybook.com/visual-testing-handbook)では、コンポーネントを Storybook で視覚的にテストする方法を掘り下げています。無料の 31 ページある eBook です。
+- [**視覚的なテストのハンドブック**](https://storybook.js.org/tutorials/visual-testing-handbook)では、コンポーネントを Storybook で視覚的にテストする方法を掘り下げています。無料の 31 ページある eBook です。
 
 - [**Storybook Discord**](https://discord.gg/UUt2PJb) では Storybook のコミュニティに参加できます。他の Storybook ユーザーと協力しましょう。
 

--- a/content/intro-to-storybook/react/ja/deploy.md
+++ b/content/intro-to-storybook/react/ja/deploy.md
@@ -102,7 +102,7 @@ jobs:
       - uses: chromaui/action@v1
         # Options required for Chromatic's GitHub Action
         with:
-          #👇 Chromatic projectToken, see https://www.learnstorybook.com/intro-to-storybook/react/en/deploy/ to obtain it
+          #👇 Chromatic projectToken, see https://storybook.js.org/tutorials/intro-to-storybook/react/en/deploy/ to obtain it
           projectToken: project-token
           token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/content/intro-to-storybook/react/ko/conclusion.md
+++ b/content/intro-to-storybook/react/ko/conclusion.md
@@ -19,7 +19,7 @@ Storybook은 React, React Native, Vue, Angular, Svelte 외 다른 여러 프레�
 
 - [**Delightful Storybook Workflow**](https://www.chromatic.com/blog/the-delightful-storybook-workflow)는 Squarespace, Major League Soccer, Discovery Network 및 Apollo GraphQL과 같은 빠른 개발 속도를 가진 팀에서 사용하는 Workflow 모범 사례를 보여줍니다.
 
-- [**시각적 테스팅 핸드북**](https://www.learnstorybook.com/visual-testing-handbook/)에서는
+- [**시각적 테스팅 핸드북**](https://storybook.js.org/tutorials/visual-testing-handbook/)에서는
   Storybook을 컴포넌트의 시각적 테스트에 사용하는 것에 대해 알아봅니다. 31페이지 분량의 무료 전자책.
 
 - [**Storybook Discord 채널**](https://discord.gg/UUt2PJb)로 Storybook 커뮤니티와 연결될 수 있습니다. Storybook 사용자를 위한 도움을 주고받으세요.

--- a/content/intro-to-storybook/react/ko/deploy.md
+++ b/content/intro-to-storybook/react/ko/deploy.md
@@ -114,7 +114,7 @@ jobs:
       - uses: chromaui/action@v1
         # Options required for Chromatic's GitHub Action
         with:
-          #👇 Chromatic projectToken, see https://www.learnstorybook.com/intro-to-storybook/react/en/deploy/ to obtain it
+          #👇 Chromatic projectToken, see https://storybook.js.org/tutorials/intro-to-storybook/react/en/deploy/ to obtain it
           projectToken: project-token
           token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/content/intro-to-storybook/react/nl/conclusion.md
+++ b/content/intro-to-storybook/react/nl/conclusion.md
@@ -19,7 +19,7 @@ Wil je wat dieper gaan? Hier zijn behulpzame bronnen.
 
 - [**The Delightful Storybook Workflow**](https://www.chromatic.com/blog/the-delightful-storybook-workflow) benadrukt workflow-best practices die worden gebruikt door high-speed teams bij Squarespace, Major League Soccer, Discovery Network en Apollo GraphQL.
 
-- [**Visual Testing Handbook**](https://www.learnstorybook.com/visual-testing-handbook/) gaat meer in detail over het gebruik van Storybook om visuele componenten te testen. Gratis e-book van 31 pagina's.
+- [**Visual Testing Handbook**](https://storybook.js.org/tutorials/visual-testing-handbook/) gaat meer in detail over het gebruik van Storybook om visuele componenten te testen. Gratis e-book van 31 pagina's.
 
 ## Who made LearnStorybook.com?
 

--- a/content/intro-to-storybook/react/nl/deploy.md
+++ b/content/intro-to-storybook/react/nl/deploy.md
@@ -99,7 +99,7 @@ jobs:
       - uses: chromaui/action@v1
         # Options required for Chromatic's GitHub Action
         with:
-          #👇 Chromatic projectToken, see https://www.learnstorybook.com/intro-to-storybook/react/en/deploy/ to obtain it
+          #👇 Chromatic projectToken, see https://storybook.js.org/tutorials/intro-to-storybook/react/en/deploy/ to obtain it
           projectToken: project-token
           token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/content/intro-to-storybook/react/pt/conclusion.md
+++ b/content/intro-to-storybook/react/pt/conclusion.md
@@ -20,7 +20,7 @@ Pretende saber mais? Aqui ficam alguns recursos que irão ajudar.
 
 - [**Manual de testes visuais**](https://www.chromatic.com/blog/the-delightful-storybook-workflow) enumera as boas práticas de fluxo de trabalho, usadas por equipas que operam a alta velocidade, tal como por exemplo a SquareSpace, a Major League Soccer, a Discovery Network e Apollo GraphQL.
 
-- [**Visual Testing Handbook**](https://www.learnstorybook.com/visual-testing-handbook/) aprofunda o uso de Storybook para testes visuais. Livro eletrónico livre de 31 páginas.
+- [**Visual Testing Handbook**](https://storybook.js.org/tutorials/visual-testing-handbook/) aprofunda o uso de Storybook para testes visuais. Livro eletrónico livre de 31 páginas.
 
 - [**Discord do Storybook**](https://discord.gg/UUt2PJb) põe-te em contacto direto com a comunidade Storybook. Onde podes oferecer e receber ajuda de outros utilizadores do Storybook.
 

--- a/content/intro-to-storybook/react/zh-CN/conclusion.md
+++ b/content/intro-to-storybook/react/zh-CN/conclusion.md
@@ -20,7 +20,7 @@ Storybook 是 React,Vue 和 Angular 的强大工具. 它拥有蓬勃发展的开
 
 - [**令人愉快的 Storybook 工作流程**](https://www.chromatic.com/blog/the-delightful-storybook-workflow) 重点介绍 Squarespace,Major League Soccer,Discovery Network 和 Apollo GraphQL 的高速团队使用的工作流程最佳实践.
 
-- [**视觉测试手册**](https://www.learnstorybook.com/visual-testing-handbook/)深入探讨将 Storybook 用于可视化测试组件. 免费的 31 页电子书.
+- [**视觉测试手册**](https://storybook.js.org/tutorials/visual-testing-handbook/)深入探讨将 Storybook 用于可视化测试组件. 免费的 31 页电子书.
 
 - [**Storybook 聊天室**](https://discord.gg/UUt2PJb) 让你与 Storybook 社区保持联系，并给予其他 Storybook 用户帮助。
 

--- a/content/intro-to-storybook/react/zh-CN/deploy.md
+++ b/content/intro-to-storybook/react/zh-CN/deploy.md
@@ -114,7 +114,7 @@ jobs:
       - uses: chromaui/action@v1
         # Options required for Chromatic's GitHub Action
         with:
-          #👇 Chromatic projectToken, see https://www.learnstorybook.com/intro-to-storybook/react/en/deploy/ to obtain it
+          #👇 Chromatic projectToken, see https://storybook.js.org/tutorials/intro-to-storybook/react/en/deploy/ to obtain it
           projectToken: project-token
           token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/content/intro-to-storybook/react/zh-TW/conclusion.md
+++ b/content/intro-to-storybook/react/zh-TW/conclusion.md
@@ -20,7 +20,7 @@ Storybook 是 React,Vue 和 Angular 的強大工具. 它擁有蓬勃發展的開
 
 - [**令人愉快的 Storybook 工作流程**](https://www.chromatic.com/blog/the-delightful-storybook-workflow) 重點介紹 Squarespace,Major League Soccer,Discovery Network 和 Apollo GraphQL 的高速團隊使用的工作流程最佳實踐.
 
-- [**視覺測試手冊**](https://www.learnstorybook.com/visual-testing-handbook/)深入探討將 Storybook 用於視覺化測試元件. 免費的 31 頁電子書.
+- [**視覺測試手冊**](hhttps://storybook.js.org/tutorials/visual-testing-handbook/)深入探討將 Storybook 用於視覺化測試元件. 免費的 31 頁電子書.
 
 ## 誰製作了 LearnStorybook.com?
 

--- a/content/intro-to-storybook/svelte/en/conclusion.md
+++ b/content/intro-to-storybook/svelte/en/conclusion.md
@@ -19,7 +19,7 @@ Want to dive deeper? Here are helpful resources.
 
 - [**The Delightful Storybook Workflow**](https://www.chromatic.com/blog/the-delightful-storybook-workflow) highlights workflow best practices used by high-velocity teams at Squarespace, Major League Soccer, Discovery Network, and Apollo GraphQL.
 
-- [**Visual Testing Handbook**](https://www.learnstorybook.com/visual-testing-handbook/) dives deep into using Storybook to visual test components. Free 31-page ebook.
+- [**Visual Testing Handbook**](https://storybook.js.org/tutorials/visual-testing-handbook/) dives deep into using Storybook to visual test components. Free 31-page ebook.
 
 - [**Storybook Discord chat**](https://discord.gg/UUt2PJb) puts you in contact with the Storybook community. Get and give help to other Storybook users.
 

--- a/content/intro-to-storybook/svelte/en/deploy.md
+++ b/content/intro-to-storybook/svelte/en/deploy.md
@@ -99,7 +99,7 @@ jobs:
       - uses: chromaui/action@v1
         # Options required for Chromatic's GitHub Action
         with:
-          #👇 Chromatic projectToken, see https://www.learnstorybook.com/intro-to-storybook/svelte/en/deploy/ to obtain it
+          #👇 Chromatic projectToken, see https://storybook.js.org/tutorials/intro-to-storybook/svelte/en/deploy/ to obtain it
           projectToken: project-token
           token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/content/intro-to-storybook/svelte/es/conclusion.md
+++ b/content/intro-to-storybook/svelte/es/conclusion.md
@@ -19,7 +19,7 @@ Quieres bucear más profundo? Aquí algunos recursos útiles:
 
 - [**El delicioso flujo de trabajo de Storybook**](https://www.chromatic.com/blog/the-delightful-storybook-workflow) destaca las mejores prácticas del flujo de trabajo utilizado por equipos de alta velocidad en Squarespace, Major League Soccer, Discovery Network y Apollo GraphQL.
 
-- [**Manual de pruebas visuales**](https://www.learnstorybook.com/visual-testing-handbook/) se sumerge profundamente en el uso de Storybook para probar componentes visuales. Libro electrónico gratuito de 31 páginas.
+- [**Manual de pruebas visuales**](https://storybook.js.org/tutorials/visual-testing-handbook/) se sumerge profundamente en el uso de Storybook para probar componentes visuales. Libro electrónico gratuito de 31 páginas.
 
 - [**Storybook Discord**](https://discord.gg/UUt2PJb) lo pondrá en contacto con la comunidad de Storybook. No solo ofrece un medio para ayudarlo, sino también para ayudar a la comunidad.
 

--- a/content/intro-to-storybook/vue/en/conclusion.md
+++ b/content/intro-to-storybook/vue/en/conclusion.md
@@ -19,7 +19,7 @@ Want to dive deeper? Here are helpful resources.
 
 - [**The Delightful Storybook Workflow**](https://www.chromatic.com/blog/the-delightful-storybook-workflow) highlights workflow best practices used by high-velocity teams at Squarespace, Major League Soccer, Discovery Network, and Apollo GraphQL.
 
-- [**Visual Testing Handbook**](https://www.learnstorybook.com/visual-testing-handbook/) dives deep into using Storybook to visual test components. Free 31-page ebook.
+- [**Visual Testing Handbook**](https://storybook.js.org/tutorials/visual-testing-handbook/) dives deep into using Storybook to visual test components. Free 31-page ebook.
 
 - [**Storybook Discord chat**](https://discord.gg/UUt2PJb) puts you in contact with the Storybook community. Get and give help to other Storybook users.
 

--- a/content/intro-to-storybook/vue/en/deploy.md
+++ b/content/intro-to-storybook/vue/en/deploy.md
@@ -100,7 +100,7 @@ jobs:
       - uses: chromaui/action@v1
         # Options required for Chromatic's GitHub Action
         with:
-          #👇 Chromatic projectToken, see https://www.learnstorybook.com/intro-to-storybook/vue/en/deploy/ to obtain it
+          #👇 Chromatic projectToken, see https://storybook.js.org/tutorials/intro-to-storybook/vue/en/deploy/ to obtain it
           projectToken: project-token
           token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/content/intro-to-storybook/vue/es/conclusion.md
+++ b/content/intro-to-storybook/vue/es/conclusion.md
@@ -19,7 +19,7 @@ Quieres bucear más profundo? Aquí algunos recursos útiles:
 
 - [**El delicioso flujo de trabajo de Storybook**](https://www.chromatic.com/blog/the-delightful-storybook-workflow) destaca las mejores prácticas del flujo de trabajo utilizado por equipos de alta velocidad en Squarespace, Major League Soccer, Discovery Network y Apollo GraphQL.
 
-- [**Manual de pruebas visuales**](https://www.learnstorybook.com/visual-testing-handbook/) se sumerge profundamente en el uso de Storybook para probar componentes visuales. Libro electrónico gratuito de 31 páginas.
+- [**Manual de pruebas visuales**](https://storybook.js.org/tutorials/visual-testing-handbook/) se sumerge profundamente en el uso de Storybook para probar componentes visuales. Libro electrónico gratuito de 31 páginas.
 
 - [**Discord de Storybook**](https://discord.gg/UUt2PJb) te pone en contacto con la comunidad de Storybook. Obtenga y brinde ayuda a otros usuarios de Storybook.
 

--- a/content/intro-to-storybook/vue/fr/conclusion.md
+++ b/content/intro-to-storybook/vue/fr/conclusion.md
@@ -19,7 +19,7 @@ Vous voulez en apprendre plus ? Voici des ressources utiles :
 
 - [**The Delightful Storybook Workflow**](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07) met en évidence les meilleures pratiques de workflow utilisées par les équipes de haute vélocité de Squarespace, Major League Soccer, Discovery Network, et Apollo GraphQL.
 
-- [**Visual Testing Handbook**](https://www.learnstorybook.com/visual-testing-handbook/) plonge profondément dans l'utilisation de Storybook pour visualiser les composants de test. Livre numérique gratui de 31 pages.
+- [**Visual Testing Handbook**](https://storybook.js.org/tutorials/visual-testing-handbook/) plonge profondément dans l'utilisation de Storybook pour visualiser les composants de test. Livre numérique gratui de 31 pages.
 
 - [**Le chat Discord de Storybook**](https://discord.gg/UUt2PJb) vous met en contact avec la communauté Storybook. Obtenez et aidez d'autres utilisateurs de Storybook.
 

--- a/content/intro-to-storybook/vue/pt/conclusion.md
+++ b/content/intro-to-storybook/vue/pt/conclusion.md
@@ -21,7 +21,7 @@ Pretende saber mais? Aqui ficam alguns recursos que irão ajudar.
 - [**Manual de testes visuais**](https://www.chromatic.com/blog/the-delightful-storybook-workflow)
   enumera as boas práticas de fluxo de trabalho, usadas por equipas que operam a alta velocidade, tal como por exemplo a SquareSpace, a Major League Soccer, a Discovery Network e Apollo GraphQL.
 
-- [**Visual Testing Handbook**](https://www.learnstorybook.com/visual-testing-handbook/) aprofunda o uso de Storybook para testes visuais. Livro eletrónico livre de 31 páginas.
+- [**Visual Testing Handbook**](https://storybook.js.org/tutorials/visual-testing-handbook/) aprofunda o uso de Storybook para testes visuais. Livro eletrónico livre de 31 páginas.
 
 - [**Discord do Storybook**](https://discord.gg/UUt2PJb) põe-te em contacto direto com a comunidade Storybook. Onde podes oferecer e receber ajuda de outros utilizadores do Storybook.
 


### PR DESCRIPTION
With this pull request the last remnants of the Learnstorybook links are removed from the Intro to Storybook. 

@IvanSotelo @zydmayday and @jeanphibaconnais if you all could pull the new changes I would really appreciate it. 

