### PR TITLE
fix: Pin @storybook/addon-a11y version to 8.5.6 in documentation

### DIFF
--- a/content/intro-to-storybook/react/en/simple-component.md
+++ b/content/intro-to-storybook/react/en/simple-component.md
@@ -383,7 +383,7 @@ Storybook includes an official [accessibility addon](https://storybook.js.org/ad
 Let's see how it works! Run the following command to install the addon:
 
 ```shell
-yarn add --dev @storybook/addon-a11y
+yarn add --dev @storybook/addon-a11y@8.5.6
 ```
 
 Then, update your Storybook configuration file (`.storybook/main.ts`) to enable it:

--- a/content/intro-to-storybook/react/es/simple-component.md
+++ b/content/intro-to-storybook/react/es/simple-component.md
@@ -331,7 +331,7 @@ Storybook también tiene un [complemento oficial de accesibilidad](https://story
 ¡Vamos a ver como funciona! Ejecuta el comando siguiente para instalar el complemento:
 
 ```shell
-yarn add --dev @storybook/addon-a11y
+yarn add --dev @storybook/addon-a11y@8.5.6
 ```
 
 Luego, actualiza tu archivo de configuración de Storybook (`.storybook/main.js`) para activarlo:

--- a/content/intro-to-storybook/react/fr/simple-component.md
+++ b/content/intro-to-storybook/react/fr/simple-component.md
@@ -331,7 +331,7 @@ Storybook inclut un [addon d'accessibilité officiel](https://storybook.js.org/a
 Regardons comment cela marche ! Executez la commande suivante pour installer l'addon:
 
 ```shell
-yarn add --dev @storybook/addon-a11y
+yarn add --dev @storybook/addon-a11y@8.5.6
 ```
 
 Ensuite, mettez à jour le fichier de configuration de Storybook (`.storybook/main.js`):

--- a/content/intro-to-storybook/react/it/simple-component.md
+++ b/content/intro-to-storybook/react/it/simple-component.md
@@ -319,7 +319,7 @@ Storybook include un [addon ufficiale per l'accessibilità](https://storybook.js
 Vediamo come funziona! Esegui il seguente comando per installare l'addon:
 
 ```shell
-yarn add --dev @storybook/addon-a11y
+yarn add --dev @storybook/addon-a11y@8.5.6
 ```
 
 Poi, aggiorna il tuo file di configurazione di Storybook (`.storybook/main.js`) per abilitarlo:

--- a/content/intro-to-storybook/react/ja/simple-component.md
+++ b/content/intro-to-storybook/react/ja/simple-component.md
@@ -319,7 +319,7 @@ Storybook には公式の[アクセシビリティアドオン](https://storyboo
 それでは、どのように動かすのか見てみましょう! 以下のコマンドでアドオンをインストールします。
 
 ```shell
-yarn add --dev @storybook/addon-a11y
+yarn add --dev @storybook/addon-a11y@8.5.6
 ```
 
 アドオンを利用可能にするために、Storybook の設定ファイル(`.storybook/main.js`)を以下のように設定します。

--- a/content/intro-to-storybook/react/ko/simple-component.md
+++ b/content/intro-to-storybook/react/ko/simple-component.md
@@ -334,7 +334,7 @@ export default function Task({ task: { id, title, state }, onArchiveTask, onPinT
 어떻게 작동하는지 봅시다! 다음 명령을 실행하여 애드온을 설치하세요:
 
 ```shell
-yarn add --dev @storybook/addon-a11y
+yarn add --dev @storybook/addon-a11y@8.5.6
 ```
 
 그 다음, 스토리북 구성 파일(`.storybook/main.js`)을 업데이트하여 활성화합니다:


### PR DESCRIPTION
## Summary
- Pin @storybook/addon-a11y version to 8.5.6 across all tutorial documentation to resolve compatibility issues
- Update installation commands in React tutorials across multiple languages (EN, ES, FR, IT, JA, KO)

## Problem
Current documentation uses `@storybook/addon-a11y` without specifying a version. This causes the latest version to be incompatible with existing Storybook configurations.

When installing the latest version without version specification, users encounter:

**Installation warning:**
```
storybook is listed by your project with version 8.5.6 (pca6a6), which doesn't satisfy what @storybook/addon-a11y and other dependencies request (but they have non-overlapping ranges!).
```

**Runtime errors when running `yarn run storybook`:**
```
Error: Build failed with 5 errors:
node_modules/@storybook/addon-a11y/dist/manager.js:4:177: ERROR: Could not resolve "storybook/manager-api"
node_modules/@storybook/addon-a11y/dist/manager.js:6:48: ERROR: Could not resolve "storybook/theming"
node_modules/@storybook/addon-a11y/dist/manager.js:8:62: ERROR: Could not resolve "storybook/highlight"
node_modules/@storybook/addon-controls/dist/manager.js:11:38: ERROR: Could not resolve "storybook/internal/csf"
node_modules/@storybook/addon-docs/node_modules/@storybook/blocks/dist/index.mjs:8:38: ERROR: Could not resolve "storybook/internal/csf"
```

## Solution
- Specify exact version 8.5.6 for @storybook/addon-a11y installation commands
- Ensures consistent, working experience for tutorial users
- Apply to 6 documentation files across React frameworks

## Note
This version pin may need to be updated in the future once compatibility issues with newer versions are resolved and tested.