### PR TITLE
Chore: (Intro Storybook) Updates Svelte to 6.5

### DIFF
--- a/content/intro-to-storybook/svelte/en/data.md
+++ b/content/intro-to-storybook/svelte/en/data.md
@@ -33,15 +33,21 @@ const TaskBox = () => {
 
   return {
     subscribe,
-    // Method to archive a task, think of a action with redux or Vuex
-    archiveTask: id =>
-      update(tasks =>
-        tasks.map(task => (task.id === id ? { ...task, state: 'TASK_ARCHIVED' } : task))
+    // Method to archive a task, think of a action with redux or Pinia
+    archiveTask: (id) =>
+      update((tasks) =>
+        tasks
+          .map((task) =>
+            task.id === id ? { ...task, state: 'TASK_ARCHIVED' } : task
+          )
+          .filter((t) => t.state === 'TASK_INBOX' || t.state === 'TASK_PINNED')
       ),
-    // Method to archive a task, think of a action with redux or Vuex
-    pinTask: id =>
-      update(tasks =>
-        tasks.map(task => (task.id === id ? { ...task, state: 'TASK_PINNED' } : task))
+    // Method to archive a task, think of a action with redux or Pinia
+    pinTask: (id) =>
+      update((tasks) =>
+        tasks.map((task) =>
+          task.id === id ? { ...task, state: 'TASK_PINNED' } : task
+        )
       ),
   };
 };
@@ -52,18 +58,20 @@ Then we'll update our `TaskList` to read data out of the store. First, let's mov
 
 In `src/components/PureTaskList.svelte`:
 
-```svelte:title=src/components/PureTaskList.svelte
+```html:title=src/components/PureTaskList.svelte
 <!--This file moved from TaskList.svelte-->
 <script>
   import Task from './Task.svelte';
   import LoadingRow from './LoadingRow.svelte';
   export let loading = false;
   export let tasks = [];
+
+  //👇 Reactive declarations (computed props in other frameworks)
   $: noTasks = tasks.length === 0;
-  $: emptyTasks = tasks.length === 0 && !loading;
+  $: emptyTasks = noTasks && !loading;
   $: tasksInOrder = [
-    ...tasks.filter(t => t.state === 'TASK_PINNED'),
-    ...tasks.filter(t => t.state !== 'TASK_PINNED'),
+    ...tasks.filter((t) => t.state === 'TASK_PINNED'),
+    ...tasks.filter((t) => t.state !== 'TASK_PINNED'),
   ];
 </script>
 
@@ -76,26 +84,28 @@ In `src/components/PureTaskList.svelte`:
     <LoadingRow />
   </div>
 {/if}
-{#if noTasks && !loading}
+{#if emptyTasks}
   <div class="list-items">
     <div class="wrapper-message">
       <span class="icon-check" />
-      <div class="title-message">You have no tasks</div>
-      <div class="subtitle-message">Sit back and relax</div>
+      <p class="title-message">You have no tasks</p>
+      <p class="subtitle-message">Sit back and relax</p>
     </div>
   </div>
 {/if}
 {#each tasksInOrder as task}
   <Task {task} on:onPinTask on:onArchiveTask />
 {/each}
+
 ```
 
 In `src/components/TaskList.svelte`:
 
-```svelte:title=src/components/TaskList.svelte
+```html:title=src/components/TaskList.svelte
 <script>
   import PureTaskList from './PureTaskList.svelte';
   import { taskStore } from '../store';
+
   function onPinTask(event) {
     taskStore.pinTask(event.detail.id);
   }
@@ -104,13 +114,11 @@ In `src/components/TaskList.svelte`:
   }
 </script>
 
-<div>
-  <PureTaskList
-    tasks={$taskStore}
-    on:onPinTask={onPinTask}
-    on:onArchiveTask={onArchiveTask}
-  />
-</div>
+<PureTaskList
+  tasks={$taskStore}
+  on:onPinTask={onPinTask}
+  on:onArchiveTask={onArchiveTask}
+/>
 ```
 
 The reason to keep the presentational version of the `TaskList` separate is that it is easier to test and isolate. As it doesn't rely on the presence of a store, it is much easier to deal with from a testing perspective. Let's rename `src/components/TaskList.stories.js` into `src/components/PureTaskList.stories.js` and ensure our stories use the presentational version:
@@ -186,7 +194,7 @@ Empty.args = {
 </video>
 
 <div class="aside">
-💡 With this change, all of our tests will require an update. Update the imports and re-run the test command with the <code>-u</code> flag to update them. Also, don't forget to commit your changes with git!
+💡 Don't forget to commit your changes with git!
 </div>
 
 Now that we have some actual data populating our component, obtained from the Svelte store, we could have wired it to `src/App.svelte` and render the component there. Don't worry about it. We'll take care of it in the next chapter.

--- a/content/intro-to-storybook/svelte/en/deploy.md
+++ b/content/intro-to-storybook/svelte/en/deploy.md
@@ -100,7 +100,7 @@ jobs:
       - uses: chromaui/action@v1
         # Options required for Chromatic's GitHub Action
         with:
-          #👇 Chromatic projectToken, see https://storybook.js.org/tutorials/intro-to-storybook/react/en/deploy/ to obtain it
+          #👇 Chromatic projectToken, see https://storybook.js.org/tutorials/intro-to-storybook/svelte/en/deploy/ to obtain it
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/content/intro-to-storybook/svelte/en/test.md
+++ b/content/intro-to-storybook/svelte/en/test.md
@@ -1,18 +1,20 @@
 ---
-title: 'Test UI components'
-tocTitle: 'Testing'
+title: 'Visual Tests'
+tocTitle: 'Visual Testing'
 description: 'Learn the ways to test UI components'
 ---
 
 No Storybook tutorial would be complete without testing. Testing is essential to creating high-quality UIs. In modular systems, minuscule tweaks can result in major regressions. So far, we have encountered three types of tests:
 
 - **Manual tests** rely on developers to manually look at a component to verify it for correctness. They help us sanity check a component’s appearance as we build.
-- **Snapshot tests** with Storyshots capture a component’s rendered markup. They help us stay abreast of markup changes that cause rendering errors and warnings.
-- **Unit tests** with Jest verify that the output of a component remains the same given a fixed input. They’re great for testing the functional qualities of a component.
+
+- **Accessibility tests** with a11y addon verify that the component is accessible to everyone. They're great for allowing us to collect information about how people with certain types of disabilities use our components.
+
+- **Interaction tests** with the play function verify that the component behaves as expected when interacting with it. They're great for testing the behavior of a component when it's in use.
 
 ## “But does it look right?”
 
-Unfortunately, the aforementioned testing methods alone aren’t enough to prevent UI bugs. UIs are tricky to test because design is subjective and nuanced. Manual tests are, well, manual. When used for UI, snapshot tests trigger too many false positives, and pixel-level unit tests are of poor value. A complete Storybook testing strategy also includes visual regression tests.
+Unfortunately, the aforementioned testing methods alone aren’t enough to prevent UI bugs. UIs are tricky to test because design is subjective and nuanced. Manual tests are, well, manual. Other UI tests, such as snapshot tests, trigger too many false positives, and pixel-level unit tests are poorly valued. A complete Storybook testing strategy also includes visual regression tests.
 
 ## Visual testing for Storybook
 
@@ -27,7 +29,7 @@ Visual regression tests, also called visual tests, are designed to catch changes
 
 Storybook is a fantastic tool for visual regression testing because every story is essentially a test specification. Each time we write or update a story, we get a spec for free!
 
-There are several tools for visual regression testing. We recommend [**Chromatic**](https://www.chromatic.com/), a free publishing service made by the Storybook maintainers that runs visual tests in parallelized cloud. It also allows us to publish Storybook online, as we saw in the [previous chapter](/intro-to-storybook/svelte/en/deploy/).
+There are several tools for visual regression testing. We recommend [**Chromatic**](https://www.chromatic.com/), a free publishing service made by the Storybook maintainers that runs visual tests in a lightning-fast cloud browser environment. It also allows us to publish Storybook online, as we saw in the [previous chapter](/intro-to-storybook/svelte/en/deploy/).
 
 ## Catch a UI change
 
@@ -44,29 +46,37 @@ git checkout -b change-task-background
 Change `src/components/Task.svelte` to the following:
 
 ```diff:title=src/components/Task.svelte
-<div class="list-item">
-   <input type="text" value={task.title} readonly />
-</div>
 <div class="list-item {task.state}">
-  <label class="checkbox">
-    <input type="checkbox" checked={isChecked} disabled name="checked" />
-    <span class="checkbox-custom" on:click={ArchiveTask} aria-label={`archiveTask-${task.id}`}/>
+  <label for="checked" class="checkbox" aria-label={`archiveTask-${task.id}`}>
+    <input
+      type="checkbox"
+      checked={isChecked}
+      disabled
+      name="checked"
+      id={`archiveTask-${task.id}`}
+    />
+    <span class="checkbox-custom" on:click={ArchiveTask} />
   </label>
-  <div class="title">
-    <input type="text"
-      readonly
+  <label for="title" aria-label={task.title} class="title">
+    <input
+      type="text"
       value={task.title}
+      readonly
+      name="title"
       placeholder="Input title"
 +     style="background: red;"
     />
-  </div>
-  <div class="actions">
-    {#if task.state !== 'TASK_ARCHIVED'}
-      <a href="/" on:click|preventDefault={PinTask}>
-        <span class="icon-star" aria-label={`pinTask-${task.id}`}/>
-      </a>
-     {/if}
-  </div>
+  </label>
+  {#if task.state !== "TASK_ARCHIVED"}
+    <button
+      class="pin-button"
+      on:click|preventDefault={PinTask}
+      id={`pinTask-${task.id}`}
+      aria-label={`pinTask-${task.id}`}
+    >
+      <span class="icon-star" />
+    </button>
+  {/if}
 </div>
 ```
 

--- a/content/intro-to-storybook/svelte/en/using-addons.md
+++ b/content/intro-to-storybook/svelte/en/using-addons.md
@@ -40,29 +40,37 @@ Controls allowed us to quickly verify different inputs to a component--in this c
 Now let's fix the issue with overflowing by adding a style to `Task.svelte`:
 
 ```diff:title=src/components/Task.svelte
-<div class="list-item">
-   <input type="text" value={task.title} readonly />
-</div>
 <div class="list-item {task.state}">
-  <label class="checkbox">
-    <input type="checkbox" checked={isChecked} disabled name="checked" />
-    <span class="checkbox-custom" on:click={ArchiveTask} aria-label={`archiveTask-${task.id}`}/>
+  <label for="checked" class="checkbox" aria-label={`archiveTask-${task.id}`}>
+    <input
+      type="checkbox"
+      checked={isChecked}
+      disabled
+      name="checked"
+      id={`archiveTask-${task.id}`}
+    />
+    <span class="checkbox-custom" on:click={ArchiveTask} />
   </label>
-  <div class="title">
-    <input type="text"
-      readonly
+  <label for="title" aria-label={task.title} class="title">
+    <input
+      type="text"
       value={task.title}
+      readonly
+      name="title"
       placeholder="Input title"
 +     style="text-overflow: ellipsis;"
     />
-  </div>
-  <div class="actions">
-    {#if task.state !== 'TASK_ARCHIVED'}
-      <a href="/" on:click|preventDefault={PinTask}>
-        <span class="icon-star" aria-label={`pinTask-${task.id}`}/>
-      </a>
-     {/if}
-  </div>
+  </label>
+  {#if task.state !== "TASK_ARCHIVED"}
+    <button
+      class="pin-button"
+      on:click|preventDefault={PinTask}
+      id={`pinTask-${task.id}`}
+      aria-label={`pinTask-${task.id}`}
+    >
+      <span class="icon-star" />
+    </button>
+  {/if}
 </div>
 ```
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -48,7 +48,7 @@ module.exports = {
           pt: 5.3,
         },
         svelte: {
-          en: 6.4,
+          en: 6.5,
           es: 5.3,
         },
         ember: {


### PR DESCRIPTION
With this pull request, the Svelte version of the Intro to Storybook tutorial is updated to feature the changes introduced with 6.5 (test-runner, a11y)
What was done:
- Updated the snippets accordingly
- Updated `gatsby-config.js`
- All necessary sections updated were updated to reflect the changes

The baseline repo for the changes is [here](https://github.com/jonniebigodes/intro-storybook-svelte-6-5)

