### PR TITLE
Fix typo - correct file name extension

### DIFF
--- a/content/intro-to-storybook/react/en/screen.md
+++ b/content/intro-to-storybook/react/en/screen.md
@@ -113,7 +113,7 @@ const store = configureStore({
 export default store;
 ```
 
-Now that we've updated our store to retrieve the data from a remote API endpoint and prepared it to handle the various states of our app, let's create our `InboxScreen.js` in the `src/components` directory:
+Now that we've updated our store to retrieve the data from a remote API endpoint and prepared it to handle the various states of our app, let's create our `InboxScreen.jsx` in the `src/components` directory:
 
 ```jsx:title=src/components/InboxScreen.jsx
 import React, { useEffect } from 'react';


### PR DESCRIPTION
Correcting the file extension in the Screens chapter

![image](https://github.com/chromaui/learnstorybook.com/assets/58271566/95037b5f-ae50-4af4-adff-ffab4a187da6)
https://storybook.js.org/tutorials/intro-to-storybook/react/en/screen/