### PR TITLE
Fix typo in intro-to-storybook testing docs

### DIFF
--- a/content/intro-to-storybook/react/en/test.md
+++ b/content/intro-to-storybook/react/en/test.md
@@ -114,6 +114,6 @@ When we’ve finished reviewing we’re ready to merge UI changes with confidenc
 
 ![Changes ready to be merged](/intro-to-storybook/chromatic-review-finished.png)
 
-Storybook helps us **build** components; testing helps us **maintain** them. The four types of UI testing covered in this tutorial were visual, snapshot, unit, and visual regression testing. The last three can be automated by adding them to a CI as we've just finished setting up. This helps us ship components without worrying about stowaway bugs. The whole workflow is illustrated below.
+Storybook helps us **build** components; testing helps us **maintain** them. The four types of UI testing covered in this tutorial were manual, snapshot, unit, and visual regression testing. The last three can be automated by adding them to a CI as we've just finished setting up. This helps us ship components without worrying about stowaway bugs. The whole workflow is illustrated below.
 
 ![Visual regression testing workflow](/intro-to-storybook/cdd-review-workflow.png)


### PR DESCRIPTION
Not sure if this was a typo or intended, but visual was twice in the list, so I think this was meant to say "manual" instead