### PR TITLE
Fix a typo error

### DIFF
--- a/content/intro-to-storybook/react/en/simple-component.md
+++ b/content/intro-to-storybook/react/en/simple-component.md
@@ -102,7 +102,7 @@ As we have multiple permutations of our component, assigning it to a `Template` 
 
 Arguments or [`args`](https://storybook.js.org/docs/react/writing-stories/args) for short, allow us to live-edit our components with the controls addon without restarting Storybook. Once an [`args`](https://storybook.js.org/docs/react/writing-stories/args) value changes, so does the component.
 
-When creating a story, we use a base `task` arg to build out the shape of the task the component expects. Typically modeled from what the actual data looks like. Again, `export`-ing this shape will enable us to reuse it in later stories, as we'll see.
+When creating a story, we use a base `task` arg to build out the shape of the task the component expects. Typically modeled from what the actual data looks like. Again, exporting this shape will enable us to reuse it in later stories, as we'll see.
 
 <div class="aside">
 💡 <a href="https://storybook.js.org/docs/react/essentials/actions"><b>Actions</b></a> help you verify interactions when building UI components in isolation. Oftentimes you won't have access to the functions and state you have in context of the app. Use <code>action()</code> to stub them in.


### PR DESCRIPTION
Fixed a type of error on [Build a simple component](https://storybook.js.org/tutorials/intro-to-storybook/react/en/simple-component/)