### PR TITLE
Chore: (Docs): Fix tutorial links

### DIFF
--- a/content/create-an-addon/react/en/conclusion.md
+++ b/content/create-an-addon/react/en/conclusion.md
@@ -16,7 +16,7 @@ The [addon documentation](https://storybook.js.org/docs/react/addons/introductio
 
 If you’re coding along with us, your repositories should look like this: [Sample addon repository](http://github.com/chromaui/learnstorybook-addon-code). This example was based on the [Storybook Addon Outline](https://github.com/chromaui/storybook-addon-outline).
 
-You can also reference other addons such as [Pseudo States](https://github.com/chromaui/storybook-addon-pseudo-states), [Dark Mode](https://github.com/hipstersmoothie/storybook-dark-mode) and all [other official addons](https://github.com/storybookjs/storybook/tree/next/addons).
+You can also reference other addons such as [Pseudo States](https://github.com/chromaui/storybook-addon-pseudo-states), [Dark Mode](https://github.com/hipstersmoothie/storybook-dark-mode) and all [other official addons](https://github.com/storybookjs/storybook/tree/next/code/addons).
 
 Thanks for learning with us. Subscribe to the Storybook mailing list to get notified when helpful articles and guides like this are published.
 

--- a/content/create-an-addon/react/es/conclusion.md
+++ b/content/create-an-addon/react/es/conclusion.md
@@ -16,7 +16,7 @@ La [documentación de complementos](https://storybook.js.org/docs/react/addons/i
 
 Si estás codificando junto a nosotros, tus repositorios deberían verse así: [Repositorio de muestra](http://github.com/chromaui/learnstorybook-addon-code). Este ejemplo está basado en el [Storybook Addon Outline](https://github.com/chromaui/storybook-addon-outline).
 
-También puedes hacer referencia a otros complementos como [Pseudo Estados](https://github.com/chromaui/storybook-addon-pseudo-states), [Modo Oscuro](https://github.com/hipstersmoothie/storybook-dark-mode) y todos los demás [complementos oficiales](https://github.com/storybookjs/storybook/tree/next/addons).
+También puedes hacer referencia a otros complementos como [Pseudo Estados](https://github.com/chromaui/storybook-addon-pseudo-states), [Modo Oscuro](https://github.com/hipstersmoothie/storybook-dark-mode) y todos los demás [complementos oficiales](https://github.com/storybookjs/storybook/tree/next/code/addons).
 
 Gracias por aprender con nosotros. Suscríbete a la lista de correo de Storybook para recibir notificaciones cuando se publiquen artículos y guías útiles como esta.
 

--- a/content/create-an-addon/react/fr/conclusion.md
+++ b/content/create-an-addon/react/fr/conclusion.md
@@ -16,7 +16,7 @@ La [documentation](https://storybook.js.org/docs/react/addons/introduction) prop
 
 Si vous suivez nos guides, votre dépôt devrait ressembler à ça : [exemple de dépôt d'un addon](http://github.com/chromaui/learnstorybook-addon-code). Cet exemple repose sur l'addon [Outline](https://github.com/chromaui/storybook-addon-outline) de Storybook.
 
-Vous pouvez également vous baser sur d'autres addons tels que [Pseudo States](https://github.com/chromaui/storybook-addon-pseudo-states), [Dark Mode](https://github.com/hipstersmoothie/storybook-dark-mode) et tous les [autres addons officiels](https://github.com/storybookjs/storybook/tree/next/addons).
+Vous pouvez également vous baser sur d'autres addons tels que [Pseudo States](https://github.com/chromaui/storybook-addon-pseudo-states), [Dark Mode](https://github.com/hipstersmoothie/storybook-dark-mode) et tous les [autres addons officiels](https://github.com/storybookjs/storybook/tree/next/code/addons).
 
 Merci d'apprendre à nos côtés. Inscrivez-vous à la mailing list de Storybook pour être averti lorsque de nouveaux articles et guides utiles comme celui-ci sont publiés.
 

--- a/content/create-an-addon/react/ko/conclusion.md
+++ b/content/create-an-addon/react/ko/conclusion.md
@@ -16,7 +16,7 @@ description: '스토리북의 확장과 자동화를 도와주세요'
 
 저희와 함께 코딩한다면, 저장소는 다음과 같아야 합니다: [애드온 저장소 예시](http://github.com/chromaui/learnstorybook-addon-code). 이 예시는 [스토리북 애드온 개요](https://github.com/chromaui/storybook-addon-outline)를 기반으로 하고 있습니다.
 
-스토리북 공식 페이지 를 통해 [Pseudo States](https://github.com/chromaui/storybook-addon-pseudo-states), [다크 모드](https://github.com/hipstersmoothie/storybook-dark-mode), [다른 모든 공식 애드온](https://github.com/storybookjs/storybook/tree/next/addons)을 참고할 수 있습니다.
+스토리북 공식 페이지 를 통해 [Pseudo States](https://github.com/chromaui/storybook-addon-pseudo-states), [다크 모드](https://github.com/hipstersmoothie/storybook-dark-mode), [다른 모든 공식 애드온](https://github.com/storybookjs/storybook/tree/next/code/addons)을 참고할 수 있습니다.
 
 여기까지 함께해주셔서 감사합니다. 유용한 블로그와 가이드가 게시될 때 알림을 받으려면 스토리북 이메일 구독 계정을 등록해주세요.
 

--- a/content/design-systems-for-developers/react/zh-CN/build.md
+++ b/content/design-systems-for-developers/react/zh-CN/build.md
@@ -114,7 +114,7 @@ Storybook 的插件是由一个庞大的社区生态系统来共同维护的。�
 
 <h4>用于验证交互的 Actions 插件</h4>
 
-当您与 Button 或 Link 之类的交互式组件进行交互时，[actions 插件](https://github.com/storybookjs/storybook/tree/next/addons/actions) 可以在 Storybook 中为您的组件提供 UI 反馈。默认情况下，Actions 应该已经安装在您的 Storybook 中了，您只需要将 “action” 作为回调传给您的组件即可。
+当您与 Button 或 Link 之类的交互式组件进行交互时，[actions 插件](https://github.com/storybookjs/storybook/tree/next/code/addons/actions) 可以在 Storybook 中为您的组件提供 UI 反馈。默认情况下，Actions 应该已经安装在您的 Storybook 中了，您只需要将 “action” 作为回调传给您的组件即可。
 
 让我们看看如何在 Button 组件中使用它，该 Button 组件接受一个封装的组件来响应它的点击事件。我们的 story 给封装组件的 click 事件上传入了 action 回调：
 

--- a/content/intro-to-storybook/vue/zh-CN/conclusion.md
+++ b/content/intro-to-storybook/vue/zh-CN/conclusion.md
@@ -15,7 +15,7 @@ description: '汇总所有的知识并学习更多Storybook技巧'
 
 如果您和我们一起编写代码的话，您的仓库应该如此所示： [Sample addon repository](http://github.com/chromaui/learnstorybook-addon-code). 此样例基于 [Storybook Addon Outline](https://github.com/chromaui/storybook-addon-outline)。
 
-您也可以参考其他的插件，例如 [Pseudo States](https://github.com/chromaui/storybook-addon-pseudo-states), [Dark Mode](https://github.com/hipstersmoothie/storybook-dark-mode) 和所有 [其他的官方插件](https://github.com/storybookjs/storybook/tree/next/addons) 并结合 使用它们。
+您也可以参考其他的插件，例如 [Pseudo States](https://github.com/chromaui/storybook-addon-pseudo-states), [Dark Mode](https://github.com/hipstersmoothie/storybook-dark-mode) 和所有 [其他的官方插件](https://github.com/storybookjs/storybook/tree/next/code/addons) 并结合 使用它们。
 
 感谢与我们共同学习。 通过订阅 Storybook 的邮件列表来获取其他有用的文章或者像此指南一样的信息。
 


### PR DESCRIPTION
WIth this pull request some of the tutorial's links are updated to point to the correct location in the monorepo in light of the recent change introduced.