### PR TITLE
Fix typos in `data.md` (English version)

### DIFF
--- a/content/intro-to-storybook/react/en/data.md
+++ b/content/intro-to-storybook/react/en/data.md
@@ -161,7 +161,7 @@ export default {
 export const Default = Template.bind({});
 Default.args = {
   // Shaping the stories through args composition.
-  // The data was inherited from the Default story in task.stories.js.
+  // The data was inherited from the Default story in Task.stories.js.
   tasks: [
     { ...TaskStories.Default.args.task, id: '1', title: 'Task 1' },
     { ...TaskStories.Default.args.task, id: '2', title: 'Task 2' },

--- a/content/intro-to-storybook/react/en/data.md
+++ b/content/intro-to-storybook/react/en/data.md
@@ -143,21 +143,25 @@ However, we can quickly solve this problem by simply rendering the `PureTaskList
 ```diff:title=src/components/TaskList.stories.js
 import React from 'react';
 
+- import TaskList from './TaskList';
 + import { PureTaskList } from './TaskList';
 import * as TaskStories from './Task.stories';
 
 export default {
+- component: TaskList,
+- title: 'TaskList',
 + component: PureTaskList,
-  title: 'PureTaskList',
++ title: 'PureTaskList',
   decorators: [story => <div style={{ padding: '3rem' }}>{story()}</div>],
 };
 
+- const Template = args => <TaskList {...args} />;
 + const Template = args => <PureTaskList {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
   // Shaping the stories through args composition.
-  // The data was inherited the Default story in task.stories.js.
+  // The data was inherited from the Default story in task.stories.js.
   tasks: [
     { ...TaskStories.Default.args.task, id: '1', title: 'Task 1' },
     { ...TaskStories.Default.args.task, id: '2', title: 'Task 2' },


### PR DESCRIPTION
Fixed a few typos:

- Some of the changes to `TaskList.stories.js` weren't noted before.
- "The data was inherited the Default..." should be "The data was inherited **from** the Default...".
- The `T` in `Task.stories.js` should be capitalized.

Thank you for approving my other recent pull request!

### EDIT: Additional Issue with Prop Types

Upon attempting to complete this section, I ran into an issue where the tests were console logging the following error:

> Warning: Failed prop type: The prop `onPinTask` is marked as required in `PureTaskList`, but its value is `undefined`.

This is because of the prop types on `PureTaskList`:

```jsx
PureTaskList.propTypes = {
  /** Checks if it's in loading state */
  loading: PropTypes.bool,
  /** The list of tasks */
  tasks: PropTypes.arrayOf(Task.propTypes.task).isRequired,
  /** Event to change the task to pinned */
  onPinTask: PropTypes.func.isRequired,
  /** Event to change the task to archived */
  onArchiveTask: PropTypes.func.isRequired,
}
```

This is different from [the commit linked to at the bottom of the section](https://github.com/chromaui/learnstorybook-code/commit/b29407b), which looks like:

```jsx
PureTaskList.propTypes = {
  /** Checks if it's in loading state */
  loading: PropTypes.bool,
  /** The list of tasks */
  tasks: PropTypes.arrayOf(Task.propTypes.task).isRequired,
  /** Event to change the task to pinned */
  onPinTask: PropTypes.func,
  /** Event to change the task to archived */
  onArchiveTask: PropTypes.func,
};
```

Perhaps this should be changed as well?

Here's a link to [the commit on my example project where the console is logging errors on tests](https://github.com/ChrisCrossCrash/storybook-taskbox-tut/tree/d4f386acf73eed97b738f76089943c0d951b6dd1) (caused by the prop type issue described above).