### PR TITLE
Chore: (Config) Adds missing info in gatsby config for Design systems for developers ZH-CN

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -62,6 +62,7 @@ module.exports = {
           en: 6.3,
           ko: 6.1,
           pt: 5.3,
+          'zh-CN': 6.3,
         },
       },
       'visual-testing-handbook': {


### PR DESCRIPTION
With this small pull request the configuration is updated to include the status about the Design Systems for developers ZH-CN version