### PR TITLE
Add id prop to input element in simple-component.md

### DIFF
--- a/content/intro-to-storybook/react/en/simple-component.md
+++ b/content/intro-to-storybook/react/en/simple-component.md
@@ -30,8 +30,8 @@ import React from 'react';
 export default function Task({ task: { id, title, state }, onArchiveTask, onPinTask }) {
   return (
     <div className="list-item">
-      <label htmlFor="title" aria-label={title}>
-        <input type="text" value={title} readOnly={true} name="title" />
+      <label htmlFor={`title-${id}`} aria-label={title}>
+        <input type="text" value={title} readOnly={true} name="title" id={`title-${id}`} />
       </label>
     </div>
   );
@@ -175,7 +175,7 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
   return (
     <div className={`list-item ${state}`}>
       <label
-        htmlFor="checked"
+        htmlFor={`archiveTask-${id}`}
         aria-label={`archiveTask-${id}`}
         className="checkbox"
       >
@@ -192,12 +192,13 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
         />
       </label>
 
-      <label htmlFor="title" aria-label={title} className="title">
+      <label htmlFor={`title-${id}`} aria-label={title} className="title">
         <input
           type="text"
           value={title}
           readOnly={true}
           name="title"
+          id={`title-${id}`}
           placeholder="Input title"
         />
       </label>
@@ -239,7 +240,7 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
   return (
     <div className={`list-item ${state}`}>
       <label
-        htmlFor="checked"
+        htmlFor={`archiveTask-${id}`}
         aria-label={`archiveTask-${id}`}
         className="checkbox"
       >
@@ -256,12 +257,13 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
         />
       </label>
 
-      <label htmlFor="title" aria-label={title} className="title">
+      <label htmlFor={`title-${id}`} aria-label={title} className="title">
         <input
           type="text"
           value={title}
           readOnly={true}
           name="title"
+          id={`title-${id}`}
           placeholder="Input title"
         />
       </label>


### PR DESCRIPTION
The value of htmlFor is id (not the input's name), so you have to put the same value into the id of the input. Btw your current example is still working because you are putting the input inside of the label, otherwise, it will not work as expected