### PR TITLE
Update RN get-started docs jest field

### DIFF
--- a/content/intro-to-storybook/react-native/en/get-started.md
+++ b/content/intro-to-storybook/react-native/en/get-started.md
@@ -71,7 +71,7 @@ Update the `jest` field in `package.json`:
 "jest": {
     "preset": "jest-expo",
     "transformIgnorePatterns": [
-      "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base)"
+      "node_modules/(?!(jest-)?@react-native|react-native|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base)"
     ],
     "setupFilesAfterEnv": [
       "<rootDir>/__mocks__/globalMock.js"


### PR DESCRIPTION
Following the [get started guide](https://storybook.js.org/tutorials/intro-to-storybook/react-native/en/get-started/) for react native, was met with:

```
 FAIL  components/__tests__/StyledText-test.js
  ● Test suite failed to run

    /home/skynet/workspace/laltal/taskbox/node_modules/@react-native/polyfills/error-guard.js:14
    type ErrorHandler = (error: mixed, isFatal: boolean) => void;
         ^^^^^^^^^^^^

    SyntaxError: Unexpected identifier
```

Fix  from [stackoverflow](https://stackoverflow.com/a/66664747) :

```js
transformIgnorePatterns: [
  'node_modules/(?!@react-native|react-native)'
],
```

Will then pass all tests on first test run.