### PR TITLE
Update transformIgnorePatterns in RN page

### DIFF
--- a/content/intro-to-storybook/react-native/en/get-started.md
+++ b/content/intro-to-storybook/react-native/en/get-started.md
@@ -71,7 +71,7 @@ Update the `jest` field in `package.json`:
 "jest": {
     "preset": "jest-expo",
     "transformIgnorePatterns": [
-      "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base)"
+      "node_modules/(?!(jest-)?@react-native|react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base)"
     ],
     "setupFilesAfterEnv": [
       "<rootDir>/__mocks__/globalMock.js"


### PR DESCRIPTION
The current version of the documentation doesn't work for me when run in a clean environment on macOS. If you don't include `@react-native` in the ignore regex it runs into syntax errors on the package `node_modules/@react-native/polyfills/error-guard.js` 

I had this problem with a tabs template project initialized with expo-cli 5.0.1.