### PR TITLE
Update mocked store example decorator

### DIFF
--- a/content/intro-to-storybook/react/en/screen.md
+++ b/content/intro-to-storybook/react/en/screen.md
@@ -252,7 +252,7 @@ import { PureInboxScreen } from './InboxScreen';
 
 export default {
   component: PureInboxScreen,
-+ decorators: [story => <Provider store={store}>{Mockstore()}</Provider>],
++ decorators: [story => <Provider store={Mockstore}>{story()}</Provider>],
   title: 'PureInboxScreen',
 };
 

--- a/content/intro-to-storybook/react/en/screen.md
+++ b/content/intro-to-storybook/react/en/screen.md
@@ -321,7 +321,7 @@ const Mockstore = configureStore({
 
 export default {
   component: PureInboxScreen,
-  decorators: [story => <Provider store={store}>{Mockstore()}</Provider>],
+  decorators: [story => <Provider store={Mockstore}>{story()}</Provider>],
   title: 'PureInboxScreen',
 };
 


### PR DESCRIPTION
There was a mistake about the usage of mocked store, in concrete, in the previous example wasn't used `story()` to render correct stories and was used a variable called `store` whenever it wasn't even imported. Also the usage of variable `Mockstore` was incorrect (was used as a function).

[Supplying context with decorators](https://storybook.js.org/tutorials/intro-to-storybook/react/en/screen/)