### PR TITLE
Chore: (Docs) Intro to Storybook updates for 6.x

### DIFF
--- a/content/intro-to-storybook/angular/en/composite-component.md
+++ b/content/intro-to-storybook/angular/en/composite-component.md
@@ -23,12 +23,9 @@ A composite component isn’t much different than the basic components it contai
 
 Start with a rough implementation of the `TaskList`. You’ll need to import the `Task` component from earlier and pass in the attributes and actions as inputs and events.
 
-```typescript
-// src/app/components/task-list.component.ts
-
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+```ts:title=src/app/components/task-list.component.ts
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { Task } from '../models/task.model';
-
 @Component({
   selector: 'app-task-list',
   template: `
@@ -45,107 +42,105 @@ import { Task } from '../models/task.model';
     </div>
   `,
 })
-export class TaskListComponent implements OnInit {
+export class TaskListComponent {
+  /** The list of tasks */
   @Input() tasks: Task[] = [];
+
+  /** Checks if it's in loading state */
   @Input() loading = false;
 
+  /** Event to change the task to pinned */
   // tslint:disable-next-line: no-output-on-prefix
-  @Output() onPinTask: EventEmitter<any> = new EventEmitter();
+  @Output()
+  onPinTask = new EventEmitter<Event>();
+
+  /** Event to change the task to archived */
   // tslint:disable-next-line: no-output-on-prefix
-  @Output() onArchiveTask: EventEmitter<any> = new EventEmitter();
-
-  constructor() {}
-
-  ngOnInit() {}
+  @Output()
+  onArchiveTask = new EventEmitter<Event>();
 }
 ```
 
 Next create `Tasklist`’s test states in the story file.
 
-```typescript
-// src/app/components/task-list.stories.ts
-
+```ts:title=src/app/components/task-list.stories.ts
 import { moduleMetadata } from '@storybook/angular';
+import { Story, Meta } from '@storybook/angular/types-6-0';
+
 import { CommonModule } from '@angular/common';
+
 import { TaskListComponent } from './task-list.component';
 import { TaskComponent } from './task.component';
-import { taskData, actionsData } from './task.stories';
+
+import * as TaskStories from './task.stories';
 
 export default {
-  title: 'TaskList',
-  excludeStories: /.*Data$/,
+  component: TaskListComponent,
   decorators: [
     moduleMetadata({
-      // imports both components to allow component composition with storybook
+      //👇 Imports both components to allow component composition with storybook
       declarations: [TaskListComponent, TaskComponent],
       imports: [CommonModule],
     }),
   ],
-};
+  title: 'TaskList',
+} as Meta;
 
-export const defaultTasksData = [
-  { ...taskData, id: '1', title: 'Task 1' },
-  { ...taskData, id: '2', title: 'Task 2' },
-  { ...taskData, id: '3', title: 'Task 3' },
-  { ...taskData, id: '4', title: 'Task 4' },
-  { ...taskData, id: '5', title: 'Task 5' },
-  { ...taskData, id: '6', title: 'Task 6' },
-];
-export const withPinnedTasksData = [
-  ...defaultTasksData.slice(0, 5),
-  { id: '6', title: 'Task 6 (pinned)', state: 'TASK_PINNED' },
-];
-// default TaskList state
-export const Default = () => ({
+const Template: Story<TaskListComponent> = args => ({
   component: TaskListComponent,
-  template: `
-  <div style="padding: 3rem">
-    <app-task-list [tasks]="tasks" (onPinTask)="onPinTask($event)" (onArchiveTask)="onArchiveTask($event)"></app-task-list>
-  </div>
-`,
   props: {
-    tasks: defaultTasksData,
-    onPinTask: actionsData.onPinTask,
-    onArchiveTask: actionsData.onArchiveTask,
+    ...args,
+    onPinTask: TaskStories.actionsData.onPinTask,
+    onArchiveTask: TaskStories.actionsData.onArchiveTask,
   },
-});
-// tasklist with pinned tasks
-export const WithPinnedTasks = () => ({
-  component: TaskListComponent,
   template: `
     <div style="padding: 3rem">
-      <app-task-list [tasks]="tasks" (onPinTask)="onPinTask($event)" (onArchiveTask)="onArchiveTask($event)"></app-task-list>
-    </div>
-  `,
-  props: {
-    tasks: withPinnedTasksData,
-    onPinTask: actionsData.onPinTask,
-    onArchiveTask: actionsData.onArchiveTask,
-  },
+      <app-task-list [tasks]="tasks" [loading]=loading (onPinTask)="onPinTask($event)" (onArchiveTask)="onArchiveTask($event)"></app-task-list>
+    </div> `,
 });
-// tasklist in loading state
-export const Loading = () => ({
-  template: `
-        <div style="padding: 3rem">
-          <app-task-list [tasks]="[]" loading="true" (onPinTask)="onPinTask($event)" (onArchiveTask)="onArchiveTask($event)"></app-task-list>
-        </div>
-      `,
-});
-// tasklist no tasks
-export const Empty = () => ({
-  template: `
-        <div style="padding: 3rem">
-          <app-task-list [tasks]="[]" (onPinTask)="onPinTask($event)" (onArchiveTask)="onArchiveTask($event)"></app-task-list>
-        </div>
-      `,
-});
+
+export const Default = Template.bind({});
+Default.args = {
+  tasks: [
+    { ...TaskStories.Default.args.task, id: '1', title: 'Task 1' },
+    { ...TaskStories.Default.args.task, id: '2', title: 'Task 2' },
+    { ...TaskStories.Default.args.task, id: '3', title: 'Task 3' },
+    { ...TaskStories.Default.args.task, id: '4', title: 'Task 4' },
+    { ...TaskStories.Default.args.task, id: '5', title: 'Task 5' },
+    { ...TaskStories.Default.args.task, id: '6', title: 'Task 6' },
+  ],
+};
+
+export const WithPinnedTasks = Template.bind({});
+WithPinnedTasks.args = {
+  // Shaping the stories through args composition.
+  // Inherited data coming from the Default story.
+  tasks: [
+    ...Default.args.tasks.slice(0, 5),
+    { id: '6', title: 'Task 6 (pinned)', state: 'TASK_PINNED' },
+  ],
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  tasks: [],
+  loading: true,
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+  // Shaping the stories through args composition.
+  // Inherited data coming from the Loading story.
+  ...Loading.args,
+  loading: false,
+};
 ```
 
 <div class="aside">
-💡 <a href="https://storybook.js.org/docs/angular/writing-stories/decorators"><b>Decorators</b></a> are a way to provide arbitrary wrappers to stories. In this case we’re using a decorator `key` on the default export to add some `padding` around the rendered component. They can also be used to wrap stories in “providers” –i.e. library components that set React context.
+💡 <a href="https://storybook.js.org/docs/angular/writing-stories/decorators"><b>Decorators</b></a> are a way to provide arbitrary wrappers to stories. In this case we’re using a decorator `key` on the default export to configure the necessary modules and components. They can also be used to wrap stories in “providers” –i.e. library components that set React context.
 </div>
 
-`taskData` supplies the shape of a `Task` that we created and exported from the `task.stories.ts` file. Similarly, `actionsData` defines the actions (mocked callbacks) that a `TaskComponent` expects, which the `TaskListComponent` also needs.
+By importing `TaskStories`, we were able to [compose](https://storybook.js.org/docs/angular/writing-stories/args#args-composition) the arguments (args for short) in our stories with minimal effort. That way the data and actions (mocked callbacks) expected by both components is preserved.
 
 Now check Storybook for the new `TaskList` stories.
 
@@ -160,41 +155,45 @@ Now check Storybook for the new `TaskList` stories.
 
 Our component is still rough but now we have an idea of the stories to work toward. You might be thinking that the `.list-items` wrapper is overly simplistic. You're right – in most cases we wouldn’t create a new component just to add a wrapper. But the **real complexity** of `TaskListComponent` is revealed in the edge cases `WithPinnedTasks`, `loading`, and `empty`.
 
-```typescript
-// src/app/components/task-list.component.ts
-
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+```diff:title=src/app/components/task-list.component.ts
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { Task } from '../models/task.model';
 
 @Component({
   selector: 'app-task-list',
   template: `
-    <div class="list-items">
-      <app-task
-        *ngFor="let task of tasksInOrder"
-        [task]="task"
-        (onArchiveTask)="onArchiveTask.emit($event)"
-        (onPinTask)="onPinTask.emit($event)"
-      >
-      </app-task>
++   <div class="list-items">
++     <app-task
++       *ngFor="let task of tasksInOrder"
++       [task]="task"
++       (onArchiveTask)="onArchiveTask.emit($event)"
++       (onPinTask)="onPinTask.emit($event)"
++     >
++     </app-task>
 
-      <div *ngIf="tasksInOrder.length === 0 && !loading" class="wrapper-message">
-        <span class="icon-check"></span>
-        <div class="title-message">You have no tasks</div>
-        <div class="subtitle-message">Sit back and relax</div>
-      </div>
++     <div *ngIf="tasksInOrder.length === 0 && !loading" class="wrapper-message">
++       <span class="icon-check"></span>
++       <div class="title-message">You have no tasks</div>
++       <div class="subtitle-message">Sit back and relax</div>
++     </div>
 
