### PR TITLE
Removed unnecessary curly bracket

### DIFF
--- a/content/intro-to-storybook/angular/en/simple-component.md
+++ b/content/intro-to-storybook/angular/en/simple-component.md
@@ -216,7 +216,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 +   </div>
   `,
 })
-export class TaskComponent { {
+export class TaskComponent {
 + @Input() task: Task;
 
   // tslint:disable-next-line: no-output-on-prefix


### PR DESCRIPTION
In the "Intro to storybook" section, the Angular version (en) of the simple component page has an unwanted curly bracket.