### PR TITLE
Removed styling only addressed in topic 'Addons'

### DIFF
--- a/content/intro-to-storybook/angular/en/simple-component.md
+++ b/content/intro-to-storybook/angular/en/simple-component.md
@@ -237,7 +237,6 @@ import { Task } from '../models/task.model';
           id="title-{{ task?.id }}"
           name="title-{{ task?.id }}"
           placeholder="Input title"
-          style="text-overflow: ellipsis;"
         />
       </label>
       <button


### PR DESCRIPTION
In the topic 'Addons' this component is tested by using the Controls Addon. At this point the overflow behavior with long strings is addressed by adding the styling and a visual regression test. Since this style is already added at the start of the course, someone following along the tutorial will not see the text overflow the component like in the examples. So it should not be there yet at this point.