### PR TITLE
Adjust the Intro to Storybook React translation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Currently, the [Intro to Storybook tutorial](https://storybook.js.org/tutorials/
 |              | Mainland Chinese | ❌      |
 |              | Dutch            | ❌      |
 |              | Korean           | ✅      |
-|              | Japanese         | ❌      |
+|              | Japanese         | ✅      |
 |              | French           | ❌      |
 |              | Italian          | ❌      |
 |              | German           | ❌      |

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -24,7 +24,7 @@ module.exports = {
           es: 8.3,
           fr: 6.5,
           it: 7.6,
-          ja: 8.1,
+          ja: 8.3,
           ko: 8.3,
           nl: 5.3,
           pt: 5.3,


### PR DESCRIPTION
With this pull request the Intro to Storybook Status for the Japanese translation is updated to prevent it from showing the outdated status as it's already matching the English version