### PR TITLE
Add missing git command

### DIFF
--- a/content/intro-to-storybook/react/en/get-started.md
+++ b/content/intro-to-storybook/react/en/get-started.md
@@ -63,6 +63,12 @@ $ git init
 Followed by:
 
 ```shell
+$ git branch -M main
+```
+
+Then:
+
+```shell
 $ git add .
 ```
 


### PR DESCRIPTION
I found the `git branch -M main` command necessary when initializing and pushing a repo to GitHub as prescribed by the tutorial. To avoid having to look it up after seeing an error, I thought it might be handy to add in here. Alternatively, it could show up on [the Deploy step](https://storybook.js.org/tutorials/intro-to-storybook/react/en/deploy/) of the tutorial.

What do you think @jonniebigodes?

You can see GitHub has it in their New Repository flow:

<img width="297" alt="image" src="https://user-images.githubusercontent.com/1123119/121725334-5f77ca00-caa6-11eb-8fe6-30063bdb0939.png">
