### PR TITLE
Chore: Fix inaccuracy in `vue/en/composite-component.md`

### DIFF
--- a/content/intro-to-storybook/vue/en/composite-component.md
+++ b/content/intro-to-storybook/vue/en/composite-component.md
@@ -144,7 +144,7 @@ Empty.args = {
 ```
 
 <div class="aside">
-💡 <a href="https://storybook.js.org/docs/vue/writing-stories/decorators"><b>Decorators</b></a> are a way to provide arbitrary wrappers to stories. In this case we’re using a decorator key on the default export to add some <code>padding</code> around the rendered component. But they can also be used to add other context to components, as we'll see later.
+💡 <a href="https://storybook.js.org/docs/vue/writing-stories/decorators"><b>Decorators</b></a> are a way to provide arbitrary wrappers to stories. In this case we’re using a decorator key on the default export to add some <code>margin</code> around the rendered component. But they can also be used to add other context to components, as we'll see later.
 </div>
 
 By importing `TaskStories`, we were able to [compose](https://storybook.js.org/docs/vue/writing-stories/args#args-composition) the arguments (args for short) in our stories with minimal effort. That way, the data and actions (mocked callbacks) expected by both components are preserved.


### PR DESCRIPTION
At some point the example code for the decorator was changed from `padding` to `margin` but this little blurb didn't update with it. 