### PR TITLE
Tweaks to the japanese dsd translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ The [Design Systems for Developers tutorial](https://storybook.js.org/tutorials/
 | English          | ✅      |
 | Korean           | ❌      |
 | Portuguese       | ❌      |
+| Japanese         | ❌      |
 | Mainland Chinese | ❌      |
 
 ---

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -61,6 +61,7 @@ module.exports = {
           ko: 6.4,
           pt: 5.3,
           'zh-CN': 6.3,
+          ja: 6.4,
         },
       },
       'visual-testing-handbook': {


### PR DESCRIPTION
With this small pull request, both Readme and Gatsby configuration files were updated to achieve parity with the recently introduced Japanese translation of the Design Systems for Developers tutorial.

Follows up on #573 

