### PR TITLE
Update get-started.md for Ember

### DIFF
--- a/content/intro-to-storybook/ember/en/get-started.md
+++ b/content/intro-to-storybook/ember/en/get-started.md
@@ -42,7 +42,7 @@ Now we can quickly check that the various environments of our application are wo
 ember test --server
 
 # Run the frontend app proper on port 4200:
-ember start
+ember serve
 
 # Start the component explorer on port 6006:
 npm run storybook-dev

--- a/content/intro-to-storybook/ember/en/get-started.md
+++ b/content/intro-to-storybook/ember/en/get-started.md
@@ -42,11 +42,10 @@ Now we can quickly check that the various environments of our application are wo
 ember test --server
 
 # Run the frontend app proper on port 4200:
-ember serve
+yarn run start
 
 # Start the component explorer on port 6006:
-npm run storybook-dev
-
+yarn run storybook-dev
 ```
 
 Our three frontend app modalities: automated test (Qunit), component development (Storybook), and the app itself.


### PR DESCRIPTION
Correct command, should be `ember serve` re: https://guides.emberjs.com/release/getting-started/quick-start/#toc_create-a-new-application

IS:

```
$ ember start

The specified command start is invalid. For available options, see `ember help`.
```