### PR TITLE
Fix task ids in mapped data

### DIFF
--- a/content/intro-to-storybook/react/en/screen.md
+++ b/content/intro-to-storybook/react/en/screen.md
@@ -47,7 +47,7 @@ const TaskBoxData = {
 +   );
 +   const data = await response.json();
 +   const result = data.map((task) => ({
-+     id: `${task.id}`,
++     id: task.id,
 +     title: task.title,
 +     state: task.completed ? 'TASK_ARCHIVED' : 'TASK_INBOX',
 +   }));


### PR DESCRIPTION
The id of the task was not interpolated but passed as a literal `${task.id}` string, which meant that all tasks had the same id, which in turn prevented the interactions from working properly later on.