-      <div *ngIf="loading">
-        <div *ngFor="let i of [1, 2, 3, 4, 5, 6]" class="loading-item">
-          <span class="glow-checkbox"></span>
-          <span class="glow-text"> <span>Loading</span> <span>cool</span> <span>state</span> </span>
-        </div>
-      </div>
-    </div>
++     <div *ngIf="loading">
++       <div *ngFor="let i of [1, 2, 3, 4, 5, 6]" class="loading-item">
++         <span class="glow-checkbox"></span>
++         <span class="glow-text"> <span>Loading</span> <span>cool</span> <span>state</span> </span>
++       </div>
++     </div>
++   </div>
   `,
 })
-export class TaskListComponent implements OnInit {
-  tasksInOrder: Task[] = [];
+export class TaskListComponent {
+- @Input() tasks: Task[] = [];
+
++  /**
++  * Component property to define ordering of tasks
++  */
++ tasksInOrder: Task[] = [];
+
   @Input() loading = false;
 
   // tslint:disable-next-line: no-output-on-prefix
@@ -203,17 +202,13 @@ export class TaskListComponent implements OnInit {
   // tslint:disable-next-line: no-output-on-prefix
   @Output() onArchiveTask: EventEmitter<any> = new EventEmitter();
 
-  @Input()
-  set tasks(arr: Task[]) {
-    this.tasksInOrder = [
-      ...arr.filter(t => t.state === 'TASK_PINNED'),
-      ...arr.filter(t => t.state !== 'TASK_PINNED'),
-    ];
-  }
-
-  constructor() {}
-
-  ngOnInit() {}
++ @Input()
++ set tasks(arr: Task[]) {
++   this.tasksInOrder = [
++     ...arr.filter(t => t.state === 'TASK_PINNED'),
++     ...arr.filter(t => t.state !== 'TASK_PINNED'),
++   ];
++ }
 }
 ```
 
@@ -250,21 +245,22 @@ So, to avoid this problem, we can use Jest to render the story to the DOM and ru
 
 Create a test file called `task-list.component.spec.ts`. Here we’ll build out our tests that make assertions about the output.
 
-```typescript
-// src/app/components/task-list.component.spec.ts
-
+```ts:title=src/app/components/task-list.component.spec.ts
 import { render } from '@testing-library/angular';
+
 import { TaskListComponent } from './task-list.component';
 import { TaskComponent } from './task.component';
