### PR TITLE
Commit store actions in PureInboxScreen stories

### DIFF
--- a/content/intro-to-storybook/vue/en/screen.md
+++ b/content/intro-to-storybook/vue/en/screen.md
@@ -191,11 +191,13 @@ import PureInboxScreen from './PureInboxScreen.vue';
 +     },
 +    },
 +   actions: {
-+     pinTask(context, id) {
++     pinTask({ commit }, id) {
 +       action('pin-task')(id);
++       commit('PIN_TASK', id);
 +     },
-+     archiveTask(context, id) {
++     archiveTask({ commit }, id) {
 +       action('archive-task')(id);
++       commit('ARCHIVE_TASK', id);
 +     },
 +   },
 + });
@@ -278,11 +280,13 @@ const store = createStore({
     },
   },
   actions: {
-    pinTask(context, id) {
+    pinTask({ commit }, id) {
       action('pin-task')(id);
+      commit('PIN_TASK', id);
     },
-    archiveTask(context, id) {
+    archiveTask({ commit }, id) {
       action('archive-task')(id);
+      commit('ARCHIVE_TASK', id);
     },
   },
 });


### PR DESCRIPTION
Unless the store actions (**ARCHIVE_TASK** and **PIN_TASK**) in `PureInboxScreen.storeis.js` are committed to the store, the archiving and pinning of tasks in Storybook does not produce any visual results.