### PR TITLE
Maitenance: Fix KO translation status and other QOL fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Currently, the [Intro to Storybook tutorial](https://storybook.js.org/tutorials/
 |              | ZH-TW            | ❌      |
 |              | Mainland Chinese | ❌      |
 |              | Dutch            | ❌      |
-|              | Korean           | ❌      |
+|              | Korean           | ✅      |
 |              | Japanese         | ❌      |
 |              | French           | ❌      |
 |              | Italian          | ❌      |

--- a/content/intro-to-storybook/angular/en/composite-component.md
+++ b/content/intro-to-storybook/angular/en/composite-component.md
@@ -9,7 +9,7 @@ Last chapter, we built our first component; this chapter extends what we learned
 
 ## Tasklist
 
-Taskbox emphasizes pinned tasks by positioning them above default tasks. It yields two variations of `TaskList` you need to create stories for, default and pinned items.
+Taskbox emphasizes pinned tasks by positioning them above default tasks. It yields two variations of `TaskList` you need to create stories for: default and pinned items.
 
 ![default and pinned tasks](/intro-to-storybook/tasklist-states-1.png)
 

--- a/content/intro-to-storybook/react/en/composite-component.md
+++ b/content/intro-to-storybook/react/en/composite-component.md
@@ -9,7 +9,7 @@ Last chapter, we built our first component; this chapter extends what we learned
 
 ## Tasklist
 
-Taskbox emphasizes pinned tasks by positioning them above default tasks. It yields two variations of `TaskList` you need to create stories for, default and pinned items.
+Taskbox emphasizes pinned tasks by positioning them above default tasks. It yields two variations of `TaskList` you need to create stories for: default and pinned items.
 
 ![default and pinned tasks](/intro-to-storybook/tasklist-states-1.png)
 

--- a/content/intro-to-storybook/svelte/en/composite-component.md
+++ b/content/intro-to-storybook/svelte/en/composite-component.md
@@ -8,7 +8,7 @@ Last chapter, we built our first component; this chapter extends what we learned
 
 ## Tasklist
 
-Taskbox emphasizes pinned tasks by positioning them above default tasks. It yields two variations of `TaskList` you need to create stories for, default and pinned items.
+Taskbox emphasizes pinned tasks by positioning them above default tasks. It yields two variations of `TaskList` you need to create stories for: default and pinned items.
 
 ![default and pinned tasks](/intro-to-storybook/tasklist-states-1.png)
 

--- a/content/intro-to-storybook/vue/en/composite-component.md
+++ b/content/intro-to-storybook/vue/en/composite-component.md
@@ -9,7 +9,7 @@ Last chapter, we built our first component; this chapter extends what we learned
 
 ## Tasklist
 
-Taskbox emphasizes pinned tasks by positioning them above default tasks. It yields two variations of `TaskList` you need to create stories for, default and pinned items.
+Taskbox emphasizes pinned tasks by positioning them above default tasks. It yields two variations of `TaskList` you need to create stories for: default and pinned items.
 
 ![default and pinned tasks](/intro-to-storybook/tasklist-states-1.png)
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -25,7 +25,7 @@ module.exports = {
           fr: 8.3,
           it: 7.6,
           ja: 8.3,
-          ko: 8.3,
+          ko: 10,
           nl: 5.3,
           pt: 5.3,
           'zh-CN': 6.1,

--- a/package.json
+++ b/package.json
@@ -97,5 +97,6 @@
   },
   "resolutions": {
     "deepmerge": "^4.3.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
Clsoes #831 and follows up on #828

With this pull request:
- The Korean metadata info is updated to reflect the mentioned pull request
- Minor tweaks to address the issue
- Pins the Yarn version to prevent it from running