### PR TITLE
Corrected the typo where the JSX file format was mistakenly labeled as JS

### DIFF
--- a/content/intro-to-storybook/react/ko/composite-component.md
+++ b/content/intro-to-storybook/react/ko/composite-component.md
@@ -19,7 +19,7 @@ Taskbox는 핀으로 고정된 task를 일반 task 위에 배치하여 강조합
 
 ## 설정하기
 
-복합 컴포넌트는 기본 컴포넌트와 크게 다르지 않습니다. `TaskList` 컴포넌트와 그에 해당하는 스토리 파일을 만들어보겠습니다. `src/components/TaskList.js` 와 `src/components/TaskList.stories.js`를 생성해 주세요.
+복합 컴포넌트는 기본 컴포넌트와 크게 다르지 않습니다. `TaskList` 컴포넌트와 그에 해당하는 스토리 파일을 만들어보겠습니다. `src/components/TaskList.jsx` 와 `src/components/TaskList.stories.jsx`를 생성해 주세요.
 
 우선 `TaskList`의 대략적인 구현부터 시작하겠습니다. 이전의 `Task` 컴포넌트를 가져온 후, 속성과 액션을 입력값으로 전달해 주세요.
 
@@ -54,7 +54,7 @@ export default function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
 
 그리고, 스토리 파일 안에 `TaskList`의 테스트 상태값들을 만들어 보세요.
 
-```js:title=src/components/TaskList.stories.js
+```jsx:title=src/components/TaskList.stories.jsx
 import React from 'react';
 
 import TaskList from './TaskList';
