### PR TITLE
Chore: (Docs) Create addon tutorial - Adds info about root level preset

### DIFF
--- a/content/create-an-addon/react/en/decorators.md
+++ b/content/create-an-addon/react/en/decorators.md
@@ -97,7 +97,7 @@ Ok, that seems like a big jump. Let’s walk through all the changes.
 
 The addon can be active in both docs and story view modes. The actual DOM node for the preview `iframe` is different in these two modes. In fact, the docs mode renders multiple story previews on one page. Therefore, we need to pick the appropriate selector for the DOM node where the styles will be injected. Also, the CSS needs to be scoped to that particular selector.
 
-<div class="aside"><b>Note:</b> the <code>useMemo</code> and <code>useEffect</code> here come from <a href="https://storybook.js.org/docs/react/addons/addons-api">@storybook/addons</a> and not React. This is because the decorator code is running in the preview part of Storybook. That's where the user's code is loaded which may not contain React. Therefore, to be framework agnostic, Storybook implements a React-like hook library which we can use!</div>
+<div class="aside"> 💡 <code>useMemo</code> and <code>useEffect</code> here come from <a href="https://storybook.js.org/docs/react/addons/addons-api">@storybook/addons</a> and not React. This is because the decorator code is running in the preview part of Storybook. That's where the user's code is loaded which may not contain React. Therefore, to be framework agnostic, Storybook implements a React-like hook library which we can use!</div>
 
 Next, as we inject the styles into the DOM, we need to keep track of them to clear them when the user toggles it off or switches the view mode.
 

--- a/content/create-an-addon/react/en/preset.md
+++ b/content/create-an-addon/react/en/preset.md
@@ -22,8 +22,31 @@ import { withGlobals } from '../withGlobals';
 export const decorators = [withGlobals];
 ```
 
-<div class="aside"><b>Note:</b> the <code>withRoundTrip</code> decorator from the Addon Kit is an example of two-way communication between the story and an addon. However, we don't require that for our addon and can delete it.</div>
-
-Success! You now have a fully functional addon in your local Storybook. In the final chapter, learn how to list your addon in the catalog. That way you can share with your team and the Storybook community.
+<div class="aside">💡 The <code>withRoundTrip</code> decorator from the Addon Kit is an example of two-way communication between the story and an addon. However, we don't require that for our addon and can delete it.</div>
 
 ![toggling the tool toggles the outlines](../../images/toggle.gif)
+
+## Root-level preset
+
+Before we can add our addon to the catalog, there's one item worth mentioning. Each Storybook addon must include a root-level preset to register the addon without any additional configuration from the user. Luckily for us, this was set up for us when we cloned the repository in the [setup section](/create-an-addon/react/en/getting-started/). If you open your `preset.js` in the root directory, you'll see the following inside:
+
+```js:title=preview.js
+function config(entry = []) {
+  return [...entry, require.resolve("./dist/esm/preset/preview")];
+}
+
+function managerEntries(entry = []) {
+  return [...entry, require.resolve("./dist/esm/preset/manager")];
+}
+
+module.exports = {
+  managerEntries,
+  config,
+};
+```
+
+<div class="aside">
+ 💡 Read the official <a href="https://storybook.js.org/docs/react/addons/writing-presets#manager-entries">Storybook documentation</a> to learn more about presets.
+</div>
+
+Success! You now have a fully functional addon in your local Storybook. In the final chapter, learn how to list your addon in the catalog. That way you can share with your team and the Storybook community.


### PR DESCRIPTION
With this pull request, the Create an Addon tutorial is updated to include some information about root level presets. Addresses and closes [this issue](https://github.com/storybookjs/storybook/issues/16094).

What was done:
- Updated the tutorial to remove "Note" in the asides as it's somewhat of a redundancy.
- Added information about root level presets.

Feel free to provide feedback