### PR TITLE
fix: update import path for fn

### DIFF
--- a/content/intro-to-storybook/react/en/simple-component.md
+++ b/content/intro-to-storybook/react/en/simple-component.md
@@ -65,7 +65,7 @@ Below we build out Task’s three test states in the story file:
 ```tsx:title=src/components/Task.stories.tsx
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { fn } from '@storybook/test';
+import { fn } from 'storybook/test';
 
 import Task from './Task';
 


### PR DESCRIPTION
fix: update import path for fn to use storybook/test instead of @storybook/test as per migration guide for Storybook 9.0