### PR TITLE
Updates branch for docs and main website

### DIFF
--- a/scripts/extract-sb-docs-metadata.sh
+++ b/scripts/extract-sb-docs-metadata.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -
 
-BRANCH='master'
+BRANCH='main'
 
 MONOREPO_CODELOAD_URL='https://codeload.github.com/storybookjs/storybook/tar.gz'
 DOCS_TAR_NAME="storybook-$BRANCH"


### PR DESCRIPTION
With this pull request, the default branch used by the docs and frontpage repos is updated to prevent builds from working correctly in CI.

Once this is out, I'll test this with a pull request for the tutorials to see if CI is working as it should. Sounds like a plan @winkerVSbecks ?

