### PR TITLE
Chore (CI): Fixes error in Chromatic CI workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,8 +7,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v3
-          with:
-            node-version: 18
+        with:
+          node-version: 18
       - run: yarn
       - run: yarn gatsby telemetry --disable
       - run: yarn build-storybook


### PR DESCRIPTION
With this small pull request, the Chromatic CI workflow is fixed to prevent it from failing.

Follows up on #684

@winkerVSbecks, when you have a chance, can you take a look? I just merged a pull request with a translation and got the notification that it was failing. And it seems we accidentally introduced a bit of regression with your pull request.

Thanks in advance.