### PR TITLE
Chore: (Docs) removes links to official storybook

### DIFF
--- a/content/create-an-addon/react/en/conclusion.md
+++ b/content/create-an-addon/react/en/conclusion.md
@@ -16,7 +16,7 @@ The [addon documentation](https://storybook.js.org/docs/react/addons/introductio
 
 If you’re coding along with us, your repositories should look like this: [Sample addon repository](http://github.com/chromaui/learnstorybook-addon-code). This example was based on the [Storybook Addon Outline](https://github.com/chromaui/storybook-addon-outline).
 
-You can also reference other addons such as [Pseudo States](https://github.com/chromaui/storybook-addon-pseudo-states), [Dark Mode](https://github.com/hipstersmoothie/storybook-dark-mode) and all [other official addons](https://github.com/storybookjs/storybook/tree/next/addons) and play with them in the [official Storybook](https://next--storybookjs.netlify.app/official-storybook/).
+You can also reference other addons such as [Pseudo States](https://github.com/chromaui/storybook-addon-pseudo-states), [Dark Mode](https://github.com/hipstersmoothie/storybook-dark-mode) and all [other official addons](https://github.com/storybookjs/storybook/tree/next/addons).
 
 Thanks for learning with us. Subscribe to the Storybook mailing list to get notified when helpful articles and guides like this are published.
 

--- a/content/create-an-addon/react/en/register-an-addon.md
+++ b/content/create-an-addon/react/en/register-an-addon.md
@@ -4,7 +4,7 @@ description: 'Build the addon UI and register it in Storybook'
 commit: '5db9bc9'
 ---
 
-Let's start in the `src/Tool.js` file. This is where the UI code for the Outline tool will live. Notice the [@storybook/components](https://www.npmjs.com/package/@storybook/components) import. This is Storybooks own component library, built with React and Emotion. It's used to build, well, Storybook itself ([demo](https://next--storybookjs.netlify.app/official-storybook/)). We can also use it to build our addon.
+Let's start in the `src/Tool.js` file. This is where the UI code for the Outline tool will live. Notice the [@storybook/components](https://www.npmjs.com/package/@storybook/components) import. This is Storybooks own component library, built with React and Emotion. It's used to build, well, Storybook itself. We can also use it to build our addon.
 
 In this case, we’ll use the `Icons` and `IconButton` components to create the outline selector tool. Modify your code to use the `outline` icon and give it an appropriate title.
 

--- a/content/create-an-addon/react/es/conclusion.md
+++ b/content/create-an-addon/react/es/conclusion.md
@@ -10,15 +10,13 @@ description: 'Ayuda a automatizar y ampliar Storybook'
 
 Comenzar es sencillo. El [Kit Addon](https://github.com/storybookjs/addon-kit) ofrece todo lo necesario para crear un complemento. Con el [API de complementos](https://storybook.js.org/docs/react/addons/addons-api), puedes agregar nuevas funciones, automatizar flujos de trabajo e integrarlo con tus bibliotecas favoritas. Además, puedes compartir esos complementos con miles de desarrolladores a través del [catálogo de complementos](https://storybook.js.org/addons).
 
-
 ## Sigue aprendiendo
 
 La [documentación de complementos](https://storybook.js.org/docs/react/addons/introduction) ofrece más guías, ejemplos de código y consejos.
 
 Si estás codificando junto a nosotros, tus repositorios deberían verse así: [Repositorio de muestra](http://github.com/chromaui/learnstorybook-addon-code). Este ejemplo está basado en el [Storybook Addon Outline](https://github.com/chromaui/storybook-addon-outline).
 
-
-También puedes hacer referencia a otros complementos como [Pseudo Estados](https://github.com/chromaui/storybook-addon-pseudo-states), [Modo Oscuro](https://github.com/hipstersmoothie/storybook-dark-mode) y todos los demás [complementos oficiales](https://github.com/storybookjs/storybook/tree/next/addons) y probarlos en el [Storybook oficial](https://next--storybookjs.netlify.app/official-storybook/).
+También puedes hacer referencia a otros complementos como [Pseudo Estados](https://github.com/chromaui/storybook-addon-pseudo-states), [Modo Oscuro](https://github.com/hipstersmoothie/storybook-dark-mode) y todos los demás [complementos oficiales](https://github.com/storybookjs/storybook/tree/next/addons).
 
 Gracias por aprender con nosotros. Suscríbete a la lista de correo de Storybook para recibir notificaciones cuando se publiquen artículos y guías útiles como esta.
 

--- a/content/create-an-addon/react/es/register-an-addon.md
+++ b/content/create-an-addon/react/es/register-an-addon.md
@@ -4,7 +4,7 @@ description: 'Crea el UI del complemento y regístralo en Storybook'
 commit: '5db9bc9'
 ---
 
-Empecemos por el archivo `src/Tool.js`. Aquí es donde vivirá el código UI de la herramienta Outline. Observa la importación de [@storybook/components](https://www.npmjs.com/package/@storybook/components). Esta es la biblioteca de componentes propia de Storybooks, construida con React y Emotion. Se usa para construir, bueno, el propio Storybook ([demo](https://next--storybookjs.netlify.app/official-storybook/)). También podemos usarlo para construir nuestro complemento.
+Empecemos por el archivo `src/Tool.js`. Aquí es donde vivirá el código UI de la herramienta Outline. Observa la importación de [@storybook/components](https://www.npmjs.com/package/@storybook/components). Esta es la biblioteca de componentes propia de Storybooks, construida con React y Emotion. Se usa para construir, bueno, el propio Storybook. También podemos usarlo para construir nuestro complemento.
 
 En este caso, usaremos los componentes `Icons` y `IconButton` para crear la herramienta de selección de contorno. Modifica tu código para usar el ícono `outline` y dale un título apropiado.
 

--- a/content/create-an-addon/react/fr/conclusion.md
+++ b/content/create-an-addon/react/fr/conclusion.md
@@ -16,7 +16,7 @@ La [documentation](https://storybook.js.org/docs/react/addons/introduction) prop
 
 Si vous suivez nos guides, votre dépôt devrait ressembler à ça : [exemple de dépôt d'un addon](http://github.com/chromaui/learnstorybook-addon-code). Cet exemple repose sur l'addon [Outline](https://github.com/chromaui/storybook-addon-outline) de Storybook.
 
-Vous pouvez également vous baser sur d'autres addons tels que [Pseudo States](https://github.com/chromaui/storybook-addon-pseudo-states), [Dark Mode](https://github.com/hipstersmoothie/storybook-dark-mode) et tous les [autres addons officiels](https://github.com/storybookjs/storybook/tree/next/addons) et jouer avec dans le [Storybook officiel](https://next--storybookjs.netlify.app/official-storybook/).
+Vous pouvez également vous baser sur d'autres addons tels que [Pseudo States](https://github.com/chromaui/storybook-addon-pseudo-states), [Dark Mode](https://github.com/hipstersmoothie/storybook-dark-mode) et tous les [autres addons officiels](https://github.com/storybookjs/storybook/tree/next/addons).
 
 Merci d'apprendre à nos côtés. Inscrivez-vous à la mailing list de Storybook pour être averti lorsque de nouveaux articles et guides utiles comme celui-ci sont publiés.
 

--- a/content/create-an-addon/react/fr/register-an-addon.md
+++ b/content/create-an-addon/react/fr/register-an-addon.md
@@ -4,7 +4,7 @@ description: "Créer l'UI de l'addon et l'enregistrer dans Storybook"
 commit: '5db9bc9'
 ---
 
-Commençons par le fichier `src/Tool.js`. C'est dans ce fichier que se trouvera tout le code de l'UI pour l'outil Outline. Notez l'import de [@storybook/components](https://www.npmjs.com/package/@storybook/components). Il s'agit de la bibliothèque de composants de Storybook, créée avec React et Emotion. Elle sert à construire, eh bien, Storybook lui-même ([démo](https://next--storybookjs.netlify.app/official-storybook/)). Nous pouvons également l'utiliser pour créer notre addon.
+Commençons par le fichier `src/Tool.js`. C'est dans ce fichier que se trouvera tout le code de l'UI pour l'outil Outline. Notez l'import de [@storybook/components](https://www.npmjs.com/package/@storybook/components). Il s'agit de la bibliothèque de composants de Storybook, créée avec React et Emotion. Elle sert à construire, eh bien, Storybook lui-même. Nous pouvons également l'utiliser pour créer notre addon.
 
 Dans notre cas, nous utiliserons les composants `Icons` et `IconButton` pour créer le bouton de notre outil de contour. Modifiez votre code afin d'utiliser l'icône `outline` et donnez au bouton un nom approprié.
 

--- a/content/create-an-addon/react/ko/conclusion.md
+++ b/content/create-an-addon/react/ko/conclusion.md
@@ -16,7 +16,7 @@ description: '스토리북의 확장과 자동화를 도와주세요'
 
 저희와 함께 코딩한다면, 저장소는 다음과 같아야 합니다: [애드온 저장소 예시](http://github.com/chromaui/learnstorybook-addon-code). 이 예시는 [스토리북 애드온 개요](https://github.com/chromaui/storybook-addon-outline)를 기반으로 하고 있습니다.
 
-[스토리북 공식 페이지](https://next--storybookjs.netlify.app/official-storybook/) 를 통해 [Pseudo States](https://github.com/chromaui/storybook-addon-pseudo-states), [다크 모드](https://github.com/hipstersmoothie/storybook-dark-mode), [다른 모든 공식 애드온](https://github.com/storybookjs/storybook/tree/next/addons)을 참고할 수 있습니다.
+스토리북 공식 페이지 를 통해 [Pseudo States](https://github.com/chromaui/storybook-addon-pseudo-states), [다크 모드](https://github.com/hipstersmoothie/storybook-dark-mode), [다른 모든 공식 애드온](https://github.com/storybookjs/storybook/tree/next/addons)을 참고할 수 있습니다.
 
 여기까지 함께해주셔서 감사합니다. 유용한 블로그와 가이드가 게시될 때 알림을 받으려면 스토리북 이메일 구독 계정을 등록해주세요.
 

--- a/content/create-an-addon/react/ko/register-addon.md
+++ b/content/create-an-addon/react/ko/register-addon.md
@@ -4,7 +4,7 @@ description: '애드온 UI를 만들고 Storybook 안에 등록하기'
 commit: ''
 ---
 
-`src/Tool.js`파일에서 시작해봅시다. 여기에 아웃라인 툴의 UI 코드가 위치합니다. [@storybook/components](https://www.npmjs.com/package/@storybook/components) 경로에서 import 하는 것을 주목하세요. 리액트(React)와 이모션(Emotion)으로 구축된 스토리북(Storybook)의 컴포넌트 라이브러리입니다. 스토리북 자체([데모](https://next--storybookjs.netlify.app/official-storybook/))를 구축하는데 사용하고, 또한 애드온을 만드는 데에 사용할 수 있습니다.
+`src/Tool.js`파일에서 시작해봅시다. 여기에 아웃라인 툴의 UI 코드가 위치합니다. [@storybook/components](https://www.npmjs.com/package/@storybook/components) 경로에서 import 하는 것을 주목하세요. 리액트(React)와 이모션(Emotion)으로 구축된 스토리북(Storybook)의 컴포넌트 라이브러리입니다. 스토리북 자체를 구축하는데 사용하고, 또한 애드온을 만드는 데에 사용할 수 있습니다.
 
 이번에는 `Icons` 와 `IconButton` 컴포넌트를 사용하여 아웃라인 셀렉터(selector) 툴을 만들겠습니다. `outline` 아이콘을 사용하고 적절한 이름을 가지도록 코드를 수정해보세요.
 
@@ -38,9 +38,8 @@ export const Tool = () => {
 };
 ```
 
-manager 파일로 이동해서, 애드온을 스토리북과 함께 고유 아이디로 `ADDON_ID` 등록합니다. 
+manager 파일로 이동해서, 애드온을 스토리북과 함께 고유 아이디로 `ADDON_ID` 등록합니다.
 툴 역시도 고유한 아이디와 함께 등록합니다. `storybook/addon-name`과 같은 이름을 권장합니다. 애드온 키트는 탭과 패널 예시도 포함하고 있습니다. 아웃라인 애드온은 툴만을 사용하기 때문에, 나머지는 삭제해도 됩니다.
-
 
 ```js:title=src/preset/manager.js
 import { addons, types } from '@storybook/addons';

--- a/content/intro-to-storybook/vue/zh-CN/conclusion.md
+++ b/content/intro-to-storybook/vue/zh-CN/conclusion.md
@@ -15,7 +15,7 @@ description: '汇总所有的知识并学习更多Storybook技巧'
 
 如果您和我们一起编写代码的话，您的仓库应该如此所示： [Sample addon repository](http://github.com/chromaui/learnstorybook-addon-code). 此样例基于 [Storybook Addon Outline](https://github.com/chromaui/storybook-addon-outline)。
 
-您也可以参考其他的插件，例如 [Pseudo States](https://github.com/chromaui/storybook-addon-pseudo-states), [Dark Mode](https://github.com/hipstersmoothie/storybook-dark-mode) 和所有 [其他的官方插件](https://github.com/storybookjs/storybook/tree/next/addons) 并结合 [official Storybook](https://next--storybookjs.netlify.app/official-storybook/)使用它们。
+您也可以参考其他的插件，例如 [Pseudo States](https://github.com/chromaui/storybook-addon-pseudo-states), [Dark Mode](https://github.com/hipstersmoothie/storybook-dark-mode) 和所有 [其他的官方插件](https://github.com/storybookjs/storybook/tree/next/addons) 并结合 使用它们。
 
 感谢与我们共同学习。 通过订阅 Storybook 的邮件列表来获取其他有用的文章或者像此指南一样的信息。
 


### PR DESCRIPTION
With this pull request, the reference to the official storybook is removed throughout the tutorials. Addresses [this issue](https://github.com/storybookjs/storybook/issues/19436)