### PR TITLE
Docs: Visual testing handbook fix arg typo

### DIFF
--- a/content/visual-testing-handbook/react/en/vtdd.md
+++ b/content/visual-testing-handbook/react/en/vtdd.md
@@ -151,7 +151,7 @@ export const HasData = {
 export const Loading = {
   args: {
     comments: [],
-    Loading: true,
+    loading: true,
   },
 };
 


### PR DESCRIPTION
With this pull request, the Visual testing handbook was updated to fix a typo in the example arg so that it renders the correct state.