### PR TITLE
Remove components directory reference

### DIFF
--- a/content/design-systems-for-developers/react/en/document.md
+++ b/content/design-systems-for-developers/react/en/document.md
@@ -310,7 +310,7 @@ Avatar is used to represent a person or an organization. By default the avatar s
 
 Every design system comes with a cover page. Storybook Docs allows you to create discrete pages using MDX.
 
-Create a new file `src/components/Intro.stories.mdx`:
+Create a new file `src/Intro.stories.mdx`:
 
 ```js:title=src/components/Intro.stories.mdx
 import { Meta } from '@storybook/addon-docs/blocks';

--- a/content/design-systems-for-developers/react/en/document.md
+++ b/content/design-systems-for-developers/react/en/document.md
@@ -312,7 +312,7 @@ Every design system comes with a cover page. Storybook Docs allows you to create
 
 Create a new file `src/Intro.stories.mdx`:
 
-```js:title=src/components/Intro.stories.mdx
+```js:title=src/Intro.stories.mdx
 import { Meta } from '@storybook/addon-docs/blocks';
 
 <Meta title="Design System/Introduction" />
@@ -335,7 +335,7 @@ module.exports = {
   // Changes the load order of our stories. First loads the Intro page
   // automatically import all files ending in *.stories.js|mdx
   stories: [
-+   '../src/components/Intro.stories.mdx',
++   '../src/Intro.stories.mdx',
     '../src/**/*.stories.mdx',
     '../src/**/*.stories.@(js|jsx|ts|tsx)',
   ],


### PR DESCRIPTION
I believe this is the first and only time the `components` directory is referenced. I know it's pretty common to have on projects, but for the purposes of this tutorial, it would be good to remain consistent.