### PR TITLE
Fix EditTask play function

### DIFF
--- a/content/ui-testing-handbook/react/en/interaction-testing.md
+++ b/content/ui-testing-handbook/react/en/interaction-testing.md
@@ -217,7 +217,7 @@ EditTask.play = async ({ canvasElement }) => {
   const itemToEdit = await getTask('Fix bug in input error state');
   const taskInput = await findByRole(itemToEdit, 'textbox');
 
-  userEvent.type(taskInput, ' and disabled state');
+  await userEvent.type(taskInput, ' and disabled state');
   await expect(taskInput.value).toBe('Fix bug in input error state and disabled state');
 };
 ```


### PR DESCRIPTION
If you do not put await in front of userEvent, then when moving through this step in the "Interactions" tab in the Storybook, there will be an instant transition to the next step, due to which the value of the input field will not have time to change, that is, the test will fail.

Video: https://monosnap.com/file/jeGnfLi5oysTYK5QOdxcu5rLq7SAqN