@@ -71,7 +71,7 @@ const Template = args => <TaskList {...args} />;
 export const Default = Template.bind({});
 Default.args = {
   // Shaping the stories through args composition.
-  // The data was inherited from the Default story in Task.stories.js.
+  // The data was inherited from the Default story in Task.stories.jsx.
   tasks: [
     { ...TaskStories.Default.args.task, id: '1', title: 'Task 1' },
     { ...TaskStories.Default.args.task, id: '2', title: 'Task 2' },
@@ -128,7 +128,7 @@ Empty.args = {
 
 우리의 컴포넌트는 아직 기본 뼈대만을 갖추었지만, 앞으로 작업하게 될 스토리에 대한 아이디어를 얻었습니다. `.list-items` 래퍼(wrapper)가 지나치게 단순하다고 생각할 수도 있습니다. 맞습니다! 대부분의 경우에 우리는 단지 래퍼(wrapper)를 추가하기 위해서 새로운 컴포넌트를 만들지 않습니다. 하지만 `TaskList` 컴포넌트의 **진정한 복잡성**은 `withPinnedTasks`, `loading` 그리고 `empty`에서 드러날 것입니다.
 
-```js:title=src/components/TaskList.js
+```jsx:title=src/components/TaskList.jsx
 import React from 'react';
 
 import Task from './Task';
@@ -199,7 +199,7 @@ export default function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
 
 컴포넌트가 커질수록 입력에 필요한 데이터 요구사항도 함께 커집니다. `TaskList`에서 prop의 요구사항을 정의해봅시다. `Task`는 하위 컴포넌트이기 때문에 렌더링에 필요한 적합한 형태의 데이터를 제공해야 합니다. 시간 절약을 위해서 `Task`에서 사용한 `propTypes`를 재사용하겠습니다.
 
-```diff:title=src/components/TaskList.js
+```diff:title=src/components/TaskList.jsx
 import React from 'react';
 + import PropTypes from 'prop-types';
 
@@ -242,7 +242,7 @@ export default function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
 
 `src/components/TaskList.test.js`라는 테스트 파일을 만들어주세요. 여기서 출력 값을 검증하는 테스트를 만들어보겠습니다.
 
-```js:title=src/components/TaskList.test.js
+```jsx:title=src/components/TaskList.test.js
 import { render } from '@testing-library/react';
 
 import { composeStories } from '@storybook/testing-react';

--- a/content/intro-to-storybook/react/ko/composite-component.md
+++ b/content/intro-to-storybook/react/ko/composite-component.md
@@ -242,7 +242,7 @@ export default function TaskList({ loading, tasks, onPinTask, onArchiveTask }) {
 
 `src/components/TaskList.test.js`라는 테스트 파일을 만들어주세요. 여기서 출력 값을 검증하는 테스트를 만들어보겠습니다.
 
-```jsx:title=src/components/TaskList.test.js
+```js:title=src/components/TaskList.test.js
 import { render } from '@testing-library/react';
 
 import { composeStories } from '@storybook/testing-react';

--- a/content/intro-to-storybook/react/ko/data.md
+++ b/content/intro-to-storybook/react/ko/data.md
@@ -83,7 +83,7 @@ export default store;
 
 다음 `TaskList` 컴포넌트를 Redux store와 연결하고, 알고자 하는 task들을 렌더링 하기 위해 업데이트합니다:
 
-```js:title=src/components/TaskList.js
+```js:title=src/components/TaskList.jsx
 import React from 'react';
 import Task from './Task';
 import { useDispatch, useSelector } from 'react-redux';
@@ -161,7 +161,7 @@ export default function TaskList() {
 }
 ```
 
-이제 컴포넌트를 생성할 실제 데이터를 리덕스에서 받았으므로, 이를 `src/app.js`에 연결하여 컴포넌트를 렌더링 할 수 있습니다. 그러나 지금은 먼저 컴포넌트 중심의 여정을 계속해나가도록 하겠습니다.
+이제 컴포넌트를 생성할 실제 데이터를 리덕스에서 받았으므로, 이를 `src/app.jsx`에 연결하여 컴포넌트를 렌더링 할 수 있습니다. 그러나 지금은 먼저 컴포넌트 중심의 여정을 계속해나가도록 하겠습니다.
 
 그에 대한 내용은 다음 챕터에서 다룰 것이므로 걱정하지 않으셔도 됩니다.
 
@@ -173,7 +173,7 @@ export default function TaskList() {
 
 이 문제를 해결하기 위해 다양한 접근 방식을 사용할 수 있습니다. 우리 앱은 매우 간단하기 때문에 [이전 장](/intro-to-storybook/react/en/composite-component)에서 했던 것과 유사한 데코레이터에 의존하고 모방된 저장소를 스토리북 스토리에 제공할 수 있습니다.
 
-```js:title=src/components/TaskList.stories.js
+```jsx:title=src/components/TaskList.stories.jsx
 import React from 'react';
 
 import TaskList from './TaskList';

--- a/content/intro-to-storybook/react/ko/screen.md
+++ b/content/intro-to-storybook/react/ko/screen.md
@@ -113,9 +113,9 @@ const store = configureStore({
 export default store;
 ```
 
-이제 원격 API 엔드포인트에서 데이터를 검색하여 스토어를 새롭게 업데이트 하고 앱의 다양한 상태를 처리하도록 준비했습니다. 이제 `src/components` 폴더에 `InboxScreen.js` 파일을 만들어봅시다:
+이제 원격 API 엔드포인트에서 데이터를 검색하여 스토어를 새롭게 업데이트 하고 앱의 다양한 상태를 처리하도록 준비했습니다. 이제 `src/components` 폴더에 `InboxScreen.jsx` 파일을 만들어봅시다:
 
-```js:title=src/components/InboxScreen.js
+```jsx:title=src/components/InboxScreen.jsx
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchTasks } from '../lib/store';
@@ -156,7 +156,7 @@ export default function InboxScreen() {
 
 또한 `App` 컴포넌트를 변경하여 `InboxScreen`을 렌더링 합니다. (올바른 화면 선택을 위하여 router를 사용해도 되지만 여기서는 고려하지 않도록 하겠습니다.)
 
-```diff:title=src/App.js
+```diff:title=src/App.jsx
 - import logo from './logo.svg';
 - import './App.css';
 + import './index.css';
@@ -171,7 +171,7 @@ function App() {
 -     <header className="App-header">
 -       <img src={logo} className="App-logo" alt="logo" />
 -       <p>
--         Edit <code>src/App.js</code> and save to reload.
+-         Edit <code>src/App.jsx</code> and save to reload.
 -       </p>
 -       <a
 -         className="App-link"
@@ -195,9 +195,9 @@ export default App;
 
 그러나 여기서 흥미로운 점은 스토리북에서 스토리를 렌더링 할 때입니다.
 
-앞에서 살펴보았듯이 `TaskList` 컴포넌트는 이제 **연결된** 컴포넌트가 되었습니다. 그리고 Redux 저장소에 의존하여 작업을 렌더링하고 있습니다.`InboxScreen` 또한 연결된 컴포넌트 이므로 비슷한 작업을 수행하고 따라서 `InboxScreen.stories.js`에서 스토리를 설정할 때에도 스토어를 제공할 수 있습니다.
+앞에서 살펴보았듯이 `TaskList` 컴포넌트는 이제 **연결된** 컴포넌트가 되었습니다. 그리고 Redux 저장소에 의존하여 작업을 렌더링하고 있습니다.`InboxScreen` 또한 연결된 컴포넌트 이므로 비슷한 작업을 수행하고 따라서 `InboxScreen.stories.jsx`에서 스토리를 설정할 때에도 스토어를 제공할 수 있습니다.
 
-```js:title=src/components/InboxScreen.stories.js
+```jsx:title=src/components/InboxScreen.stories.jsx
 import React from 'react';
 
 import InboxScreen from './InboxScreen';
@@ -261,7 +261,7 @@ export const parameters = {
 
 마지막으로 `InboxScreen` 스토리를 업데이트하고 모의 원격 API 호출 파라미터를 [parameter](https://storybook.js.org/docs/react/writing-stories/parameters) 포함합니다.
 
-```diff:title=src/components/InboxScreen.stories.js
+```diff:title=src/components/InboxScreen.stories.jsx
 import React from 'react';
 
 import InboxScreen from './InboxScreen';
@@ -332,7 +332,7 @@ play 기능은 UI가 업데이트 될 때 어떤 일이 발생하는지 확인�
 
 그럼 이제 실행해 봅시다. 새로만든 `InboxScreen` 스토리를 업데이트하고 다음을 추가하여 컴포넌트 상호작용을 추가해 봅시다.
 
-```diff:title=src/components/InboxScreen.stories.js
+```diff:title=src/components/InboxScreen.stories.jsx
 import React from 'react';
 
 import InboxScreen from './InboxScreen';

--- a/content/intro-to-storybook/react/ko/simple-component.md
+++ b/content/intro-to-storybook/react/ko/simple-component.md
@@ -20,11 +20,11 @@ commit: '9b36e1a'
 
 ## 설정하기
 
-먼저 `Task` 컴포넌트와 그에 해당하는 스토리 파일을 만들어 봅시다. `src/components/Task.js`와 `src/components/Task.stories.js`을 생성해 주세요.
+먼저 `Task` 컴포넌트와 그에 해당하는 스토리 파일을 만들어 봅시다. `src/components/Task.jsx`와 `src/components/Task.stories.jsx`을 생성해 주세요.
 
 `Task`의 기본 구현부터 시작하겠습니다. 우리가 필요로 하는 속성들과 여러분이 task에 대해 취할 수 있는 두 가지 액션(목록 간 이동하는 것)을 간단히 살펴보도록 하겠습니다.
 
-```js:title=src/components/Task.js
+```jsx:title=src/components/Task.jsx
 import React from 'react';
 
 export default function Task({ task: { id, title, state }, onArchiveTask, onPinTask }) {
@@ -40,7 +40,7 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
 
 아래의 코드는 `Task`의 세 가지 테스트 상태를 스토리 파일에 작성한 것입니다.
 
-```js:title=src/components/Task.stories.js
+```jsx:title=src/components/Task.stories.jsx
 import React from 'react';
 
 import Task from './Task';
@@ -119,7 +119,7 @@ module.exports = {
 -   '../src/**/*.stories.mdx',
 -   '../src/**/*.stories.@(js|jsx|ts|tsx)'
 - ],
-+ stories: ['../src/components/**/*.stories.js'],
++ stories: ['../src/components/**/*.stories.jsx'],
   staticDirs: ['../public'],
   addons: [
     '@storybook/addon-links',
@@ -173,7 +173,7 @@ export const parameters = {
 
 컴포넌트는 아직 기본만 갖춘 상태입니다. 먼저, 너무 자세하지 않지만 우선 디자인을 이룰 수 있는 코드를 적어보겠습니다.
 
-```js:title=src/components/Task.js
+```jsx:title=src/components/Task.jsx
 import React from 'react';
 
 export default function Task({ task: { id, title, state }, onArchiveTask, onPinTask }) {
@@ -223,7 +223,7 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
 
 컴포넌트에 필요한 데이터 형태를 명시하려면 리액트(React)에서 `propTypes`를 사용하는 것이 가장 좋습니다. 이는 자체적 문서화일 뿐만 아니라, 문제를 조기에 발견하는 데 도움이 됩니다.
 
-```diff:title=src/components/Task.js
+```diff:title=src/components/Task.jsx
 import React from 'react';
 + import PropTypes from 'prop-types';
 

--- a/content/intro-to-storybook/react/ko/test.md
+++ b/content/intro-to-storybook/react/ko/test.md
@@ -41,9 +41,9 @@ description: 'UI 컴포넌트 테스트 방법 배우기'
 git checkout -b change-task-background
 ```
 
-`src/components/Task.js`를 다음과 같이 변경하세요:
+`src/components/Task.jsx`를 다음과 같이 변경하세요:
 
-```diff:title=src/components/Task.js
+```diff:title=src/components/Task.jsx
 <div className="title">
   <input
     type="text"

--- a/content/intro-to-storybook/react/ko/using-addons.md
+++ b/content/intro-to-storybook/react/ko/using-addons.md
@@ -38,9 +38,9 @@ Controls을 사용하면 QA 엔지니어, UI 엔지니어 또는 기타 이해 �
 
 Controls을 통해 컴포넌트에 대한 다양한 입력(이 경우, 긴 문자열)을 신속하게 확인할 수 있었고, UI 문제를 발견하는 데 필요한 작업이 줄었습니다.
 
-이제 `Task.js`에 스타일을 추가하여 글자가 넘치는 문제를 해결하겠습니다.
+이제 `Task.jsx`에 스타일을 추가하여 글자가 넘치는 문제를 해결하겠습니다.
 
-```diff:title=src/components/Task.js
+```diff:title=src/components/Task.jsx
 <input
   type="text"
   value={title}
@@ -58,9 +58,9 @@ Controls을 통해 컴포넌트에 대한 다양한 입력(이 경우, 긴 문�
 
 앞으로는 Controls를 통해 동일한 문자열을 입력하여 수동으로 이 문제를 재현할 수 있습니다. 그러나 이 edge case를 보여주는 story를 작성하는 것이 더 쉽습니다. 이는 회귀 테스트(regression test) 커버리지를 확장하고 팀에게 컴포넌트의 한계를 명확하게 설명할 수 있습니다.
 
-긴 문자열 케이스에 대한 새로운 스토리를 `Task.stories.js` 에 추가해봅시다.
+긴 문자열 케이스에 대한 새로운 스토리를 `Task.stories.jsx` 에 추가해봅시다.
 
-```js:title=src/components/Task.stories.js
+```js:title=src/components/Task.stories.jsx
 const longTitleString = `This task's name is absurdly large. In fact, I think if I keep going I might end up with content overflow. What will happen? The star that represents a pinned task could have text overlapping. The text could cut-off abruptly when it reaches the star. I hope not!`;
 export const LongTitle = Template.bind({});
 LongTitle.args = {


### PR DESCRIPTION
I found an issue in the Korean translation of “Intro to Storybook” where the JSX file format was incorrectly labeled as JS. 

So, I have fixed this minor typo.

Thank you.