### PR TITLE
Fix typo: incorrect file name for code block

### DIFF
--- a/content/visual-testing-handbook/react/en/vtdd.md
+++ b/content/visual-testing-handbook/react/en/vtdd.md
@@ -191,7 +191,7 @@ yarn add styled-components
 
 Update your `CommentList.js` file to the following:
 
-```diff:title=src/components/CommentList.stories.js
+```diff:title=src/components/CommentList.js
 import React from 'react';
 
 import PropTypes from 'prop-types';


### PR DESCRIPTION
The article gives the wrong file name on the top of the code block. It should be "src/components/CommentList.js"