### PR TITLE
Docs: Intro Storybook fix CSS selector

### DIFF
--- a/content/intro-to-storybook/angular/en/test.md
+++ b/content/intro-to-storybook/angular/en/test.md
@@ -76,7 +76,7 @@ Change `src/app/components/task.component` to the following:
           id="title-{{ task?.id }}"
           name="title-{{ task?.id }}"
           placeholder="Input title"
-+         style="background: red;"
++         style="background-color: red;"
         />
       </label>
       <button

--- a/content/intro-to-storybook/angular/es/test.md
+++ b/content/intro-to-storybook/angular/es/test.md
@@ -50,7 +50,7 @@ Cambie `TaskComponent` a lo siguiente:
   [value]="task?.title"
   readonly="true"
   placeholder="Input title"
-+ style="background: red;"
++ style="background-color: red;"
 />
 ```
 

--- a/content/intro-to-storybook/angular/ja/test.md
+++ b/content/intro-to-storybook/angular/ja/test.md
@@ -49,7 +49,7 @@ git checkout -b change-task-background
   [value]="task?.title"
   readonly="true"
   placeholder="Input title"
-+ style="background: red;"
++ style="background-color: red;"
 />
 ```
 

--- a/content/intro-to-storybook/ember/en/test.md
+++ b/content/intro-to-storybook/ember/en/test.md
@@ -63,7 +63,7 @@ Change `Task` to the following:
       readonly
       value={{@task.title}}
       placeholder="Input title"
-+     style="background:red;"
++     style="background-color: red;"
     />
   </div>
   <div class="actions">

--- a/content/intro-to-storybook/react/ar/test.md
+++ b/content/intro-to-storybook/react/ar/test.md
@@ -58,7 +58,7 @@ git checkout -b change-task-background
     value={title}
     readOnly={true}
     placeholder="Input title"
-+   style={{ background: 'red' }}
++   style={{ backgroundColor: 'red' }}
   />
 </div>
 

--- a/content/intro-to-storybook/react/en/test.md
+++ b/content/intro-to-storybook/react/en/test.md
@@ -76,7 +76,7 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
           readOnly={true}
           name="title"
           placeholder="Input title"
-+         style={{ background: 'red' }}
++         style={{ backgroundColor: 'red' }}
         />
       </label>
 

--- a/content/intro-to-storybook/react/es/test.md
+++ b/content/intro-to-storybook/react/es/test.md
@@ -74,7 +74,7 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
           readOnly={true}
           name="title"
           placeholder="Input title"
-+         style={{ background: 'red' }}
++         style={{ backgroundColor: 'red' }}
         />
       </label>
 

--- a/content/intro-to-storybook/react/fr/test.md
+++ b/content/intro-to-storybook/react/fr/test.md
@@ -74,7 +74,7 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
           readOnly={true}
           name="title"
           placeholder="Input title"
-+         style={{ background: 'red' }}
++         style={{ backgroundColor: 'red' }}
         />
       </label>
 

--- a/content/intro-to-storybook/react/it/test.md
+++ b/content/intro-to-storybook/react/it/test.md
@@ -76,7 +76,7 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
           readOnly={true}
           name="title"
           placeholder="Input title"
-+         style={{ background: 'red' }}
++         style={{ backgroundColor: 'red' }}
         />
       </label>
 

--- a/content/intro-to-storybook/react/ja/test.md
+++ b/content/intro-to-storybook/react/ja/test.md
@@ -72,7 +72,7 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
           readOnly={true}
           name="title"
           placeholder="Input title"
-+         style={{ background: 'red' }}
++         style={{ backgroundColor: 'red' }}
         />
       </label>
 

--- a/content/intro-to-storybook/react/ko/test.md
+++ b/content/intro-to-storybook/react/ko/test.md
@@ -50,7 +50,7 @@ git checkout -b change-task-background
     value={title}
     readOnly={true}
     placeholder="Input title"
-+   style={{ background: 'red' }}
++   style={{ backgroundColor: 'red' }}
   />
 </div>
 ```

--- a/content/intro-to-storybook/react/nl/test.md
+++ b/content/intro-to-storybook/react/nl/test.md
@@ -50,7 +50,7 @@ Verander `Task` naar het volgende:
     value={title}
     readOnly={true}
     placeholder="Input title"
-    style={{ textOverflow: 'ellipsis', background: 'red' }}
+    style={{ backgroundColor: 'red' }}
   />
 </div>
 ```

--- a/content/intro-to-storybook/react/zh-CN/test.md
+++ b/content/intro-to-storybook/react/zh-CN/test.md
@@ -48,7 +48,7 @@ git checkout -b change-task-background
     value={title}
     readOnly={true}
     placeholder="Input title"
-    style={{ background: 'red' }}
+    style={{ backgroundColor: 'red' }}
   />
 </div>
 ```

--- a/content/intro-to-storybook/react/zh-TW/test.md
+++ b/content/intro-to-storybook/react/zh-TW/test.md
@@ -50,7 +50,7 @@ git checkout -b change-task-background
     value={title}
     readOnly={true}
     placeholder="Input title"
-+   style={{ background: 'red' }}
++   style={{ backgroundColor: 'red' }}
   />
 </div>
 ```

--- a/content/intro-to-storybook/svelte/en/test.md
+++ b/content/intro-to-storybook/svelte/en/test.md
@@ -64,7 +64,7 @@ Change `src/components/Task.svelte` to the following:
       readonly
       name="title"
       placeholder="Input title"
-+     style="background: red;"
++     style="background-color: red;"
     />
   </label>
   {#if task.state !== "TASK_ARCHIVED"}

--- a/content/intro-to-storybook/vue/en/test.md
+++ b/content/intro-to-storybook/vue/en/test.md
@@ -70,7 +70,7 @@ Change `src/components/Task` to the following:
         :id="'title-' + task.id"
         name="title"
         placeholder="Input title"
-+       style="background: red" />
++       style="background-color: red" />
       />
     </label>
     <button

--- a/content/intro-to-storybook/vue/es/test.md
+++ b/content/intro-to-storybook/vue/es/test.md
@@ -49,7 +49,7 @@ Cambie "Task" a lo siguiente:
   :value="task.title"
   readonly
   placeholder="Input title"
-+ style="background: red;"
++ style="background-color: red"
 />
 ```
 

--- a/content/intro-to-storybook/vue/zh-CN/test.md
+++ b/content/intro-to-storybook/vue/zh-CN/test.md
@@ -68,7 +68,7 @@ git checkout -b change-task-background
         :id="'title-' + task.id"
         name="title"
         placeholder="Input title"
-+       style="background: red" />
++       style="background-color: red" />
       />
     </label>
     <button


### PR DESCRIPTION
With this pull request the CSS selector used in the Test chapter of the Intro to Storybook tutorial was updated to align with the rest of the documentation and avoid misconceptions about the selector and make it element-based as opposed to what's currently in effect (i.e., the shorthand).

Closes #739