### PR TITLE
Update data.md to include missing import of updateTaskState

### DIFF
--- a/content/intro-to-storybook/react/en/data.md
+++ b/content/intro-to-storybook/react/en/data.md
@@ -85,7 +85,7 @@ import PropTypes from 'prop-types';
 import Task from './Task';
 
 import { useDispatch, useSelector } from 'react-redux';
-import { archiveTask, pinTask } from '../lib/redux';
+import { updateTaskState } from '../lib/store';
 
 export function PureTaskList({ loading, tasks, onPinTask, onArchiveTask }) {
   /* previous implementation of TaskList */


### PR DESCRIPTION
An import for updateTaskState was missing and the imports for archiveTask and pinTask were unused