### PR TITLE
Update PureInboxScreen name to InboxScreen

### DIFF
--- a/content/intro-to-storybook/svelte/en/screen.md
+++ b/content/intro-to-storybook/svelte/en/screen.md
@@ -175,7 +175,7 @@ The play function helps us verify what happens to the UI when tasks are updated.
 
 The `@storybook/addon-interactions` helps us visualize our tests in Storybook, providing a step-by-step flow. It also offers a handy set of UI controls to pause, resume, rewind, and step through each interaction.
 
-Let's see it in action! Update your newly created `PureInboxScreen` story, and set up component interactions by adding the following:
+Let's see it in action! Update your newly created `InboxScreen` story, and set up component interactions by adding the following:
 
 ```diff:title=src/components/InboxScreen.stories.js
 import InboxScreen from './InboxScreen.svelte';


### PR DESCRIPTION
It looks like this name changed at some point and this reference was not updated.

I was a little confused when I ran into this while working through the tutorial. After looking around I think this is just a stale name. Let me know if I've just misunderstood something! I don't see any other references to PureInboxScreen in the svelte tutorial.