-import { withPinnedTasksData } from './task-list.stories';
+
+//👇 Our story imported here
+import { WithPinnedTasks } from './task-list.stories';
+
 describe('TaskList component', () => {
   it('renders pinned tasks at the start of the list', async () => {
     const mockedActions = jest.fn();
     const tree = await render(TaskListComponent, {
       declarations: [TaskComponent],
       componentProperties: {
-        tasks: withPinnedTasksData,
-        loading: false,
+        ...WithPinnedTasks.args,
         onPinTask: {
           emit: mockedActions,
         } as any,

--- a/content/intro-to-storybook/angular/en/data.md
+++ b/content/intro-to-storybook/angular/en/data.md
@@ -23,12 +23,11 @@ npm install @ngxs/store @ngxs/logger-plugin @ngxs/devtools-plugin
 
 Then we'll construct a straightforward store that responds to actions that change the state of tasks, in a file called `src/app/state/task.state.ts` (intentionally kept simple):
 
-```typescript
-// src/app/state/task.state.ts
+```ts:title=src/app/state/task.state.ts
 import { State, Selector, Action, StateContext } from '@ngxs/store';
 import { Task } from '../models/task.model';
 
-// defines the actions available to the app
+// Defines the actions available to the app
 export const actions = {
   ARCHIVE_TASK: 'ARCHIVE_TASK',
   PIN_TASK: 'PIN_TASK',
@@ -59,7 +58,7 @@ export class TaskStateModel {
   entities: { [id: number]: Task };
 }
 
-// sets the default state
+// Sets the default state
 @State<TaskStateModel>({
   name: 'tasks',
   defaults: {
@@ -73,7 +72,7 @@ export class TasksState {
     return Object.keys(entities).map(id => entities[+id]);
   }
 
-  // triggers the PinTask action, similar to redux
+  // Triggers the PinTask action, similar to redux
   @Action(PinTask)
   pinTask({ patchState, getState }: StateContext<TaskStateModel>, { payload }: PinTask) {
     const state = getState().entities;
@@ -87,7 +86,7 @@ export class TasksState {
       entities,
     });
   }
-  // triggers the archiveTask action, similar to redux
+  // Triggers the archiveTask action, similar to redux
   @Action(ArchiveTask)
   archiveTask({ patchState, getState }: StateContext<TaskStateModel>, { payload }: ArchiveTask) {
     const state = getState().entities;
@@ -110,27 +109,25 @@ We're going to update our `TaskListComponent` to read data from the store, but f
 
 In `src/app/components/pure-task-list.component.ts`:
 
-```typescript
-//src/app/components/pure-task-list.component.ts
+```diff:title=src/app/components/pure-task-list.component.ts
 
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { Task } from '../models/task.model';
-
 @Component({
-  selector: 'app-pure-task-list',
+- selector:'app-task-list',
++ selector: 'app-pure-task-list',
   // same content as before with the task-list.component.ts
 })
-export class PureTaskListComponent implements OnInit {
+- export class TaskListComponent {
++ export class PureTaskListComponent {
   // same content as before with the task-list.component.ts
-}
+ }
 ```
 
 Afterwards we change `src/app/components/task-list.component.ts` to the following:
 
-```typescript
-// src/app/components/task-list.component.ts
-
-import { Component, OnInit } from '@angular/core';
+```ts:title=src/app/components/task-list.component.ts
+import { Component } from '@angular/core';
 import { Select, Store } from '@ngxs/store';
 import { TasksState, ArchiveTask, PinTask } from '../state/task.state';
 import { Task } from '../models/task.model';
@@ -146,16 +143,21 @@ import { Observable } from 'rxjs';
     ></app-pure-task-list>
   `,
 })
-export class TaskListComponent implements OnInit {
+export class TaskListComponent {
   @Select(TasksState.getAllTasks) tasks$: Observable<Task[]>;
 
   constructor(private store: Store) {}
 
-  ngOnInit() {}
+  /**
+   * Component method to trigger the archiveTask event
+   */
   archiveTask(id: string) {
     this.store.dispatch(new ArchiveTask(id));
   }
 
+  /**
+   * Component method to trigger the pinTask event
+   */
   pinTask(id: string) {
     this.store.dispatch(new PinTask(id));
   }
@@ -166,9 +168,7 @@ Now we're going to create a angular module to bridge the components and the stor
 
 Create a new file called `task.module.ts` inside the `components` folder and add the following:
 
-```typescript
-//src/app/components/task.module.ts
-
+```ts:title=src/app/components/task.module.ts
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { NgxsModule } from '@ngxs/store';
@@ -189,25 +189,25 @@ export class TaskModule {}
 
 All the pieces are in place, all that is needed is wire the store to the app. In our top level module (`src/app/app.module.ts`):
 
-```typescript
-// src/app/app.module.ts
-
+```diff:title=src/app/app.module.ts
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { TaskModule } from './components/task.module';
-import { NgxsModule } from '@ngxs/store';
-import { NgxsReduxDevtoolsPluginModule } from '@ngxs/devtools-plugin';
-import { NgxsLoggerPluginModule } from '@ngxs/logger-plugin';
+
++ import { TaskModule } from './components/task.module';
++ import { NgxsModule } from '@ngxs/store';
++ import { NgxsReduxDevtoolsPluginModule } from '@ngxs/devtools-plugin';
++ import { NgxsLoggerPluginModule } from '@ngxs/logger-plugin';
+
 import { AppComponent } from './app.component';
 
 @NgModule({
   declarations: [AppComponent],
   imports: [
     BrowserModule,
-    TaskModule,
-    NgxsModule.forRoot([]),
-    NgxsReduxDevtoolsPluginModule.forRoot(),
-    NgxsLoggerPluginModule.forRoot(),
++   TaskModule,
++   NgxsModule.forRoot([]),
++   NgxsReduxDevtoolsPluginModule.forRoot(),
++   NgxsLoggerPluginModule.forRoot(),
   ],
   providers: [],
   bootstrap: [AppComponent],
@@ -217,83 +217,75 @@ export class AppModule {}
 
 The reason to keep the presentational version of the `TaskList` separate is because it is easier to test and isolate. As it doesn't rely on the presence of a store it is much easier to deal with from a testing perspective. Let's also rename `src/app/components/task-list.stories.ts` into `src/app/components/pure-task-list.stories.ts`, and ensure our stories use the presentational version:
 
-```typescript
-// src/app/components/pure-task-list.stories.ts
-
+```ts:title=src/app/components/pure-task-list.stories.ts
 import { moduleMetadata } from '@storybook/angular';
+import { Story, Meta } from '@storybook/angular/types-6-0';
+
 import { CommonModule } from '@angular/common';
+
 import { PureTaskListComponent } from './pure-task-list.component';
 import { TaskComponent } from './task.component';
-import { taskData, actionsData } from './task.stories';
+import * as TaskStories from './task.stories';
 
 export default {
-  title: 'PureTaskList',
-  excludeStories: /.*Data$/,
+  component: PureTaskListComponent,
   decorators: [
     moduleMetadata({
-      // imports both components to allow component composition with storybook
+      //👇 Imports both components to allow component composition with storybook
       declarations: [PureTaskListComponent, TaskComponent],
       imports: [CommonModule],
     }),
   ],
-};
+  title: 'PureTaskList',
+} as Meta;
 
-export const defaultTasksData = [
-  { ...taskData, id: '1', title: 'Task 1' },
-  { ...taskData, id: '2', title: 'Task 2' },
-  { ...taskData, id: '3', title: 'Task 3' },
-  { ...taskData, id: '4', title: 'Task 4' },
-  { ...taskData, id: '5', title: 'Task 5' },
-  { ...taskData, id: '6', title: 'Task 6' },
-];
-export const withPinnedTasksData = [
-  ...defaultTasksData.slice(0, 5),
-  { id: '6', title: 'Task 6 (pinned)', state: 'TASK_PINNED' },
-];
-// default TaskList state
-export const Default = () => ({
+const Template: Story<PureTaskListComponent> = args => ({
   component: PureTaskListComponent,
-  template: `
-  <div style="padding: 3rem">
-    <app-pure-task-list [tasks]="tasks" (onPinTask)="onPinTask($event)" (onArchiveTask)="onArchiveTask($event)"></app-pure-task-list>
-  </div>
-`,
   props: {
-    tasks: defaultTasksData,
-    onPinTask: actionsData.onPinTask,
-    onArchiveTask: actionsData.onArchiveTask,
+    ...args,
+    onPinTask: TaskStories.actionsData.onPinTask,
+    onArchiveTask: TaskStories.actionsData.onArchiveTask,
   },
-});
-// tasklist with pinned tasks
-export const WithPinnedTasks = () => ({
-  component: PureTaskListComponent,
   template: `
     <div style="padding: 3rem">
-      <app-pure-task-list [tasks]="tasks" (onPinTask)="onPinTask($event)" (onArchiveTask)="onArchiveTask($event)"></app-pure-task-list>
-    </div>
-  `,
-  props: {
-    tasks: withPinnedTasksData,
-    onPinTask: actionsData.onPinTask,
-    onArchiveTask: actionsData.onArchiveTask,
-  },
+      <app-pure-task-list [tasks]="tasks" [loading]=loading (onPinTask)="onPinTask($event)" (onArchiveTask)="onArchiveTask($event)"></app-pure-task-list>
+    </div> `,
 });
-// tasklist in loading state
-export const Loading = () => ({
-  template: `
-        <div style="padding: 3rem">
-          <app-pure-task-list [tasks]="[]" loading="true" (onPinTask)="onPinTask($event)" (onArchiveTask)="onArchiveTask($event)"></app-pure-task-list>
-        </div>
-      `,
-});
-// tasklist no tasks
-export const Empty = () => ({
-  template: `
-        <div style="padding: 3rem">
-          <app-pure-task-list [tasks]="[]" (onPinTask)="onPinTask($event)" (onArchiveTask)="onArchiveTask($event)"></app-pure-task-list>
-        </div>
-      `,
-});
+
+export const Default = Template.bind({});
+Default.args = {
+  tasks: [
+    { ...TaskStories.Default.args.task, id: '1', title: 'Task 1' },
+    { ...TaskStories.Default.args.task, id: '2', title: 'Task 2' },
+    { ...TaskStories.Default.args.task, id: '3', title: 'Task 3' },
+    { ...TaskStories.Default.args.task, id: '4', title: 'Task 4' },
+    { ...TaskStories.Default.args.task, id: '5', title: 'Task 5' },
+    { ...TaskStories.Default.args.task, id: '6', title: 'Task 6' },
+  ],
+};
+export const WithPinnedTasks = Template.bind({});
+WithPinnedTasks.args = {
+  // Shaping the stories through args composition.
+  // Inherited data coming from the Default story.
+  tasks: [
+    ...Default.args.tasks.slice(0, 5),
+    { id: '6', title: 'Task 6 (pinned)', state: 'TASK_PINNED' },
+  ],
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  tasks: [],
+  loading: true,
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+  // Shaping the stories through args composition.
+  // Inherited data coming from the Loading story.
+  ...Loading.args,
+  loading: false,
+};
 ```
 
 <video autoPlay muted playsInline loop>
@@ -305,21 +297,24 @@ export const Empty = () => ({
 
 Similarly, we need to use `PureTaskListComponent` in our Jest test:
 
-```typescript
-// src/app/components/task-list.component.spec.ts
-
+```diff:title= src/app/components/task-list.component.spec.ts
 import { render } from '@testing-library/angular';
-import { PureTaskListComponent } from './pure-task-list.component';
+- import { TaskListComponent } from './task-list.component.ts';
++ import { PureTaskListComponent } from './pure-task-list.component';
+
 import { TaskComponent } from './task.component';
-import { withPinnedTasksData } from './pure-task-list.stories';
-describe('PureTaskList component', () => {
+
+//👇 Our story imported here
+- import { WithPinnedTasks } from './task-list.stories';
++ import { WithPinnedTasks } from './pure-task-list.stories';
+
+describe('TaskList component', () => {
   it('renders pinned tasks at the start of the list', async () => {
     const mockedActions = jest.fn();
     const tree = await render(PureTaskListComponent, {
       declarations: [TaskComponent],
       componentProperties: {
-        tasks: withPinnedTasksData,
-        loading: false,
+        ...WithPinnedTasks.args,
         onPinTask: {
           emit: mockedActions,
         } as any,

--- a/content/intro-to-storybook/angular/en/deploy.md
+++ b/content/intro-to-storybook/angular/en/deploy.md
@@ -1,81 +1,139 @@
 ---
 title: 'Deploy Storybook'
 tocTitle: 'Deploy'
-description: 'Deploy Storybook online with GitHub and Netlify'
+description: 'Learn how to deploy Storybook online'
 ---
 
-In this tutorial we ran Storybook on our development machine. You may also want to share that Storybook with the team, especially the non-technical members. Thankfully, it’s easy to deploy Storybook online.
-
-<div class="aside">
-<strong>Did you setup Chromatic testing earlier?</strong>
-<br/>
-🎉 Your stories are already deployed! Chromatic securely indexes your stories online and tracks them across branches and commits. Skip this chapter and go to the <a href="/intro-to-storybook/angular/en/conclusion">conclusion</a>.
-</div>
+Throughout this tutorial, we built components on our local development machine. At some point, we'll need to share our work to get team feedback. Let's deploy Storybook online to help teammates review UI implementation.
 
 ## Exporting as a static app
 
-To deploy Storybook we first need to export it as a static web app. This functionality is already built into Storybook out of the box.
+To deploy Storybook we first need to export it as a static web app. This functionality is already built-in to Storybook and pre-configured.
 
-Now when you build Storybook via `npm run build-storybook`, it will output a static Storybook in the `storybook-static` directory.
+Running `npm run build-storybook` will output a static Storybook in the `storybook-static` directory, which can then be deployed to any static site hosting service.
 
-## Continuous deploy
+## Publish Storybook
 
-We want to share the latest version of components whenever we push code. To do this we need to continuous deploy Storybook. We’ll rely on GitHub and Netlify to deploy our static site. We’re using the Netlify free plan.
-
-### GitHub
-
-If you're following along from the previous testing chapter jump to setting up a repository on GitHub.
-
-When the project was initialized with Angular CLI, a local repository was already setup for you. At this stage we already have a set of commits that we can push to a remote repository.
+This tutorial uses <a href="https://www.chromatic.com/">Chromatic</a>, a free publishing service made by the Storybook maintainers. It allows us to deploy and host our Storybook safely and securely in the cloud.
 
 ### Setup a repository in GitHub
 
-Go to GitHub and setup a repository [here](https://github.com/new). Name your repo “taskbox”.
+Before we begin, our local code needs to sync with a remote version control service. When our project was initialized in the [Get started chapter](/intro-to-storybook/angular/en/get-started), we already initialized a local repository. At this stage we already have a set of commits that we can push to a remote one.
+
+Go to GitHub and create a new repository for our project [here](https://github.com/new). Name the repo “taskbox”, same as our local project.
 
 ![GitHub setup](/intro-to-storybook/github-create-taskbox.png)
 
-In the new repo setup copy the origin URL of the repo and add it to your git project with this command:
+In the new repo, grab the origin URL of the repo and add it to your git project with this command:
 
 ```bash
 $ git remote add origin https://github.com/<your username>/taskbox.git
 ```
 
-Finally push the repo to GitHub
+Finally, push our local repo to the remote repo on GitHub with:
 
 ```bash
 $ git push -u origin main
 ```
 
-### Netlify
+### Get Chromatic
 
-Netlify has a continuous deployment service built in which will allow us to deploy Storybook without needing to configure our own CI.
+Add the package as a development dependency.
 
-<div class="aside">
-If you use CI at your company, add a deploy script to your config that uploads <code>storybook-static</code> to a static hosting service like S3.
-</div>
+```bash
+npm install -D chromatic
+```
 
-[Create an account on Netlify](https://app.netlify.com/start) and click to “create site”.
+Once the package is installed, [login to Chromatic](https://www.chromatic.com/start) with your GitHub account (Chromatic will only ask for lightweight permissions). Then we'll create a new project called name "taskbox" and sync it with the GithHub repository we've setup.
 
-![Netlify create site](/intro-to-storybook/netlify-create-site.png)
+Click `Choose GitHub repo` under collaborators and select your repo.
 
-Next click the GitHub button to connect Netlify to GitHub. This allows it to access our remote Taskbox repo.
+<video autoPlay muted playsInline loop style="width:520px; margin: 0 auto;">
+  <source
+    src="/intro-to-storybook/chromatic-setup-learnstorybook.mp4"
+    type="video/mp4"
+  />
+</video>
 
-Now select the taskbox GitHub repo from the list of options.
+Copy the unique `project-token` that was generated for your project. Then execute it, by issuing the following in the command line, to build and deploy our Storybook. Make sure to replace `project-token` with your project token.
 
-![Netlify connect to repo](/intro-to-storybook/netlify-account-picker.png)
+```bash
+npx chromatic --project-token=<project-token>
+```
 
-Configure Netlify by highlighting which build command to run in its CI and which directory the static site is outputted in. For branch choose `main`. Directory is `storybook-static`. Build command use `npm run build-storybook`.
+![Chromatic running](/intro-to-storybook/chromatic-manual-storybook-console-log.png)
 
-![Netlify settings](/intro-to-storybook/netlify-settings-npm.png)
+When finished, you'll get a link `https://random-uuid.chromatic.com` to your published Storybook. Share the link with your team to get feedback.
 
-<div class="aside"><p>Should your deployment fail with Netlify, add the <a href="https://storybook.js.org/docs/configurations/cli-options/#for-build-storybook">--quiet </a> flag to your <code>build-storybook</code> script.</p></div>
+![Storybook deployed with chromatic package](/intro-to-storybook/chromatic-manual-storybook-deploy-6-0.png)
 
-Submit the form to build and deploy the code on the `main` branch of taskbox.
+Hooray! We published Storybook with one command, but manually running a command every time we want to get feedback on UI implementation is repetitive. Ideally, we'd publish the latest version of components whenever we push code. We'll need to continuously deploy Storybook.
 
-When that's finished we'll see a confirmation message on Netlify with a link to Taskbox’ Storybook online. If you're following along, your deployed Storybook should be online [like so](https://clever-banach-415c03.netlify.com/).
+## Continuous deployment with Chromatic
 
-![Netlify Storybook deploy](/intro-to-storybook/netlify-storybook-deploy.png)
+Now that our project is hosted in a GitHub repository, we can use a continuous integration(CI) service to deploy our Storybook automatically. [GitHub Actions](https://github.com/features/actions) is a free CI service that's built into GitHub that makes automatic publishing easy.
 
-We finished setting up continuous deployment of your Storybook! Now we can share our stories with teammates via a link.
+### Add a GitHub Action to deploy Storybook
 
-This is helpful for visual review as part of the standard app development process or simply to show off work 💅.
+In the root folder of our project, create a new directory called `.github` then create another `workflows` directory inside of it.
+
+Create a new file called `chromatic.yml` like the one below. Replace `project-token` with your project token.
+
+```yaml:title=.github/workflows/chromatic.yml
+# Workflow name
+name: 'Chromatic Deployment'
+
+# Event for the workflow
+on: push
+
+# List of jobs
+jobs:
+  test:
+    # Operating System
+    runs-on: ubuntu-latest
+    # Job steps
+    steps:
+      - uses: actions/checkout@v1
+      - run: npm install
+        #👇 Adds Chromatic as a step in the workflow
+      - uses: chromaui/action@v1
+        # Options required for Chromatic's GitHub Action
+        with:
+          #👇 Chromatic projectToken, see https://storybook.js.org/tutorials/intro-to-storybook/angular/en/deploy/ to obtain it
+          projectToken: project-token
+          token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+<div class="aside"><p>💡 For brevity purposes <a href="https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets">GitHub secrets</a> weren't mentioned. Secrets are secure environment variables provided by GitHub so that you don't need to hard code the <code>project-token</code>.</p></div>
+
+### Commit the action
+
+In the command line, issue the following command to add the changes that were done:
+
+```bash
+git add .
+```
+
+Then commit them by issuing:
+
+```bash
+git commit -m "GitHub action setup"
+```
+
+Finally push them to the remote repository with:
+
+```bash
+git push origin main
+```
+
+Once you’ve set up the GitHub action. Your Storybook will be deployed to Chromatic whenever you push code. You can find all the published Storybook’s on your project’s build screen in Chromatic.
+
+![Chromatic user dashboard](/intro-to-storybook/chromatic-user-dashboard.png)
+
+Click the latest build, it should be the one at the top.
+
+Then, click the `View Storybook` button to see the latest version of your Storybook.
+
+![Storybook link on Chromatic](/intro-to-storybook/chromatic-build-storybook-link.png)
+
+Use the link and share it with your team members. This is helpful as a part of the standard app development process or simply to show off work 💅.

--- a/content/intro-to-storybook/angular/en/screen.md
+++ b/content/intro-to-storybook/angular/en/screen.md
@@ -15,9 +15,7 @@ As our app is very simple, the screen we’ll build is pretty trivial, simply wr
 
 Let's start by updating the store ( in `src/app/state/task.state.ts`) to include the error field we want:
 
-```typescript
-// src/app/state/task.state.ts
-
+```diff:title=src/app/state/task.state.ts
 import { State, Selector, Action, StateContext } from '@ngxs/store';
 import { Task } from '../models/task.model';
 
@@ -25,8 +23,8 @@ import { Task } from '../models/task.model';
 export const actions = {
   ARCHIVE_TASK: 'ARCHIVE_TASK',
   PIN_TASK: 'PIN_TASK',
-  // defines the new error field we need
-  ERROR: 'APP_ERROR',
+  // Defines the new error field we need
++ ERROR: 'APP_ERROR',
 };
 
 export class ArchiveTask {
@@ -40,11 +38,11 @@ export class PinTask {
 
   constructor(public payload: string) {}
 }
-// the class definition for our error field
-export class AppError {
-  static readonly type = actions.ERROR;
-  constructor(public payload: boolean) {}
-}
++ // The class definition for our error field
++ export class AppError {
++   static readonly type = actions.ERROR;
++   constructor(public payload: boolean) {}
++ }
 
 // The initial state of our store when the app loads.
 // Usually you would fetch this from a server
@@ -57,15 +55,15 @@ const defaultTasks = {
 
 export class TaskStateModel {
   entities: { [id: number]: Task };
-  error: boolean;
++ error: boolean;
 }
 
-// sets the default state
+// Sets the default state
 @State<TaskStateModel>({
   name: 'tasks',
   defaults: {
     entities: defaultTasks,
-    error: false,
++   error: false,
   },
 })
 export class TasksState {
@@ -75,14 +73,14 @@ export class TasksState {
     return Object.keys(entities).map(id => entities[+id]);
   }
 
-  // defines a new selector for the error field
+  // Defines a new selector for the error field
   @Selector()
   static getError(state: TaskStateModel) {
     const { error } = state;
     return error;
   }
   //
-  // triggers the PinTask action, similar to redux
+  // Triggers the PinTask action, similar to redux
   @Action(PinTask)
   pinTask({ patchState, getState }: StateContext<TaskStateModel>, { payload }: PinTask) {
     const state = getState().entities;
@@ -96,7 +94,7 @@ export class TasksState {
       entities,
     });
   }
-  // triggers the PinTask action, similar to redux
+  // Triggers the PinTask action, similar to redux
   @Action(ArchiveTask)
   archiveTask({ patchState, getState }: StateContext<TaskStateModel>, { payload }: ArchiveTask) {
     const state = getState().entities;
@@ -111,23 +109,21 @@ export class TasksState {
     });
   }
 
-  // function to handle how the state should be updated when the action is triggered
-  @Action(AppError)
-  setAppError({ patchState, getState }: StateContext<TaskStateModel>, { payload }: AppError) {
-    const state = getState();
-    patchState({
-      error: !state.error,
-    });
-  }
++ // Function to handle how the state should be updated when the action is triggered
++ @Action(AppError)
++ setAppError({ patchState, getState }: StateContext<TaskStateModel>, { payload }: AppError) {
++   const state = getState();
++   patchState({
++     error: !state.error,
++   });
++ }
 }
 ```
 
 The store is updated with the new field. Let's create a presentational `pure-inbox-screen.component.ts` in `src/app/components/` folder:
 
-```typescript
-// src/app/components/pure-inbox-screen.component.ts
-
-import { Component, OnInit, Input } from '@angular/core';
+```ts:title=src/app/components/pure-inbox-screen.component.ts
+import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'app-pure-inbox-screen',
@@ -150,21 +146,15 @@ import { Component, OnInit, Input } from '@angular/core';
     </div>
   `,
 })
-export class PureInboxScreenComponent implements OnInit {
+export class PureInboxScreenComponent {
   @Input() error: any;
-
-  constructor() {}
-
-  ngOnInit() {}
 }
 ```
 
 Then we can create the container, which like before, grabs the data for `PureInboxScreenComponent`. In a new file called `inbox-screen.component.ts`:
 
-```typescript
-// src/app/components/inbox-screen.component.ts
-
-import { Component, OnInit } from '@angular/core';
+```ts:title=src/app/components/inbox-screen.component.ts
+import { Component } from '@angular/core';
 import { Select } from '@ngxs/store';
 import { TasksState } from '../state/task.state';
 import { Observable } from 'rxjs';
@@ -175,38 +165,33 @@ import { Observable } from 'rxjs';
     <app-pure-inbox-screen [error]="error$ | async"></app-pure-inbox-screen>
   `,
 })
-export class InboxScreenComponent implements OnInit {
+export class InboxScreenComponent {
   @Select(TasksState.getError) error$: Observable<any>;
-
-  constructor() {}
-
-  ngOnInit() {}
 }
 ```
 
 We also need to change the `AppComponent` to render the `InboxScreenComponent` (eventually we would use a router to choose the correct screen, but let's not worry about that here):
 
-```typescript
-//src/app/app.component.ts
-
+```diff:title=src/app/app.component.ts
 import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-root',
-  template: `
-    <app-inbox-screen></app-inbox-screen>
-  `,
+- templateUrl: './app.component.html',
+- styleUrls: ['./app.component.css']
++ template: `
++   <app-inbox-screen></app-inbox-screen>
++ `,
 })
 export class AppComponent {
-  title = 'taskbox';
+- title = 'intro-storybook-angular-template';
++ title = 'taskbox';
 }
 ```
 
 And finally the `app.module.ts`:
 
-```typescript
-//src/app/app.module.ts
-
+```diff:title=src/app/app.module.ts
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { TaskModule } from './components/task.module';
@@ -214,11 +199,12 @@ import { NgxsModule } from '@ngxs/store';
 import { NgxsReduxDevtoolsPluginModule } from '@ngxs/devtools-plugin';
 import { NgxsLoggerPluginModule } from '@ngxs/logger-plugin';
 import { AppComponent } from './app.component';
-import { InboxScreenComponent } from './components/inbox-screen.component';
-import { PureInboxScreenComponent } from './components/pure-inbox-screen.component';
+
++ import { InboxScreenComponent } from './components/inbox-screen.component';
++ import { PureInboxScreenComponent } from './components/pure-inbox-screen.component';
 
 @NgModule({
-  declarations: [AppComponent, InboxScreenComponent, PureInboxScreenComponent],
++ declarations: [AppComponent, InboxScreenComponent, PureInboxScreenComponent],
   imports: [
     BrowserModule,
     TaskModule,
@@ -242,32 +228,34 @@ When placing the `TaskListComponent` into Storybook, we were able to dodge this 
 
 However, for the `PureInboxScreenComponent` we have a problem because although the `PureInboxScreenComponent` itself is presentational, its child, the `TaskListComponent`, is not. In a sense the `PureInboxScreenComponent` has been polluted by “container-ness”. So when we setup our stories in `pure-inbox-screen.stories.ts`:
 
-```typescript
-// src/app/components/pure-inbox-screen.stories.ts
-
+```ts:title=src/app/components/pure-inbox-screen.stories.ts
 import { moduleMetadata } from '@storybook/angular';
+import { Story, Meta } from '@storybook/angular/types-6-0';
+
 import { PureInboxScreenComponent } from './pure-inbox-screen.component';
 import { TaskModule } from './task.module';
+
 export default {
   title: 'PureInboxScreen',
+  component: PureInboxScreenComponent,
   decorators: [
     moduleMetadata({
       imports: [TaskModule],
     }),
   ],
-};
-// inbox screen default state
-export const Default = () => ({
+} as Meta;
+
+const Template: Story<PureInboxScreenComponent> = args => ({
   component: PureInboxScreenComponent,
+  props: args,
 });
 
-// inbox screen error state
-export const error = () => ({
-  component: PureInboxScreenComponent,
-  props: {
-    error: true,
-  },
-});
+export const Default = Template.bind({});
+
+export const Error = Template.bind({});
+Error.args = {
+  error: true,
+};
 ```
 
 We see that our stories are broken now. This is due to the fact that both depend on our store and, even though, we're using a "pure" component for the error both stories still need the context.
@@ -284,35 +272,39 @@ As an aside, passing data down the hierarchy is a legitimate approach, especiall
 
 The good news is that is pretty straightforward to supply the `Store` to the `PureInboxScreenComponent` in a story! We can supply the `Store` provided in a decorator:
 
-```typescript
-// src/app/components/pure-inbox-screen.stories.ts
-
+```diff:title=src/app/components/pure-inbox-screen.stories.ts
 import { moduleMetadata } from '@storybook/angular';
+import { Story, Meta } from '@storybook/angular/types-6-0';
+
 import { PureInboxScreenComponent } from './pure-inbox-screen.component';
 import { TaskModule } from './task.module';
-import { Store, NgxsModule } from '@ngxs/store';
-import { TasksState } from '../state/task.state';
+
++ import { Store, NgxsModule } from '@ngxs/store';
++ import { TasksState } from '../state/task.state';
+
 export default {
   title: 'PureInboxScreen',
+  component:PureInboxScreenComponent,
   decorators: [
     moduleMetadata({
-      imports: [TaskModule, NgxsModule.forRoot([TasksState])],
-      providers: [Store],
+-     imports: [TaskModule],
++     imports: [TaskModule, NgxsModule.forRoot([TasksState])],
++     providers: [Store],
     }),
   ],
-};
-// inbox screen default state
-export const Default = () => ({
+} as Meta;
+
+const Template: Story<PureInboxScreenComponent> = (args) => ({
   component: PureInboxScreenComponent,
+  props: args,
 });
 
-// inbox screen error state
-export const error = () => ({
-  component: PureInboxScreenComponent,
-  props: {
-    error: true,
-  },
-});
+export const Default = Template.bind({});
+
+export const Error = Template.bind({});
+Error.args = {
+  error: true,
+};
 ```
 
 Similar approaches exist to provide mocked context for other data libraries, such as [@ngrx](https://github.com/ngrx/platform) or [Apollo](https://www.apollographql.com/docs/angular/).

--- a/content/intro-to-storybook/angular/en/simple-component.md
+++ b/content/intro-to-storybook/angular/en/simple-component.md
@@ -26,9 +26,8 @@ First, let’s create the task component and its accompanying story file: `src/a
 
 We’ll begin with the baseline implementation of the `TaskComponent`, simply taking in the inputs we know we’ll need and the two actions you can take on a task (to move it between lists):
 
-```typescript
-// src/app/components/task.component.ts
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+```ts:title=src/app/components/task.component.ts
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'app-task',
@@ -38,19 +37,16 @@ import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
     </div>
   `,
 })
-export class TaskComponent implements OnInit {
-  title: string;
+export class TaskComponent {
   @Input() task: any;
 
   // tslint:disable-next-line: no-output-on-prefix
-  @Output() onPinTask: EventEmitter<any> = new EventEmitter();
+  @Output()
+  onPinTask = new EventEmitter<Event>();
 
   // tslint:disable-next-line: no-output-on-prefix
-  @Output() onArchiveTask: EventEmitter<any> = new EventEmitter();
-
-  constructor() {}
-
-  ngOnInit() {}
+  @Output()
+  onArchiveTask = new EventEmitter<Event>();
 }
 ```
 
@@ -58,58 +54,57 @@ Above, we render straightforward markup for `TaskComponent` based on the existin
 
 Below we build out Task’s three test states in the story file:
 
-```typescript
-// src/app/components/task.stories.ts
+```ts:title=src/app/components/task.stories.ts
+import { Story, Meta } from '@storybook/angular/types-6-0';
 import { action } from '@storybook/addon-actions';
+
 import { TaskComponent } from './task.component';
+
 export default {
   title: 'Task',
+  component: TaskComponent,
   excludeStories: /.*Data$/,
-};
+} as Meta;
 
 export const actionsData = {
   onPinTask: action('onPinTask'),
   onArchiveTask: action('onArchiveTask'),
 };
 
-export const taskData = {
-  id: '1',
-  title: 'Test Task',
-  state: 'Task_INBOX',
-  updated_at: new Date(2019, 0, 1, 9, 0),
+const Template: Story<TaskComponent> = args => ({
+  component: TaskComponent,
+  props: {
+    ...args,
+    onPinTask: actionsData.onPinTask,
+    onArchiveTask: actionsData.onArchiveTask,
+  },
+});
+
+export const Default = Template.bind({});
+Default.args = {
+  task: {
+    id: '1',
+    title: 'Test Task',
+    state: 'TASK_INBOX',
+    updatedAt: new Date(2018, 0, 1, 9, 0),
+  },
 };
-export const Default = () => ({
-  component: TaskComponent,
-  props: {
-    task: taskData,
-    onPinTask: actionsData.onPinTask,
-    onArchiveTask: actionsData.onArchiveTask,
+
+export const Pinned = Template.bind({});
+Pinned.args = {
+  task: {
+    ...Default.args.task,
+    state: 'TASK_PINNED',
   },
-});
-// pinned task state
-export const Pinned = () => ({
-  component: TaskComponent,
-  props: {
-    task: {
-      ...taskData,
-      state: 'TASK_PINNED',
-    },
-    onPinTask: actionsData.onPinTask,
-    onArchiveTask: actionsData.onArchiveTask,
+};
+
+export const Archived = Template.bind({});
+Archived.args = {
+  task: {
+    ...Default.args.task,
+    state: 'TASK_ARCHIVED',
   },
-});
-// archived task state
-export const Archived = () => ({
-  component: TaskComponent,
-  props: {
-    task: {
-      ...taskData,
-      state: 'TASK_ARCHIVED',
-    },
-    onPinTask: actionsData.onPinTask,
-    onArchiveTask: actionsData.onArchiveTask,
-  },
-});
+};
 ```
 
 There are two basic levels of organization in Storybook: the component and its child stories. Think of each story as a permutation of a component. You can have as many stories per component as you need.
@@ -123,17 +118,25 @@ To tell Storybook about the component we are documenting, we create a `default` 
 
 - `component` -- the component itself,
 - `title` -- how to refer to the component in the sidebar of the Storybook app,
-- `excludeStories` -- information required by the story, but should not be rendered by the Storybook app.
+- `excludeStories` -- exports in the story file that should not be rendered as stories by Storybook.
 
 To define our stories, we export a function for each of our test states to generate a story. The story is a function that returns a rendered element (i.e. a component class with a set of props) in a given state---exactly like a [Stateless Functional Component](https://angular.io/guide/component-interaction).
 
+As we have multiple permutations of our component, it's convenient to assign it to a `Template` variable. Introducing this pattern in your stories will reduce the amount of code you need to write and maintain.
+
+<div class="aside">
+💡 <code>Template.bind({})</code> is a <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind">standard JavaScript</a> technique for making a copy of a function. We use this technique to allow each exported story to set its own properties, but use the same implementation.
+</div>
+
+Arguments or [`args`](https://storybook.js.org/docs/angular/writing-stories/args) for short, allow us to live edit our components with the controls addon without restarting Storybook. Once an [`args`](https://storybook.js.org/docs/vue/writing-stories/args) value changes so does the component.
+
+When creating a story we use a base `task` arg to build out the shape of the task the component expects. This is typically modelled from what the true data looks like. Again, `export`-ing this shape will enable us to reuse it in later stories, as we'll see.
+
 `action()` allows us to create a callback that appears in the **actions** panel of the Storybook UI when clicked. So when we build a pin button, we’ll be able to determine in the test UI if a button click is successful.
 
-As we need to pass the same set of actions to all permutations of our component, it is convenient to bundle them up into a single `actionsData` variable and use pass them into our story definition each time.
+As we need to pass the same set of actions to all permutations of our component, it is convenient to bundle them up into a single `actionsData` variable and pass them into our story definition each time.
 
 Another nice thing about bundling the `actionsData` that a component needs, is that you can `export` them and use them in stories for components that reuse this component, as we'll see later.
-
-When creating a story we use a base task (`taskData`) to build out the shape of the task the component expects. This is typically modelled from what the true data looks like. Again, `export`-ing this shape will enable us to reuse it in later stories, as we'll see.
 
 <div class="aside">
 💡 <a href="https://storybook.js.org/docs/angular/essentials/actions"><b>Actions</b></a> help you verify interactions when building UI components in isolation. Oftentimes you won't have access to the functions and state you have in context of the app. Use <code>action()</code> to stub them in.
@@ -143,11 +146,10 @@ When creating a story we use a base task (`taskData`) to build out the shape of 
 
 We also need to make one small change to the Storybook configuration so it notices our recently created stories. Change your Storybook configuration file (`.storybook/main.js`) to the following:
 
-```javascript
-// .storybook/main.js
+```diff:title=.storybook/main.js
 module.exports = {
-  stories: ['../src/app/components/**/*.stories.ts'],
-  addons: ['@storybook/addon-actions', '@storybook/addon-links', '@storybook/addon-notes'],
++ stories: ['../src/app/components/**/*.stories.ts'],
+  addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
 };
 ```
 
@@ -166,9 +168,7 @@ It’s best practice to specify the shape of data that a component expects. Not 
 
 Create a new folder called `models` inside `app` folder and inside a new file called `task.model.ts` with the following content:
 
-```typescript
-// src/app/models/task.model.ts
-
+```ts:title=src/app/models/task.model.ts
 export interface Task {
   id: string;
   title: string;
@@ -182,55 +182,65 @@ Now we have Storybook setup, styles imported, and test cases built out, we can q
 
 Our component is still rather rudimentary at the moment. We're going to make some changes so that it matches the intended design without going into too much detail:
 
-```typescript
-// src/app/components/task.component.ts
+```diff:title=src/app/components/task.component.ts
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
-import { Task } from '../models/task.model';
++ import { Task } from '../models/task.model';
+
 @Component({
   selector: 'app-task',
   template: `
-    <div class="list-item {{ task?.state }}">
-      <label class="checkbox">
-        <input
-          type="checkbox"
-          [defaultChecked]="task?.state === 'TASK_ARCHIVED'"
-          disabled="true"
-          name="checked"
-        />
-        <span class="checkbox-custom" (click)="onArchive(task.id)"></span>
-      </label>
-      <div class="title">
-        <input type="text" [value]="task?.title" readonly="true" placeholder="Input title" />
-      </div>
-      <div class="actions">
-        <a *ngIf="task?.state !== 'TASK_ARCHIVED'" (click)="onPin(task.id)">
-          <span class="icon-star"></span>
-        </a>
-      </div>
-    </div>
++   <div class="list-item {{ task?.state }}">
++     <label class="checkbox">
++       <input
++         type="checkbox"
++         [defaultChecked]="task?.state === 'TASK_ARCHIVED'"
++         disabled="true"
++         name="checked"
++       />
++       <span class="checkbox-custom" (click)="onArchive(task.id)"></span>
++     </label>
++     <div class="title">
++       <input
++         type="text"
++         [value]="task?.title"
++         readonly="true"
++         placeholder="Input title"
++       />
++     </div>
++     <div class="actions">
++       <a *ngIf="task?.state !== 'TASK_ARCHIVED'" (click)="onPin(task.id)">
++         <span class="icon-star"></span>
++       </a>
++     </div>
++   </div>
   `,
 })
-export class TaskComponent implements OnInit {
-  title: string;
-  @Input() task: Task;
+export class TaskComponent { {
++ @Input() task: Task;
 
   // tslint:disable-next-line: no-output-on-prefix
-  @Output() onPinTask: EventEmitter<any> = new EventEmitter();
+  @Output()
+  onPinTask = new EventEmitter<Event>();
 
   // tslint:disable-next-line: no-output-on-prefix
-  @Output() onArchiveTask: EventEmitter<any> = new EventEmitter();
+  @Output()
+  onArchiveTask = new EventEmitter<Event>();
 
-  constructor() {}
-
-  ngOnInit() {}
-
-  onPin(id: any) {
-    this.onPinTask.emit(id);
-  }
-  onArchive(id: any) {
-    this.onArchiveTask.emit(id);
-  }
++ /**
++  * Component method to trigger the onPin event
++  * @param id string
++  */
++ onPin(id: any) {
++   this.onPinTask.emit(id);
++ }
++ /**
++  * Component method to trigger the onArchive event
++  * @param id string
++  */
++ onArchive(id: any) {
++   this.onArchiveTask.emit(id);
++ }
 }
 ```
 
@@ -269,8 +279,7 @@ npm install -D @storybook/addon-storyshots
 
 Then create the `src/storybook.test.js` file with the following in it:
 
-```typescript
-// src/storybook.test.js
+```ts:title=src/storybook.test.js
 import initStoryshots from '@storybook/addon-storyshots';
 
 initStoryshots();
@@ -278,19 +287,18 @@ initStoryshots();
 
 Finally we need to make a small change in the `jest` key in our `package.json`:
 
-```json
+```diff:title=package.json
 {
-  ....
    "transform": {
       "^.+\\.(ts|html)$": "ts-jest",
       "^.+\\.js$": "babel-jest",
-      "^.+\\.stories\\.[jt]sx?$": "@storybook/addon-storyshots/injectFileName"
++     "^.+\\.stories\\.[jt]sx?$": "@storybook/addon-storyshots/injectFileName"
 
     },
 }
 ```
 
-Once the above is done, we can run `npm run jest` and see the following output:
+Once the above is done, we can run `npm run test` and see the following output:
 
 ![Task test runner](/intro-to-storybook/task-testrunner.png)
 

--- a/content/intro-to-storybook/angular/en/test.md
+++ b/content/intro-to-storybook/angular/en/test.md
@@ -7,17 +7,17 @@ commit: 8fdc779
 
 No Storybook tutorial would be complete without testing. Testing is essential to creating high quality UIs. In modular systems, miniscule tweaks can result in major regressions. So far we encountered three types of tests:
 
-- **Visual tests** rely on developers to manually look at a component to verify it for correctness. They help us sanity check a component’s appearance as we build.
+- **Manual tests** rely on developers to manually look at a component to verify it for correctness. They help us sanity check a component’s appearance as we build.
 - **Snapshot tests** with Storyshots capture a component’s rendered markup. They help us stay abreast of markup changes that cause rendering errors and warnings.
-- **Unit tests** with Jest verify that the output of a component remains the same given an fixed input. They’re great for testing the functional qualities of a component.
+- **Unit tests** with Jest verify that the output of a component remains the same given a fixed input. They’re great for testing the functional qualities of a component.
 
 ## “But does it look right?”
 
-Unfortunately, the aforementioned testing methods alone aren’t enough to prevent UI bugs. UIs are tricky to test because design is subjective and nuanced. Visual tests are too manual, snapshot tests trigger too many false positives when used for UI, and pixel-level unit tests are poor value. A complete Storybook testing strategy also includes visual regression tests.
+Unfortunately, the aforementioned testing methods alone aren’t enough to prevent UI bugs. UIs are tricky to test because design is subjective and nuanced. Manual tests are, well, manual. Snapshot tests trigger too many false positives when used for UI. Pixel-level unit tests are poor value. A complete Storybook testing strategy also includes visual regression tests.
 
-## Visual regression testing for Storybook
+## Visual testing for Storybook
 
-Visual regression tests are designed to catch changes in appearance. They work by capturing screenshots of every story and comparing them commit-to-commit to surface changes. This is perfect for verifying graphical elements like layout, color, size, and contrast.
+Visual regression tests, also called visual tests, are designed to catch changes in appearance. They work by capturing screenshots of every story and comparing them commit-to-commit to surface changes. This is perfect for verifying graphical elements like layout, color, size, and contrast.
 
 <video autoPlay muted playsInline loop style="width:480px; margin: 0 auto;">
   <source
@@ -28,90 +28,75 @@ Visual regression tests are designed to catch changes in appearance. They work b
 
 Storybook is a fantastic tool for visual regression testing because every story is essentially a test specification. Each time we write or update a story we get a spec for free!
 
-There are a number of tools for visual regression testing. For professional teams we recommend [**Chromatic**](https://www.chromatic.com/), an addon made by Storybook maintainers that runs tests in the cloud.
-
-## Setup visual regression testing
-
-Chromatic is a hassle-free Storybook addon for visual regression testing and review in the cloud. Since it’s a paid service (with a free trial), it may not be for everyone. However, Chromatic is an instructive example of a production visual testing workflow that we'll try out for free. Let’s have a look.
-
-### Bring git up to date
-
-Angular CLI has already created a repo for your project; let's check in the changes we made:
-
-First you want to setup Git for your project in the local directory. Chromatic uses Git history to keep track of your UI components.
-
-```bash
-$ git add .
-```
-
-Now commit the files.
-
-```bash
-$ git commit -m "taskbox UI"
-```
-
-### Get Chromatic
-
-Add the package as a dependency.
-
-```bash
-npm install -D chromatic
-```
-
-One fantastic thing about this addon is that it will use Git history to keep track of your UI components.
-
-Then [login to Chromatic](https://www.chromatic.com/start) with your GitHub account (Chromatic only asks for lightweight permissions). Create a project with name "taskbox" and copy your unique `project-token`.
-
-<video autoPlay muted playsInline loop style="width:520px; margin: 0 auto;">
-  <source
-    src="/intro-to-storybook/chromatic-setup-learnstorybook.mp4"
-    type="video/mp4"
-  />
-</video>
-
-Run the test command in the command line to setup visual regression tests for Storybook. Don't forget to add your unique app code in place of `<project-token>`.
-
-```bash
-npx chromatic --project-token=<project-token>
-```
-
-<div class="aside">
-If your Storybook has a custom build script you may have to <a href="https://www.chromatic.com/docs/setup#command-options">add options </a> to this command.
-</div>
-
-Once the first test is complete, we have test baselines for each story. In other words, screenshots of each story known to be “good”. Future changes to those stories will be compared to the baselines.
-
-![Chromatic baselines](/intro-to-storybook/chromatic-baselines.png)
+There are a number of tools for visual regression testing. We recommend [**Chromatic**](https://www.chromatic.com/), a free publishing service made by the Storybook maintainers that runs visual tests in parallelized cloud. It also allows us to publish Storybook online as we saw in the [previous chapter](/intro-to-storybook/angular/en/deploy/).
 
 ## Catch a UI change
 
-Visual regression testing relies on comparing images of the new rendered UI code to the baseline images. If a UI change is caught you get notified. See how it works by tweaking the background of the `Task` component:
+Visual regression testing relies on comparing images of the new rendered UI code to the baseline images. If a UI change is caught we'll get notified.
 
-![code change](/intro-to-storybook/chromatic-change-to-task-component.png)
+Let's see how it works by tweaking the background of the `Task` component.
+
+Start by creating a new branch for this change:
+
+```bash
+git checkout -b change-task-background
+```
+
+Change `TaskComponent` to the following:
+
+```diff:title=src/app/components/task.component.ts
+<input
+  type="text"
+  [value]="task?.title"
+  readonly="true"
+  placeholder="Input title"
++ style="background: red;"
+/>
+```
 
 This yields a new background color for the item.
 
 ![task background change](/intro-to-storybook/chromatic-task-change.png)
 
-Use the test command from earlier to run another Chromatic test.
+Add the file:
 
 ```bash
-npx chromatic --project-token=<project-token>
+git add .
 ```
 
-Follow the link to the web UI where you’ll see changes.
+Commit it:
 
-![UI changes in Chromatic](/intro-to-storybook/chromatic-catch-changes.png)
+```bash
+git commit -m "change task background to red"
+```
 
-There are a lot of changes! The component hierarchy where `Task` is a child of `TaskList` and `Inbox` means one small tweak snowballs into major regressions. This circumstance is precisely why developers need visual regression testing in addition to other testing methods.
+And push the changes to the remote repo:
+
+```bash
+git push -u origin change-task-background
+```
+
+Finally, open your GitHub repository and open a pull request for the `change-task-background` branch.
+
+![Creating a PR in GitHub for task](/github/pull-request-background.png)
+
+Add a descriptive text to your pull request and click `Create pull request`. Click on the "🟡 UI Tests" PR check at the bottom of the page.
+
+![Created a PR in GitHub for task](/github/pull-request-background-ok.png)
+
+This will show you the UI changes caught by your commit.
+
+![Chromatic caught changes](/intro-to-storybook/chromatic-catch-changes.png)
+
+There are a lot of changes! The component hierarchy where `TaskComponent` is a child of `TaskListComponent` and `InboxScreenComponent` means one small tweak snowballs into major regressions. This circumstance is precisely why developers need visual regression testing in addition to other testing methods.
 
 ![UI minor tweaks major regressions](/intro-to-storybook/minor-major-regressions.gif)
 
 ## Review changes
 
-Visual regression testing ensures components don’t change by accident. But it’s still up to you to determine whether changes are intentional or not.
+Visual regression testing ensures components don’t change by accident. But it’s still up to us to determine whether changes are intentional or not.
 
-If a change is intentional you need to update the baseline so that future tests are compared to the latest version of the story. If a change is unintentional it needs to be fixed.
+If a change is intentional we'll need to update the baseline so that future tests are compared to the latest version of the story. If a change is unintentional it needs to be fixed.
 
 <video autoPlay muted playsInline loop style="width:480px; margin: 0 auto;">
   <source
@@ -128,6 +113,6 @@ When we’ve finished reviewing we’re ready to merge UI changes with confidenc
 
 ![Changes ready to be merged](/intro-to-storybook/chromatic-review-finished.png)
 
-Storybook helps you **build** components; testing helps you **maintain** them. The four types of UI testing are covered in this tutorial are visual, snapshot, unit, and visual regression testing. You can automate the last three by adding them to your CI script. This helps you ship components without worrying about stowaway bugs. The whole workflow is illustrated below.
+Storybook helps us **build** components; testing helps us **maintain** them. The four types of UI testing covered in this tutorial were visual, snapshot, unit, and visual regression testing. The last three can be automated by adding them to a CI as we've just finished setting up. This helps us ship components without worrying about stowaway bugs. The whole workflow is illustrated below.
 
 ![Visual regression testing workflow](/intro-to-storybook/cdd-review-workflow.png)

--- a/content/intro-to-storybook/angular/en/using-addons.md
+++ b/content/intro-to-storybook/angular/en/using-addons.md
@@ -1,168 +1,89 @@
 ---
 title: 'Addons'
 tocTitle: 'Addons'
-description: 'Learn how to integrate and use addons using a popular example'
+description: 'Learn how to integrate and use the popular Controls addon'
 ---
 
-Storybook boasts a robust system of [addons](https://storybook.js.org/docs/angular/configure/storybook-addons) with which you can enhance the developer experience for
-everybody in your team. If you've been following along with this tutorial linearly, we have referenced multiple addons so far, and you will have already implemented one in the [Testing chapter](/intro-to-storybook/angular/en/test/).
+Storybook has a robust ecosystem of [addons](https://storybook.js.org/docs/angular/configure/storybook-addons) that you can use to enhance the developer experience for everybody in your team. View them all [here](https://storybook.js.org/addons),
 
-<div class="aside">
-<strong>Looking for a list of potential addons?</strong>
-<br/>
-😍 You can see the list of officially-supported and strongly-supported community addons <a href="https://storybook.js.org/addons">here</a>.
-</div>
+If you've been following along with this tutorial, you've already encountered multiple addons, and set one up in the [Testing](/intro-to-storybook/angular/en/test/) chapter.
 
-We could write forever about configuring and using addons for all of your particular use-cases. For now, let's work towards integrating one of the most popular addons within Storybook's ecosystem: [knobs](https://github.com/storybooks/storybook/tree/master/addons/knobs).
+There are addons for every possible use case. It would take forever to write about them all. Let's integrate one of the most popular addons: [Controls](https://storybook.js.org/docs/angular/essentials/controls).
 
-## Setting Up Knobs
+## What is Controls?
 
-Knobs is an amazing resource for designers and developers to experiment and play with components in a controlled environment without the need to code! You essentially provide dynamically defined fields with which a user manipulates the props being passed to the components in your stories. Here's what we're going to implement...
+Controls allows designers and developers to easily explore component behavior by _playing_ with its arguments. No code required. Controls creates an addon panel next to your stories, so you can edit their arguments live.
+
+Fresh installs of Storybook include Controls out of the box. No extra configuration needed.
 
 <video autoPlay muted playsInline loop>
   <source
-    src="/intro-to-storybook/addon-knobs-demo.mp4"
+    src="/intro-to-storybook/controls-in-action.mp4"
     type="video/mp4"
   />
 </video>
 
-### Installation
+## Addons unlock new Storybook workflows
 
-First, we will need to add it as a development dependency.
+Storybook is a wonderful [component-driven development environment](https://www.componentdriven.org/). The Controls addon evolves Storybook into an interactive documentation tool.
 
-```bash
-npm install -D @storybook/addon-knobs
-```
+### Using Controls to find edge cases
 
-Register Knobs in your `.storybook/main.js` file.
+With Controls QA Engineers, UI Engineers, or any other stakeholder can push the component to the limit! Let's consider the following example, what would happen to our `Task` if we added a **MASSIVE** string?
 
-```javascript
-// .storybook/main.js
+![Oh no! The far right content is cut-off!](/intro-to-storybook/task-edge-case.png)
 
-module.exports = {
-  stories: ['../src/app/components/**/*.stories.ts'],
-  addons: ['@storybook/addon-actions', '@storybook/addon-links', '@storybook/addon-knobs'],
-};
-```
+That's not right! It looks like the text overflows beyond the bounds of the Task component.
 
-<div class="aside">
-<strong>📝 Addon registration order matters!</strong>
-<br/>
-The order you list these addons will dictate the order in which they appear as tabs on your addon panel (for those that appear there).
-</div>
+Controls allowed us to quickly verify different inputs to a component. In this case a long string. This reduces the work required to discover UI problems.
 
-That's it! Time to use it in a story.
+Now let's fix the issue with overflowing by adding a style to `Task.vue`:
 
-### Usage
-
-Let's use the object knob type in the `Task` component.
-
-First, import the `withKnobs` decorator and the `object` knob type to `task.stories.ts`:
-
-```javascript
-// src/app/components/task.stories.ts
-import { action } from '@storybook/addon-actions';
-import { withKnobs, object } from '@storybook/addon-knobs';
-```
-
-Next, within the `default` export of the `task.stories.ts` file, add `withKnobs` to the `decorators` key:
-
-```javascript
-// src/app/components/task.stories.ts
-export default {
-  title: 'Task',
-  decorators: [withKnobs],
-  // same as before
-};
-```
-
-Lastly, integrate the `object` knob type within the "default" story:
-
-```javascript
-// src/app/components/task.stories.ts
-
-// default task state
-export const Default = () => ({
-  component: TaskComponent,
-  props: {
-    task: object('task', { ...taskData }),
-    onPinTask: actionsData.onPinTask,
-    onArchiveTask: actionsData.onArchiveTask,
-  },
-});
-
-// same as before
-```
-
-Now a new "Knobs" tab should show up next to the "Action Logger" tab in the bottom pane.
-
-As documented [here](https://github.com/storybooks/storybook/tree/master/addons/knobs#object), the `object` knob type accepts a label and a default object as parameters. The label is constant and shows up to the left of a text field in your addons panel. The object you've passed will be represented as an editable JSON blob. As long as you submit valid JSON, your component will adjust based upon the data being passed to the object!
-
-## Addons Evolve Your Storybook's Scope
-
-Not only does your Storybook instance serve as a wonderful [CDD environment](https://www.componentdriven.org/), but now we're providing an interactive source of documentation. PropTypes are great, but a designer or somebody completely new to a component's code will be able to figure out its behavior very quickly via Storybook with the knobs addon implemented.
-
-## Using Knobs To Find Edge-Cases
-
-Additionally, with easy access to editing passed data to a component, QA Engineers or preventative UI Engineers can now push a component to the limit! As an example, what happens to `TaskComponent` if our list item has a _MASSIVE_ string?
-
-![Oh no! The far right content is cut-off!](/intro-to-storybook/addon-knobs-demo-edge-case.png) 😥
-
-Thanks to quickly being able to try different inputs to a component we can find and fix such problems with relative ease! Let's fix the issue with overflowing by adding a style to `task.component.ts`:
-
-```html
-<!-- src/app/components/task.component.ts -->
-
-<!-- This is the input for our task title. In practice we would probably update the styles for this element
-but for this tutorial, let's fix the problem with an inline style:
- -->
+```diff:title=src/app/components/task.component.ts
 <input
   type="text"
   [value]="task?.title"
   readonly="true"
   placeholder="Input title"
-  [ngStyle]="{textOverflow:'ellipsis'}"
-/>
++ style="text-overflow: ellipsis;"
 />
 ```
 
-![That's better.](/intro-to-storybook/addon-knobs-demo-edge-case-resolved.png) 👍
+![That's better.](/intro-to-storybook/edge-case-solved-with-controls.png)
 
-## Adding A New Story To Avoid Regressions
+Problem solved! The text is now truncated when it reaches the boundary of the Task area using a handsome ellipsis.
 
-Of course we can always reproduce this problem by entering the same input into the knobs, but it's better to write a fixed story for this input. This will increase your regression testing and clearly outline the limits of the component(s) to the rest of your team.
+### Adding a new story to avoid regressions
 
-Let's add a story for the long text case in `task.stories.ts`:
+In the future, We can manually reproduce this problem by entering the same string via Controls. But it's easier to write a story that showcases this edge case. That expands our regression test coverage and clearly outlines the limits of the component(s) for the rest of the team.
 
-```javascript
-// src/app/components/task.stories.ts
+Add a new story for the long text case in `Task.stories.js`:
 
-// tslint:disable-next-line: max-line-length
-const longTitle = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not!`;
+```ts:title=src/app/components/task.stories.ts
+const longTitleString = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not!`;
 
-// same as before
-
-export const LongTitle = () => ({
-  component: TaskComponent,
-  props: {
-    task: {
-      ...taskData,
-      title: longTitle,
-    },
-    onPinTask: actionsData.onPinTask,
-    onArchiveTask: actionsData.onArchiveTask,
+export const LongTitle = Template.bind({});
+LongTitle.args = {
+  task: {
+    ...Default.args.task,
+    title: longTitleString,
   },
-});
+};
 ```
 
-Now we've added the story, we can reproduce this edge-case with ease whenever we want to work on it:
+Now we can reproduce and work on this edge case with ease.
 
-![Here it is in Storybook.](/intro-to-storybook/addon-knobs-demo-edge-case-in-storybook.png)
+<video autoPlay muted playsInline loop>
+  <source
+    src="/intro-to-storybook/task-stories-long-title.mp4"
+    type="video/mp4"
+  />
+</video>
 
-If we are using [visual regression testing](/intro-to-storybook/angular/en/test/), we will also be informed if we ever break our ellipsizing solution. Such obscure edge-cases are always liable to be forgotten!
+If we are [visual testing](/intro-to-storybook/angular/en/test/), we'll also be informed if the ellipsizing solution breaks. Obscure edge-cases are liable to be forgotten without test coverage!
+
+<div class="aside"><p>💡 Controls is a great way to get non-developers playing with your components and stories, and much more than we've seen here, we recommend reading the <a href="https://storybook.js.org/docs/angular/essentials/controls">official documentation</a> to learn more about it. However, there are many more ways you can customize Storybook to fit your workflow with addons.</div>
 
 ### Merge Changes
 
 Don't forget to merge your changes with git!
-
-<div class="aside"><p>As we've seen, Knobs is a great way to get non-developers playing with your components and stories. However, there are many more ways you can customize Storybook to fit your workflow with addons. In the <a href="/create-an-addon/react/en/introduction/">create an addon guide</a> we'll teach you that, by creating a addon that will help you supercharge your development workflow.</p></div>

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -42,7 +42,7 @@ module.exports = {
           pt: 5.3,
         },
         angular: {
-          en: 5.3,
+          en: 6.1,
           es: 5.3,
           pt: 5.3,
         },


### PR DESCRIPTION
With this pull request the Angular version of the Intro to Storybook was updated to 6.x and now documents how to use Controls instead of Knobs.

What was done:
- Updated the sections starting from Single Component up to Using Addons section 
- Snippets are now featuring the new approach introduced with the migration of content.


There's still one version of the tutorial that will require adjustments to replace knobs in favor of Controls (i.e. React Native but that version of Storybook is still under development and not yet stabilized for Controls).

When that version includes support for Controls then the tutorial will be updated accordingly.

Feel free to provide feedback