### PR TITLE
Updating deprecated async storage package for React Native's get-started guide

### DIFF
--- a/content/intro-to-storybook/react-native/en/get-started.md
+++ b/content/intro-to-storybook/react-native/en/get-started.md
@@ -522,6 +522,6 @@ const StorybookUIRoot = getStorybookUI({
 export default StorybookUIRoot;
 ```
 
-<div class="aside"><p>We're adding the <code>asyncStorage:null</code> due to the fact that starting with React Native 0.59 Async Storage was deprecated. Should you need to use it in your own app, you'll have to add it manually by installing <code>@react-native-community/async-storage</code> package and adjust the code above accordingly. You can read more about how to setup Storybook with Async Storage in <a href="https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#react-native-async-storage">here</a>. As the tutorial will not use any of the features of Async Storage, we can safely add this element to Storybook configuration.</p></div>
+<div class="aside"><p>We're adding the <code>asyncStorage:null</code> due to the fact that starting with React Native 0.59 Async Storage was deprecated. Should you need to use it in your own app, you'll have to add it manually by installing <code>@react-native-async-storage/async-storage</code> package and adjust the code above accordingly. You can read more about how to setup Storybook with Async Storage in <a href="https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#react-native-async-storage">here</a>. As the tutorial will not use any of the features of Async Storage, we can safely add this element to Storybook configuration.</p></div>
 
 After adding styling and assets, the app will render a bit strangely. That’s OK. We aren’t working on the app right now. We’re starting off with building our first component!


### PR DESCRIPTION
The `@react-native-community/async-storage` package has been deprecated in favor of https://github.com/react-native-async-storage/async-storage

Deprecation notice can be found [here]( https://www.npmjs.com/package/@react-native-community/async-storage)

The package change _is_ reflected in the [RN Migration Guide](https://github.com/storybookjs/react-native/blob/0974d3cf2fff82f22d6ef2d32f83bc16dba62f3a/MIGRATION.md)