### PR TITLE
specify RN sdk version for this tutorial

### DIFF
--- a/content/intro-to-storybook/react-native/en/get-started.md
+++ b/content/intro-to-storybook/react-native/en/get-started.md
@@ -24,7 +24,7 @@ With that out of the way, let’s run the following commands:
 
 ```bash
 # Create our application:
-expo init --template tabs taskbox
+expo init --template tabs@sdk-36 taskbox
 
 cd taskbox
 


### PR DESCRIPTION
Tthe latest expo template doesn't fit to current RN tutorial.
With the latest tutorial, it is hard to walkthrough the first section (Get started).
By specifying sdk version, beginners would follow the tutorial better.