### PR TITLE
Fix typos in composite component page

### DIFF
--- a/content/intro-to-storybook/react/en/composite-component.md
+++ b/content/intro-to-storybook/react/en/composite-component.md
@@ -195,7 +195,7 @@ Note the position of the pinned item in the list. We want the pinned item to ren
 
 ## Data requirements and props
 
-As the component grows, so too do input requirements. Define the prop requirements of `TaskList`. Because `Task` is a child component, make sure to provide data in the right shape to render it. To save time and headache, reuse the propTypes you defined in `Task` earlier.
+As the component grows, so do input requirements. Define the prop requirements of `TaskList`. Because `Task` is a child component, make sure to provide data in the right shape to render it. To save time and headache, reuse the `propTypes` you defined in `Task` earlier.
 
 ```diff:title=src/components/TaskList.js
 import React from 'react';


### PR DESCRIPTION
The composite component page of Intro to Storybook had a minor typo / unnecessary word in the data requirements and props. Although it's a minor issue, I believe it would improve the quality of the already fantastically written tutorial.

Preview of the typo: 
![image](https://user-images.githubusercontent.com/34748469/140372318-f88100d4-c205-4fe3-a9c3-b9bfad9fae60.png)
