### PR TITLE
Adjust path to stories in .storybook/main.js (Ember Tutorial)

### DIFF
--- a/content/intro-to-storybook/ember/en/simple-component.md
+++ b/content/intro-to-storybook/ember/en/simple-component.md
@@ -125,7 +125,7 @@ module.exports = {
 -   '../src/**/*.stories.mdx',
 -   '../src/**/*.stories.@(js|jsx|ts|tsx)'
 - ],
-+ stories: ['../src/components/**/*.stories.js'],
++ stories: ['../app/components/**/*.stories.js'],
   addons: ['@storybook/addon-actions', '@storybook/addon-links'],
 };
 ```


### PR DESCRIPTION
Thanks for the Ember tutorial :+1: 

I was just going through it and noticed one thing:

At one point the Storybook configuration needs to be adjusted to notice the stories in:  
`'../src/components/**/*.stories.js'`

for Ember it should be:  
`'../app/components/**/*.stories.js'`